### PR TITLE
Phase 2: Implement TUI with ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,11 @@ name = "conductor-tui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "conductor-core",
  "crossterm",
  "ratatui",
+ "rusqlite",
 ]
 
 [[package]]

--- a/conductor-tui/Cargo.toml
+++ b/conductor-tui/Cargo.toml
@@ -15,3 +15,5 @@ conductor-core = { path = "../conductor-core" }
 ratatui = "0.29"
 crossterm = "0.28"
 anyhow = "1"
+chrono = "0.4"
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -1,0 +1,75 @@
+use conductor_core::repo::Repo;
+use conductor_core::session::Session;
+use conductor_core::tickets::Ticket;
+use conductor_core::worktree::Worktree;
+
+/// Every user intent or background result flows through this enum.
+#[derive(Debug)]
+pub enum Action {
+    // Navigation
+    Quit,
+    Back,
+    NextPanel,
+    PrevPanel,
+    MoveUp,
+    MoveDown,
+    Select,
+
+    // Views
+    GoToDashboard,
+    GoToTickets,
+    GoToSession,
+
+    // CRUD triggers
+    Create,
+    Delete,
+    Push,
+    CreatePr,
+    SyncTickets,
+    LinkTicket,
+    StartSession,
+    EndSession,
+
+    // Filter
+    EnterFilter,
+    FilterChar(char),
+    FilterBackspace,
+    ExitFilter,
+
+    // Modal
+    ShowHelp,
+    DismissModal,
+    ConfirmYes,
+    ConfirmNo,
+    InputChar(char),
+    InputBackspace,
+    InputSubmit,
+
+    // Background results
+    DataRefreshed {
+        repos: Vec<Repo>,
+        worktrees: Vec<Worktree>,
+        tickets: Vec<Ticket>,
+        session: Option<Session>,
+        session_worktrees: Vec<Worktree>,
+    },
+    TicketSyncComplete {
+        repo_slug: String,
+        count: usize,
+    },
+    TicketSyncFailed {
+        repo_slug: String,
+        error: String,
+    },
+    #[allow(dead_code)]
+    BackgroundError {
+        message: String,
+    },
+    #[allow(dead_code)]
+    BackgroundSuccess {
+        message: String,
+    },
+
+    // No-op (unhandled key)
+    None,
+}

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -1,0 +1,726 @@
+use std::process::Command;
+use std::time::Duration;
+
+use anyhow::Result;
+use ratatui::DefaultTerminal;
+use rusqlite::Connection;
+
+use conductor_core::config::Config;
+use conductor_core::github;
+use conductor_core::repo::RepoManager;
+use conductor_core::session::SessionTracker;
+use conductor_core::tickets::TicketSyncer;
+use conductor_core::worktree::WorktreeManager;
+
+use crate::action::Action;
+use crate::background;
+use crate::event::{Event, EventLoop};
+use crate::input;
+use crate::state::{
+    AppState, ConfirmAction, DashboardFocus, InputAction, Modal, RepoDetailFocus, View,
+};
+use crate::ui;
+
+pub struct App {
+    state: AppState,
+    conn: Connection,
+    config: Config,
+}
+
+impl App {
+    pub fn new(conn: Connection, config: Config) -> Self {
+        Self {
+            state: AppState::new(),
+            conn,
+            config,
+        }
+    }
+
+    /// Main run loop.
+    pub fn run(mut self, terminal: &mut DefaultTerminal) -> Result<()> {
+        // Initial data load
+        self.refresh_data();
+
+        let events = EventLoop::new(Duration::from_millis(200));
+
+        // Spawn background workers
+        let bg_tx = events.bg_sender();
+        background::spawn_db_poller(bg_tx.clone(), Duration::from_secs(2));
+        let sync_mins = self.config.general.sync_interval_minutes as u64;
+        background::spawn_ticket_sync(bg_tx, Duration::from_secs(sync_mins * 60));
+
+        loop {
+            terminal.draw(|frame| ui::render(frame, &self.state))?;
+
+            match events.next() {
+                Ok(Event::Key(key)) => {
+                    let action = input::map_key(key, &self.state);
+                    self.update(action);
+                }
+                Ok(Event::Tick) => {
+                    // Tick: just re-render (for timer updates etc.)
+                }
+                Ok(Event::Background(action)) => {
+                    self.update(action);
+                }
+                Err(_) => break,
+            }
+
+            if self.state.should_quit {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handle an action by mutating state.
+    fn update(&mut self, action: Action) {
+        match action {
+            Action::None => {}
+            Action::Quit => self.state.should_quit = true,
+
+            // Navigation
+            Action::Back => self.go_back(),
+            Action::NextPanel => self.next_panel(),
+            Action::PrevPanel => self.prev_panel(),
+            Action::MoveUp => self.move_up(),
+            Action::MoveDown => self.move_down(),
+            Action::Select => self.select(),
+
+            // View navigation
+            Action::GoToDashboard => {
+                self.state.view = View::Dashboard;
+            }
+            Action::GoToTickets => {
+                self.state.view = View::Tickets;
+                self.state.ticket_index = 0;
+            }
+            Action::GoToSession => {
+                self.state.view = View::Session;
+            }
+
+            // Filter
+            Action::EnterFilter => {
+                self.state.filter_active = true;
+                self.state.filter_text.clear();
+            }
+            Action::FilterChar(c) => {
+                self.state.filter_text.push(c);
+            }
+            Action::FilterBackspace => {
+                self.state.filter_text.pop();
+            }
+            Action::ExitFilter => {
+                self.state.filter_active = false;
+            }
+
+            // Modal
+            Action::ShowHelp => {
+                self.state.modal = Modal::Help;
+            }
+            Action::DismissModal => {
+                self.state.modal = Modal::None;
+            }
+            Action::ConfirmYes => self.handle_confirm_yes(),
+            Action::ConfirmNo => {
+                self.state.modal = Modal::None;
+            }
+            Action::InputChar(c) => {
+                if let Modal::Input { ref mut value, .. } = self.state.modal {
+                    value.push(c);
+                }
+            }
+            Action::InputBackspace => {
+                if let Modal::Input { ref mut value, .. } = self.state.modal {
+                    value.pop();
+                }
+            }
+            Action::InputSubmit => self.handle_input_submit(),
+
+            // CRUD
+            Action::Create => self.handle_create(),
+            Action::Delete => self.handle_delete(),
+            Action::Push => self.handle_push(),
+            Action::CreatePr => self.handle_create_pr(),
+            Action::SyncTickets => self.handle_sync_tickets(),
+            Action::LinkTicket => self.handle_link_ticket(),
+            Action::StartSession => self.handle_start_session(),
+            Action::EndSession => self.handle_end_session(),
+
+            // Background results
+            Action::DataRefreshed {
+                repos,
+                worktrees,
+                tickets,
+                session,
+                session_worktrees,
+            } => {
+                self.state.data.repos = repos;
+                self.state.data.worktrees = worktrees;
+                self.state.data.tickets = tickets;
+                self.state.data.current_session = session;
+                self.state.data.session_worktrees = session_worktrees;
+                self.state.data.rebuild_maps();
+                self.clamp_indices();
+            }
+            Action::TicketSyncComplete { repo_slug, count } => {
+                self.state.status_message = Some(format!("Synced {count} tickets for {repo_slug}"));
+                self.refresh_data();
+            }
+            Action::TicketSyncFailed { repo_slug, error } => {
+                self.state.status_message = Some(format!("Sync failed for {repo_slug}: {error}"));
+            }
+            Action::BackgroundError { message } => {
+                self.state.modal = Modal::Error { message };
+            }
+            Action::BackgroundSuccess { message } => {
+                self.state.status_message = Some(message);
+                self.refresh_data();
+            }
+        }
+    }
+
+    fn refresh_data(&mut self) {
+        let repo_mgr = RepoManager::new(&self.conn, &self.config);
+        let wt_mgr = WorktreeManager::new(&self.conn, &self.config);
+        let ticket_syncer = TicketSyncer::new(&self.conn);
+        let session_tracker = SessionTracker::new(&self.conn);
+
+        self.state.data.repos = repo_mgr.list().unwrap_or_default();
+        self.state.data.worktrees = wt_mgr.list(None).unwrap_or_default();
+        self.state.data.tickets = ticket_syncer.list(None).unwrap_or_default();
+        self.state.data.current_session = session_tracker.current().unwrap_or(None);
+        self.state.data.session_worktrees = if let Some(ref s) = self.state.data.current_session {
+            session_tracker.get_worktrees(&s.id).unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        self.state.data.rebuild_maps();
+        self.clamp_indices();
+
+        // If in repo detail, refresh scoped data
+        if let Some(ref repo_id) = self.state.selected_repo_id {
+            self.state.detail_worktrees = self
+                .state
+                .data
+                .worktrees
+                .iter()
+                .filter(|wt| &wt.repo_id == repo_id)
+                .cloned()
+                .collect();
+            self.state.detail_tickets = self
+                .state
+                .data
+                .tickets
+                .iter()
+                .filter(|t| &t.repo_id == repo_id)
+                .cloned()
+                .collect();
+        }
+    }
+
+    fn clamp_indices(&mut self) {
+        let repos_len = self.state.data.repos.len();
+        if repos_len > 0 && self.state.repo_index >= repos_len {
+            self.state.repo_index = repos_len - 1;
+        }
+
+        let wt_len = self.state.data.worktrees.len();
+        if wt_len > 0 && self.state.worktree_index >= wt_len {
+            self.state.worktree_index = wt_len - 1;
+        }
+
+        let t_len = self.state.data.tickets.len();
+        if t_len > 0 && self.state.ticket_index >= t_len {
+            self.state.ticket_index = t_len - 1;
+        }
+    }
+
+    fn go_back(&mut self) {
+        match self.state.view {
+            View::Dashboard => self.state.should_quit = true,
+            View::RepoDetail => {
+                self.state.view = View::Dashboard;
+                self.state.selected_repo_id = None;
+            }
+            View::WorktreeDetail => {
+                if self.state.selected_repo_id.is_some() {
+                    self.state.view = View::RepoDetail;
+                } else {
+                    self.state.view = View::Dashboard;
+                }
+                self.state.selected_worktree_id = None;
+            }
+            View::Tickets | View::Session => {
+                self.state.view = View::Dashboard;
+            }
+        }
+    }
+
+    fn next_panel(&mut self) {
+        match self.state.view {
+            View::Dashboard => {
+                self.state.dashboard_focus = self.state.dashboard_focus.next();
+            }
+            View::RepoDetail => {
+                self.state.repo_detail_focus = self.state.repo_detail_focus.toggle();
+            }
+            _ => {}
+        }
+    }
+
+    fn prev_panel(&mut self) {
+        match self.state.view {
+            View::Dashboard => {
+                self.state.dashboard_focus = self.state.dashboard_focus.prev();
+            }
+            View::RepoDetail => {
+                self.state.repo_detail_focus = self.state.repo_detail_focus.toggle();
+            }
+            _ => {}
+        }
+    }
+
+    fn move_up(&mut self) {
+        match self.state.view {
+            View::Dashboard => match self.state.dashboard_focus {
+                DashboardFocus::Repos => {
+                    self.state.repo_index = self.state.repo_index.saturating_sub(1);
+                }
+                DashboardFocus::Worktrees => {
+                    self.state.worktree_index = self.state.worktree_index.saturating_sub(1);
+                }
+                DashboardFocus::Tickets => {
+                    self.state.ticket_index = self.state.ticket_index.saturating_sub(1);
+                }
+            },
+            View::RepoDetail => match self.state.repo_detail_focus {
+                RepoDetailFocus::Worktrees => {
+                    self.state.detail_wt_index = self.state.detail_wt_index.saturating_sub(1);
+                }
+                RepoDetailFocus::Tickets => {
+                    self.state.detail_ticket_index =
+                        self.state.detail_ticket_index.saturating_sub(1);
+                }
+            },
+            View::Tickets => {
+                self.state.ticket_index = self.state.ticket_index.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+
+    fn move_down(&mut self) {
+        match self.state.view {
+            View::Dashboard => match self.state.dashboard_focus {
+                DashboardFocus::Repos => {
+                    let max = self.state.data.repos.len().saturating_sub(1);
+                    if self.state.repo_index < max {
+                        self.state.repo_index += 1;
+                    }
+                }
+                DashboardFocus::Worktrees => {
+                    let max = self.state.data.worktrees.len().saturating_sub(1);
+                    if self.state.worktree_index < max {
+                        self.state.worktree_index += 1;
+                    }
+                }
+                DashboardFocus::Tickets => {
+                    let max = self.state.data.tickets.len().saturating_sub(1);
+                    if self.state.ticket_index < max {
+                        self.state.ticket_index += 1;
+                    }
+                }
+            },
+            View::RepoDetail => match self.state.repo_detail_focus {
+                RepoDetailFocus::Worktrees => {
+                    let max = self.state.detail_worktrees.len().saturating_sub(1);
+                    if self.state.detail_wt_index < max {
+                        self.state.detail_wt_index += 1;
+                    }
+                }
+                RepoDetailFocus::Tickets => {
+                    let max = self.state.detail_tickets.len().saturating_sub(1);
+                    if self.state.detail_ticket_index < max {
+                        self.state.detail_ticket_index += 1;
+                    }
+                }
+            },
+            View::Tickets => {
+                let max = self.state.data.tickets.len().saturating_sub(1);
+                if self.state.ticket_index < max {
+                    self.state.ticket_index += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn select(&mut self) {
+        match self.state.view {
+            View::Dashboard => match self.state.dashboard_focus {
+                DashboardFocus::Repos => {
+                    if let Some(repo) = self.state.selected_repo() {
+                        let repo_id = repo.id.clone();
+                        self.state.selected_repo_id = Some(repo_id.clone());
+                        self.state.detail_worktrees = self
+                            .state
+                            .data
+                            .worktrees
+                            .iter()
+                            .filter(|wt| wt.repo_id == repo_id)
+                            .cloned()
+                            .collect();
+                        self.state.detail_tickets = self
+                            .state
+                            .data
+                            .tickets
+                            .iter()
+                            .filter(|t| t.repo_id == repo_id)
+                            .cloned()
+                            .collect();
+                        self.state.detail_wt_index = 0;
+                        self.state.detail_ticket_index = 0;
+                        self.state.repo_detail_focus = RepoDetailFocus::Worktrees;
+                        self.state.view = View::RepoDetail;
+                    }
+                }
+                DashboardFocus::Worktrees => {
+                    if let Some(wt) = self.state.selected_worktree() {
+                        self.state.selected_worktree_id = Some(wt.id.clone());
+                        self.state.selected_repo_id = None;
+                        self.state.view = View::WorktreeDetail;
+                    }
+                }
+                DashboardFocus::Tickets => {
+                    // Tickets don't have a detail view from dashboard; show full ticket list
+                    self.state.view = View::Tickets;
+                }
+            },
+            View::RepoDetail => {
+                if let Some(wt) = self.state.detail_worktrees.get(self.state.detail_wt_index) {
+                    self.state.selected_worktree_id = Some(wt.id.clone());
+                    self.state.view = View::WorktreeDetail;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_confirm_yes(&mut self) {
+        let modal = std::mem::replace(&mut self.state.modal, Modal::None);
+        if let Modal::Confirm { on_confirm, .. } = modal {
+            match on_confirm {
+                ConfirmAction::DeleteWorktree { repo_slug, wt_slug } => {
+                    let wt_mgr = WorktreeManager::new(&self.conn, &self.config);
+                    match wt_mgr.delete(&repo_slug, &wt_slug) {
+                        Ok(()) => {
+                            self.state.status_message =
+                                Some(format!("Deleted worktree: {wt_slug}"));
+                            self.state.view = View::Dashboard;
+                            self.state.selected_worktree_id = None;
+                            self.refresh_data();
+                        }
+                        Err(e) => {
+                            self.state.modal = Modal::Error {
+                                message: format!("Delete failed: {e}"),
+                            };
+                        }
+                    }
+                }
+                ConfirmAction::EndSession { session_id } => {
+                    let tracker = SessionTracker::new(&self.conn);
+                    match tracker.end(&session_id, None) {
+                        Ok(()) => {
+                            self.state.status_message = Some("Session ended".to_string());
+                            self.refresh_data();
+                        }
+                        Err(e) => {
+                            self.state.modal = Modal::Error {
+                                message: format!("End session failed: {e}"),
+                            };
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_input_submit(&mut self) {
+        let modal = std::mem::replace(&mut self.state.modal, Modal::None);
+        if let Modal::Input {
+            value, on_submit, ..
+        } = modal
+        {
+            if value.is_empty() {
+                return;
+            }
+            match on_submit {
+                InputAction::CreateWorktree { repo_slug } => {
+                    let wt_mgr = WorktreeManager::new(&self.conn, &self.config);
+                    match wt_mgr.create(&repo_slug, &value, None, None) {
+                        Ok(wt) => {
+                            self.state.status_message =
+                                Some(format!("Created worktree: {}", wt.slug));
+                            self.refresh_data();
+                        }
+                        Err(e) => {
+                            self.state.modal = Modal::Error {
+                                message: format!("Create failed: {e}"),
+                            };
+                        }
+                    }
+                }
+                InputAction::LinkTicket { worktree_id } => {
+                    let syncer = TicketSyncer::new(&self.conn);
+                    // Find ticket by source_id
+                    let ticket = self
+                        .state
+                        .data
+                        .tickets
+                        .iter()
+                        .find(|t| t.source_id == value);
+                    if let Some(t) = ticket {
+                        match syncer.link_to_worktree(&t.id, &worktree_id) {
+                            Ok(()) => {
+                                self.state.status_message =
+                                    Some(format!("Linked ticket #{}", t.source_id));
+                                self.refresh_data();
+                            }
+                            Err(e) => {
+                                self.state.modal = Modal::Error {
+                                    message: format!("Link failed: {e}"),
+                                };
+                            }
+                        }
+                    } else {
+                        self.state.modal = Modal::Error {
+                            message: format!("Ticket #{value} not found"),
+                        };
+                    }
+                }
+                InputAction::SessionNotes { session_id } => {
+                    let tracker = SessionTracker::new(&self.conn);
+                    match tracker.end(&session_id, Some(&value)) {
+                        Ok(()) => {
+                            self.state.status_message =
+                                Some("Session ended with notes".to_string());
+                            self.refresh_data();
+                        }
+                        Err(e) => {
+                            self.state.modal = Modal::Error {
+                                message: format!("End session failed: {e}"),
+                            };
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_create(&mut self) {
+        match self.state.view {
+            View::Dashboard | View::RepoDetail => {
+                let repo_slug = self
+                    .state
+                    .selected_repo_id
+                    .as_ref()
+                    .and_then(|id| self.state.data.repo_slug_map.get(id))
+                    .cloned()
+                    .or_else(|| self.state.selected_repo().map(|r| r.slug.clone()));
+
+                if let Some(slug) = repo_slug {
+                    self.state.modal = Modal::Input {
+                        title: "Create Worktree".to_string(),
+                        prompt: format!("Worktree name for {slug} (e.g., smart-playlists):"),
+                        value: String::new(),
+                        on_submit: InputAction::CreateWorktree { repo_slug: slug },
+                    };
+                } else {
+                    self.state.status_message = Some("Select a repo first".to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_delete(&mut self) {
+        if self.state.view == View::WorktreeDetail {
+            if let Some(ref wt_id) = self.state.selected_worktree_id {
+                if let Some(wt) = self.state.data.worktrees.iter().find(|w| &w.id == wt_id) {
+                    let repo_slug = self
+                        .state
+                        .data
+                        .repo_slug_map
+                        .get(&wt.repo_id)
+                        .cloned()
+                        .unwrap_or_else(|| "?".to_string());
+                    self.state.modal = Modal::Confirm {
+                        title: "Delete Worktree".to_string(),
+                        message: format!(
+                            "Delete worktree {}/{}? This removes the git worktree and branch.",
+                            repo_slug, wt.slug
+                        ),
+                        on_confirm: ConfirmAction::DeleteWorktree {
+                            repo_slug,
+                            wt_slug: wt.slug.clone(),
+                        },
+                    };
+                }
+            }
+        }
+    }
+
+    fn handle_push(&mut self) {
+        let wt = self
+            .state
+            .selected_worktree_id
+            .as_ref()
+            .and_then(|id| self.state.data.worktrees.iter().find(|w| &w.id == id))
+            .cloned();
+
+        if let Some(wt) = wt {
+            self.state.status_message = Some(format!("Pushing {}...", wt.slug));
+            let output = Command::new("git")
+                .args(["push", "-u", "origin", &wt.branch])
+                .current_dir(&wt.path)
+                .output();
+            match output {
+                Ok(o) if o.status.success() => {
+                    self.state.status_message = Some(format!("Pushed {}", wt.slug));
+                }
+                Ok(o) => {
+                    let stderr = String::from_utf8_lossy(&o.stderr);
+                    self.state.modal = Modal::Error {
+                        message: format!("Push failed: {stderr}"),
+                    };
+                }
+                Err(e) => {
+                    self.state.modal = Modal::Error {
+                        message: format!("Push failed: {e}"),
+                    };
+                }
+            }
+        } else {
+            self.state.status_message = Some("Select a worktree first".to_string());
+        }
+    }
+
+    fn handle_create_pr(&mut self) {
+        let wt = self
+            .state
+            .selected_worktree_id
+            .as_ref()
+            .and_then(|id| self.state.data.worktrees.iter().find(|w| &w.id == id))
+            .cloned();
+
+        if let Some(wt) = wt {
+            self.state.status_message = Some(format!("Creating PR for {}...", wt.slug));
+            let output = Command::new("gh")
+                .args(["pr", "create", "--fill", "--head", &wt.branch])
+                .current_dir(&wt.path)
+                .output();
+            match output {
+                Ok(o) if o.status.success() => {
+                    let url = String::from_utf8_lossy(&o.stdout);
+                    self.state.status_message = Some(format!("PR created: {}", url.trim()));
+                }
+                Ok(o) => {
+                    let stderr = String::from_utf8_lossy(&o.stderr);
+                    self.state.modal = Modal::Error {
+                        message: format!("PR creation failed: {stderr}"),
+                    };
+                }
+                Err(e) => {
+                    self.state.modal = Modal::Error {
+                        message: format!("PR creation failed: {e}"),
+                    };
+                }
+            }
+        } else {
+            self.state.status_message = Some("Select a worktree first".to_string());
+        }
+    }
+
+    fn handle_sync_tickets(&mut self) {
+        self.state.status_message = Some("Syncing tickets...".to_string());
+
+        let repo_mgr = RepoManager::new(&self.conn, &self.config);
+        let repos = repo_mgr.list().unwrap_or_default();
+        let syncer = TicketSyncer::new(&self.conn);
+
+        let mut total = 0;
+        for repo in &repos {
+            if let Some((owner, name)) = github::parse_github_remote(&repo.remote_url) {
+                match github::sync_github_issues(&owner, &name) {
+                    Ok(tickets) => {
+                        if let Ok(count) = syncer.upsert_tickets(&repo.id, &tickets) {
+                            total += count;
+                        }
+                    }
+                    Err(e) => {
+                        self.state.status_message =
+                            Some(format!("Sync error for {}: {e}", repo.slug));
+                    }
+                }
+            }
+        }
+
+        self.state.status_message = Some(format!("Synced {total} tickets"));
+        self.refresh_data();
+    }
+
+    fn handle_link_ticket(&mut self) {
+        if let Some(ref wt_id) = self.state.selected_worktree_id.clone() {
+            self.state.modal = Modal::Input {
+                title: "Link Ticket".to_string(),
+                prompt: "Enter ticket number (e.g., 42):".to_string(),
+                value: String::new(),
+                on_submit: InputAction::LinkTicket {
+                    worktree_id: wt_id.clone(),
+                },
+            };
+        } else {
+            self.state.status_message = Some("Select a worktree first".to_string());
+        }
+    }
+
+    fn handle_start_session(&mut self) {
+        if self.state.data.current_session.is_some() {
+            self.state.status_message = Some("Session already active".to_string());
+            return;
+        }
+
+        let tracker = SessionTracker::new(&self.conn);
+        match tracker.start() {
+            Ok(session) => {
+                self.state.status_message = Some(format!(
+                    "Session started: {}",
+                    &session.id[..13.min(session.id.len())]
+                ));
+                self.refresh_data();
+                self.state.view = View::Session;
+            }
+            Err(e) => {
+                self.state.modal = Modal::Error {
+                    message: format!("Start session failed: {e}"),
+                };
+            }
+        }
+    }
+
+    fn handle_end_session(&mut self) {
+        if let Some(ref session) = self.state.data.current_session {
+            self.state.modal = Modal::Confirm {
+                title: "End Session".to_string(),
+                message: "End the current session?".to_string(),
+                on_confirm: ConfirmAction::EndSession {
+                    session_id: session.id.clone(),
+                },
+            };
+        } else {
+            self.state.status_message = Some("No active session".to_string());
+        }
+    }
+}

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -1,0 +1,107 @@
+use std::sync::mpsc::Sender;
+use std::thread;
+use std::time::Duration;
+
+use conductor_core::config::{db_path, load_config};
+use conductor_core::db::open_database;
+use conductor_core::github;
+use conductor_core::repo::RepoManager;
+use conductor_core::session::SessionTracker;
+use conductor_core::tickets::TicketSyncer;
+use conductor_core::worktree::WorktreeManager;
+
+use crate::action::Action;
+use crate::event::Event;
+
+/// Spawn the DB poller thread. Polls every `interval` and sends DataRefreshed events.
+pub fn spawn_db_poller(tx: Sender<Event>, interval: Duration) {
+    thread::spawn(move || loop {
+        thread::sleep(interval);
+        if let Some(action) = poll_data() {
+            if tx.send(Event::Background(action)).is_err() {
+                break;
+            }
+        }
+    });
+}
+
+/// Poll all data from the database. Returns a DataRefreshed action if successful.
+pub fn poll_data() -> Option<Action> {
+    let db = db_path();
+    let conn = open_database(&db).ok()?;
+    let config = load_config().ok()?;
+
+    let repo_mgr = RepoManager::new(&conn, &config);
+    let wt_mgr = WorktreeManager::new(&conn, &config);
+    let ticket_syncer = TicketSyncer::new(&conn);
+    let session_tracker = SessionTracker::new(&conn);
+
+    let repos = repo_mgr.list().ok()?;
+    let worktrees = wt_mgr.list(None).ok()?;
+    let tickets = ticket_syncer.list(None).ok()?;
+    let session = session_tracker.current().ok()?;
+    let session_worktrees = if let Some(ref s) = session {
+        session_tracker.get_worktrees(&s.id).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    Some(Action::DataRefreshed {
+        repos,
+        worktrees,
+        tickets,
+        session,
+        session_worktrees,
+    })
+}
+
+/// Spawn the ticket sync timer. Syncs all repos every `interval`.
+pub fn spawn_ticket_sync(tx: Sender<Event>, interval: Duration) {
+    thread::spawn(move || loop {
+        thread::sleep(interval);
+        sync_all_tickets(&tx);
+    });
+}
+
+fn sync_all_tickets(tx: &Sender<Event>) {
+    let db = db_path();
+    let Ok(conn) = open_database(&db) else { return };
+    let Ok(config) = load_config() else { return };
+
+    let repo_mgr = RepoManager::new(&conn, &config);
+    let Ok(repos) = repo_mgr.list() else { return };
+
+    let syncer = TicketSyncer::new(&conn);
+    for repo in repos {
+        if let Some((owner, name)) = github::parse_github_remote(&repo.remote_url) {
+            let action = match github::sync_github_issues(&owner, &name) {
+                Ok(tickets) => match syncer.upsert_tickets(&repo.id, &tickets) {
+                    Ok(count) => Action::TicketSyncComplete {
+                        repo_slug: repo.slug.clone(),
+                        count,
+                    },
+                    Err(e) => Action::TicketSyncFailed {
+                        repo_slug: repo.slug.clone(),
+                        error: e.to_string(),
+                    },
+                },
+                Err(e) => Action::TicketSyncFailed {
+                    repo_slug: repo.slug.clone(),
+                    error: e.to_string(),
+                },
+            };
+            if tx.send(Event::Background(action)).is_err() {
+                return;
+            }
+        }
+    }
+}
+
+/// Spawn a one-shot background operation for blocking tasks.
+#[allow(dead_code)]
+pub fn spawn_blocking(tx: Sender<Event>, f: impl FnOnce() -> Action + Send + 'static) {
+    thread::spawn(move || {
+        let action = f();
+        let _ = tx.send(Event::Background(action));
+    });
+}

--- a/conductor-tui/src/event.rs
+++ b/conductor-tui/src/event.rs
@@ -1,0 +1,63 @@
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use crossterm::event::{self, Event as CrosstermEvent, KeyEvent};
+
+/// Unified event type for the TUI main loop.
+#[derive(Debug)]
+pub enum Event {
+    /// A keyboard event from crossterm.
+    Key(KeyEvent),
+    /// A periodic tick for UI refresh.
+    Tick,
+    /// A message from a background worker (carries an Action).
+    Background(crate::action::Action),
+}
+
+/// The event loop: spawns a crossterm input reader thread, a tick timer,
+/// and exposes a sender for background workers.
+pub struct EventLoop {
+    rx: mpsc::Receiver<Event>,
+    bg_tx: mpsc::Sender<Event>,
+}
+
+impl EventLoop {
+    /// Create a new event loop. `tick_rate` controls the tick interval.
+    pub fn new(tick_rate: Duration) -> Self {
+        let (tx, rx) = mpsc::channel();
+        let bg_tx = tx.clone();
+
+        // Crossterm input reader thread
+        let input_tx = tx.clone();
+        thread::spawn(move || loop {
+            if event::poll(tick_rate).unwrap_or(false) {
+                if let Ok(CrosstermEvent::Key(key)) = event::read() {
+                    if input_tx.send(Event::Key(key)).is_err() {
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Tick timer thread
+        thread::spawn(move || loop {
+            thread::sleep(tick_rate);
+            if tx.send(Event::Tick).is_err() {
+                break;
+            }
+        });
+
+        Self { rx, bg_tx }
+    }
+
+    /// Get the next event, blocking until one is available.
+    pub fn next(&self) -> Result<Event, mpsc::RecvError> {
+        self.rx.recv()
+    }
+
+    /// Get a sender for background workers to push events.
+    pub fn bg_sender(&self) -> mpsc::Sender<Event> {
+        self.bg_tx.clone()
+    }
+}

--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -1,0 +1,108 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::action::Action;
+use crate::state::{AppState, DashboardFocus, Modal, View};
+
+/// Map a key event to an action based on the current app state.
+/// Priority: Modal > Filter > Normal keybindings.
+pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
+    // Ctrl+C always quits
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        return Action::Quit;
+    }
+
+    // Modal state takes priority
+    match &state.modal {
+        Modal::Help => {
+            return match key.code {
+                KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q') | KeyCode::Enter => {
+                    Action::DismissModal
+                }
+                _ => Action::None,
+            };
+        }
+        Modal::Confirm { .. } => {
+            return match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => Action::ConfirmYes,
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => Action::ConfirmNo,
+                _ => Action::None,
+            };
+        }
+        Modal::Input { .. } => {
+            return match key.code {
+                KeyCode::Enter => Action::InputSubmit,
+                KeyCode::Esc => Action::DismissModal,
+                KeyCode::Backspace => Action::InputBackspace,
+                KeyCode::Char(c) => Action::InputChar(c),
+                _ => Action::None,
+            };
+        }
+        Modal::Error { .. } => {
+            return match key.code {
+                KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => Action::DismissModal,
+                _ => Action::None,
+            };
+        }
+        Modal::None => {}
+    }
+
+    // Filter mode
+    if state.filter_active {
+        return match key.code {
+            KeyCode::Esc => Action::ExitFilter,
+            KeyCode::Enter => Action::ExitFilter,
+            KeyCode::Backspace => Action::FilterBackspace,
+            KeyCode::Char(c) => Action::FilterChar(c),
+            _ => Action::None,
+        };
+    }
+
+    // Normal keybindings
+    match key.code {
+        KeyCode::Char('q') => Action::Quit,
+        KeyCode::Char('?') => Action::ShowHelp,
+        KeyCode::Char('/') => Action::EnterFilter,
+        KeyCode::Esc => Action::Back,
+        KeyCode::Tab => Action::NextPanel,
+        KeyCode::BackTab => Action::PrevPanel,
+        KeyCode::Char('j') | KeyCode::Down => Action::MoveDown,
+        KeyCode::Char('k') | KeyCode::Up => Action::MoveUp,
+        KeyCode::Enter => Action::Select,
+
+        // CRUD actions (context-dependent)
+        KeyCode::Char('c') => Action::Create,
+        KeyCode::Char('d') => Action::Delete,
+        KeyCode::Char('p') => Action::Push,
+        KeyCode::Char('P') => Action::CreatePr,
+        KeyCode::Char('s') => match state.view {
+            View::Session => Action::EndSession,
+            _ => Action::SyncTickets,
+        },
+        KeyCode::Char('S') => Action::StartSession,
+        KeyCode::Char('l') => Action::LinkTicket,
+
+        // Direct view navigation
+        KeyCode::Char('t') => Action::GoToTickets,
+        KeyCode::Char('1') => Action::GoToDashboard,
+        KeyCode::Char('2') => Action::GoToTickets,
+        KeyCode::Char('3') => Action::GoToSession,
+
+        _ => Action::None,
+    }
+}
+
+/// Get the current list length for the focused panel (used for bounds-checking navigation).
+#[allow(dead_code)]
+pub fn focused_list_len(state: &AppState) -> usize {
+    match state.view {
+        View::Dashboard => match state.dashboard_focus {
+            DashboardFocus::Repos => state.data.repos.len(),
+            DashboardFocus::Worktrees => state.data.worktrees.len(),
+            DashboardFocus::Tickets => state.data.tickets.len(),
+        },
+        View::RepoDetail => state.detail_worktrees.len().max(state.detail_tickets.len()),
+        View::WorktreeDetail => 0,
+        View::Tickets => state.data.tickets.len(),
+        View::Session => state.data.session_worktrees.len(),
+    }
+}

--- a/conductor-tui/src/main.rs
+++ b/conductor-tui/src/main.rs
@@ -1,6 +1,33 @@
+mod action;
+mod app;
+mod background;
+mod event;
+mod input;
+mod state;
+mod ui;
+
 use anyhow::Result;
 
+use conductor_core::config::{db_path, ensure_dirs, load_config};
+use conductor_core::db::open_database;
+
 fn main() -> Result<()> {
-    println!("conductor-tui — not yet implemented (Phase 2)");
-    Ok(())
+    // Install panic hook that restores terminal before printing panic info
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        ratatui::restore();
+        original_hook(info);
+    }));
+
+    let config = load_config()?;
+    ensure_dirs(&config)?;
+
+    let db = db_path();
+    let conn = open_database(&db)?;
+
+    let mut terminal = ratatui::init();
+    let result = app::App::new(conn, config).run(&mut terminal);
+    ratatui::restore();
+
+    result
 }

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -1,0 +1,206 @@
+use std::collections::HashMap;
+
+use conductor_core::repo::Repo;
+use conductor_core::session::Session;
+use conductor_core::tickets::Ticket;
+use conductor_core::worktree::Worktree;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum View {
+    Dashboard,
+    RepoDetail,
+    WorktreeDetail,
+    Tickets,
+    Session,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DashboardFocus {
+    Repos,
+    Worktrees,
+    Tickets,
+}
+
+impl DashboardFocus {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Repos => Self::Worktrees,
+            Self::Worktrees => Self::Tickets,
+            Self::Tickets => Self::Repos,
+        }
+    }
+
+    pub fn prev(self) -> Self {
+        match self {
+            Self::Repos => Self::Tickets,
+            Self::Worktrees => Self::Repos,
+            Self::Tickets => Self::Worktrees,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoDetailFocus {
+    Worktrees,
+    Tickets,
+}
+
+impl RepoDetailFocus {
+    pub fn toggle(self) -> Self {
+        match self {
+            Self::Worktrees => Self::Tickets,
+            Self::Tickets => Self::Worktrees,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Modal {
+    None,
+    Help,
+    Confirm {
+        title: String,
+        message: String,
+        on_confirm: ConfirmAction,
+    },
+    Input {
+        title: String,
+        prompt: String,
+        value: String,
+        on_submit: InputAction,
+    },
+    Error {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum ConfirmAction {
+    DeleteWorktree { repo_slug: String, wt_slug: String },
+    EndSession { session_id: String },
+}
+
+#[derive(Debug, Clone)]
+pub enum InputAction {
+    CreateWorktree {
+        repo_slug: String,
+    },
+    LinkTicket {
+        worktree_id: String,
+    },
+    #[allow(dead_code)]
+    SessionNotes {
+        session_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DataCache {
+    pub repos: Vec<Repo>,
+    pub worktrees: Vec<Worktree>,
+    pub tickets: Vec<Ticket>,
+    pub current_session: Option<Session>,
+    pub session_worktrees: Vec<Worktree>,
+    /// repo_id -> slug for display
+    pub repo_slug_map: HashMap<String, String>,
+    /// ticket_id -> Ticket for lookups
+    pub ticket_map: HashMap<String, Ticket>,
+    /// repo_id -> worktree count
+    pub repo_worktree_count: HashMap<String, usize>,
+}
+
+impl DataCache {
+    pub fn rebuild_maps(&mut self) {
+        self.repo_slug_map.clear();
+        for repo in &self.repos {
+            self.repo_slug_map
+                .insert(repo.id.clone(), repo.slug.clone());
+        }
+
+        self.ticket_map.clear();
+        for ticket in &self.tickets {
+            self.ticket_map.insert(ticket.id.clone(), ticket.clone());
+        }
+
+        self.repo_worktree_count.clear();
+        for wt in &self.worktrees {
+            *self
+                .repo_worktree_count
+                .entry(wt.repo_id.clone())
+                .or_insert(0) += 1;
+        }
+    }
+}
+
+pub struct AppState {
+    pub view: View,
+    pub dashboard_focus: DashboardFocus,
+    pub repo_detail_focus: RepoDetailFocus,
+    pub modal: Modal,
+    pub data: DataCache,
+
+    // Selection indices
+    pub repo_index: usize,
+    pub worktree_index: usize,
+    pub ticket_index: usize,
+
+    // Detail view context
+    pub selected_repo_id: Option<String>,
+    pub selected_worktree_id: Option<String>,
+
+    // Scoped lists for detail views
+    pub detail_worktrees: Vec<Worktree>,
+    pub detail_tickets: Vec<Ticket>,
+    pub detail_wt_index: usize,
+    pub detail_ticket_index: usize,
+
+    // Filter
+    pub filter_active: bool,
+    pub filter_text: String,
+
+    // Status bar message
+    pub status_message: Option<String>,
+
+    pub should_quit: bool,
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        Self {
+            view: View::Dashboard,
+            dashboard_focus: DashboardFocus::Repos,
+            repo_detail_focus: RepoDetailFocus::Worktrees,
+            modal: Modal::None,
+            data: DataCache::default(),
+            repo_index: 0,
+            worktree_index: 0,
+            ticket_index: 0,
+            selected_repo_id: None,
+            selected_worktree_id: None,
+            detail_worktrees: Vec::new(),
+            detail_tickets: Vec::new(),
+            detail_wt_index: 0,
+            detail_ticket_index: 0,
+            filter_active: false,
+            filter_text: String::new(),
+            status_message: None,
+            should_quit: false,
+        }
+    }
+
+    /// Get the currently selected repo, if any.
+    pub fn selected_repo(&self) -> Option<&Repo> {
+        self.data.repos.get(self.repo_index)
+    }
+
+    /// Get the currently selected worktree from the dashboard list.
+    pub fn selected_worktree(&self) -> Option<&Worktree> {
+        self.data.worktrees.get(self.worktree_index)
+    }
+
+    /// Get the currently selected ticket from the dashboard list.
+    #[allow(dead_code)]
+    pub fn selected_ticket(&self) -> Option<&Ticket> {
+        self.data.tickets.get(self.ticket_index)
+    }
+}

--- a/conductor-tui/src/ui/common.rs
+++ b/conductor-tui/src/ui/common.rs
@@ -1,0 +1,87 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+
+use crate::state::{AppState, View};
+
+pub fn render_header(frame: &mut Frame, area: Rect, state: &AppState) {
+    let view_name = match state.view {
+        View::Dashboard => "Dashboard",
+        View::RepoDetail => "Repo Detail",
+        View::WorktreeDetail => "Worktree Detail",
+        View::Tickets => "Tickets",
+        View::Session => "Session",
+    };
+
+    let session_info = if let Some(ref session) = state.data.current_session {
+        if session.ended_at.is_none() {
+            let elapsed = session_elapsed(&session.started_at);
+            format!(" | Session: {elapsed}")
+        } else {
+            String::new()
+        }
+    } else {
+        String::new()
+    };
+
+    let header = Line::from(vec![
+        Span::styled(
+            " Conductor ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(" {view_name}"),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(session_info, Style::default().fg(Color::Yellow)),
+    ]);
+
+    frame.render_widget(Paragraph::new(header), area);
+}
+
+pub fn render_status_bar(frame: &mut Frame, area: Rect, state: &AppState) {
+    let msg = if state.filter_active {
+        format!("/{} ", state.filter_text)
+    } else if let Some(ref msg) = state.status_message {
+        msg.clone()
+    } else {
+        match state.view {
+            View::Dashboard => {
+                "Tab:panel  j/k:nav  Enter:select  c:create  s:sync  ?:help  q:quit".to_string()
+            }
+            View::RepoDetail => "j/k:nav  Enter:select  c:create  Esc:back  ?:help".to_string(),
+            View::WorktreeDetail => "p:push  P:PR  l:link  d:delete  Esc:back  ?:help".to_string(),
+            View::Tickets => "j/k:nav  /:filter  Esc:back  ?:help".to_string(),
+            View::Session => "s:end session  Esc:back  ?:help".to_string(),
+        }
+    };
+
+    let bar = Paragraph::new(Line::from(Span::styled(
+        msg,
+        Style::default().fg(Color::DarkGray),
+    )));
+    frame.render_widget(bar, area);
+}
+
+/// Calculate elapsed time from an ISO 8601 timestamp to now.
+fn session_elapsed(started_at: &str) -> String {
+    let Ok(start) = chrono::DateTime::parse_from_rfc3339(started_at) else {
+        return "??:??".to_string();
+    };
+    let elapsed = chrono::Utc::now().signed_duration_since(start);
+    let hours = elapsed.num_hours();
+    let minutes = elapsed.num_minutes() % 60;
+    let seconds = elapsed.num_seconds() % 60;
+    if hours > 0 {
+        format!("{hours}h{minutes:02}m{seconds:02}s")
+    } else {
+        format!("{minutes}m{seconds:02}s")
+    }
+}

--- a/conductor-tui/src/ui/dashboard.rs
+++ b/conductor-tui/src/ui/dashboard.rs
@@ -1,0 +1,202 @@
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+use ratatui::Frame;
+
+use crate::state::{AppState, DashboardFocus};
+
+pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
+    // Split: top row (repos left 40%, worktrees right 60%), bottom (tickets 100%)
+    let vert = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
+        .split(area);
+
+    let top = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(vert[0]);
+
+    render_repos(frame, top[0], state);
+    render_worktrees(frame, top[1], state);
+    render_tickets(frame, vert[1], state);
+}
+
+fn render_repos(frame: &mut Frame, area: Rect, state: &AppState) {
+    let focused = state.dashboard_focus == DashboardFocus::Repos;
+    let border_style = if focused {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    let items: Vec<ListItem> = state
+        .data
+        .repos
+        .iter()
+        .map(|r| {
+            let wt_count = state.data.repo_worktree_count.get(&r.id).unwrap_or(&0);
+            ListItem::new(Line::from(vec![
+                Span::styled(&r.slug, Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(format!("  ({wt_count} worktrees)")),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .title(" Repos "),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    let mut list_state = ListState::default();
+    if focused && !state.data.repos.is_empty() {
+        list_state.select(Some(state.repo_index));
+    }
+
+    frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn render_worktrees(frame: &mut Frame, area: Rect, state: &AppState) {
+    let focused = state.dashboard_focus == DashboardFocus::Worktrees;
+    let border_style = if focused {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    let items: Vec<ListItem> = state
+        .data
+        .worktrees
+        .iter()
+        .map(|wt| {
+            let repo_slug = state
+                .data
+                .repo_slug_map
+                .get(&wt.repo_id)
+                .map(|s| s.as_str())
+                .unwrap_or("?");
+            let status_color = match wt.status.as_str() {
+                "active" => Color::Green,
+                "merged" => Color::Blue,
+                "abandoned" => Color::Red,
+                _ => Color::White,
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{repo_slug}/"),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(&wt.slug, Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw("  "),
+                Span::styled(
+                    format!("[{}]", wt.status),
+                    Style::default().fg(status_color),
+                ),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .title(" Worktrees "),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    let mut list_state = ListState::default();
+    if focused && !state.data.worktrees.is_empty() {
+        list_state.select(Some(state.worktree_index));
+    }
+
+    frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn render_tickets(frame: &mut Frame, area: Rect, state: &AppState) {
+    let focused = state.dashboard_focus == DashboardFocus::Tickets;
+    let border_style = if focused {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    let items: Vec<ListItem> = state
+        .data
+        .tickets
+        .iter()
+        .filter(|t| {
+            if state.filter_active && !state.filter_text.is_empty() {
+                let lower = state.filter_text.to_lowercase();
+                t.title.to_lowercase().contains(&lower)
+                    || t.source_id.contains(&lower)
+                    || t.labels.to_lowercase().contains(&lower)
+            } else {
+                true
+            }
+        })
+        .map(|t| {
+            let repo_slug = state
+                .data
+                .repo_slug_map
+                .get(&t.repo_id)
+                .map(|s| s.as_str())
+                .unwrap_or("?");
+            let state_color = match t.state.as_str() {
+                "open" => Color::Green,
+                "closed" => Color::Red,
+                "in_progress" => Color::Yellow,
+                _ => Color::White,
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{repo_slug} "),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(
+                    format!("#{} ", t.source_id),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::raw(&t.title),
+                Span::raw("  "),
+                Span::styled(format!("[{}]", t.state), Style::default().fg(state_color)),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border_style)
+                .title(" Tickets "),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    let mut list_state = ListState::default();
+    if focused && !state.data.tickets.is_empty() {
+        list_state.select(Some(state.ticket_index));
+    }
+
+    frame.render_stateful_widget(list, area, &mut list_state);
+}

--- a/conductor-tui/src/ui/help.rs
+++ b/conductor-tui/src/ui/help.rs
@@ -1,0 +1,89 @@
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+pub fn render(frame: &mut Frame, area: Rect) {
+    let popup = centered_rect(60, 80, area);
+    frame.render_widget(Clear, popup);
+
+    let lines = vec![
+        Line::from(Span::styled(
+            "Keybindings",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        help_line("Tab / Shift+Tab", "Cycle panel focus"),
+        help_line("j / k", "Navigate within panel"),
+        help_line("Enter", "Drill into selected item"),
+        help_line("Esc", "Back to previous view"),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Actions",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        help_line("c", "Create worktree"),
+        help_line("d", "Delete (with confirmation)"),
+        help_line("p", "Push current worktree"),
+        help_line("P", "Create pull request"),
+        help_line("s", "Sync tickets / End session"),
+        help_line("S", "Start session"),
+        help_line("l", "Link ticket to worktree"),
+        help_line("/", "Filter/search"),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Navigation",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        help_line("1", "Dashboard"),
+        help_line("2 / t", "Tickets view"),
+        help_line("3", "Session view"),
+        help_line("?", "Toggle this help"),
+        help_line("q", "Quit"),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Press Esc or ? to close",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let help = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(" Help "),
+    );
+
+    frame.render_widget(help, popup);
+}
+
+fn help_line<'a>(key: &'a str, desc: &'a str) -> Line<'a> {
+    Line::from(vec![
+        Span::styled(
+            format!("  {key:<20}"),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(desc),
+    ])
+}
+
+/// Create a centered rectangle of a given percentage width and height.
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Percentage(percent_y)])
+        .flex(Flex::Center)
+        .split(area);
+    Layout::horizontal([Constraint::Percentage(percent_x)])
+        .flex(Flex::Center)
+        .split(vertical[0])[0]
+}

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -1,0 +1,57 @@
+mod common;
+mod dashboard;
+mod help;
+mod modal;
+mod repo_detail;
+mod session;
+mod tickets;
+mod worktree_detail;
+
+use ratatui::Frame;
+
+use crate::state::{AppState, Modal, View};
+
+/// Root render function: dispatch by current view, then overlay modals.
+pub fn render(frame: &mut Frame, state: &AppState) {
+    let area = frame.area();
+
+    // Layout: header (1 line) + body (fill) + status bar (1 line)
+    let layout = ratatui::layout::Layout::default()
+        .direction(ratatui::layout::Direction::Vertical)
+        .constraints([
+            ratatui::layout::Constraint::Length(1),
+            ratatui::layout::Constraint::Min(0),
+            ratatui::layout::Constraint::Length(1),
+        ])
+        .split(area);
+
+    let header_area = layout[0];
+    let body_area = layout[1];
+    let status_area = layout[2];
+
+    common::render_header(frame, header_area, state);
+
+    match state.view {
+        View::Dashboard => dashboard::render(frame, body_area, state),
+        View::RepoDetail => repo_detail::render(frame, body_area, state),
+        View::WorktreeDetail => worktree_detail::render(frame, body_area, state),
+        View::Tickets => tickets::render(frame, body_area, state),
+        View::Session => session::render(frame, body_area, state),
+    }
+
+    common::render_status_bar(frame, status_area, state);
+
+    // Modal overlay on top
+    match &state.modal {
+        Modal::None => {}
+        Modal::Help => help::render(frame, area),
+        Modal::Confirm { title, message, .. } => modal::render_confirm(frame, area, title, message),
+        Modal::Input {
+            title,
+            prompt,
+            value,
+            ..
+        } => modal::render_input(frame, area, title, prompt, value),
+        Modal::Error { message } => modal::render_error(frame, area, message),
+    }
+}

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -1,0 +1,99 @@
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+pub fn render_confirm(frame: &mut Frame, area: Rect, title: &str, message: &str) {
+    let popup = centered_rect(50, 30, area);
+    frame.render_widget(Clear, popup);
+
+    let content = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(Span::raw(message)),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "  y",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" = confirm    "),
+            Span::styled(
+                "n",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" = cancel"),
+        ]),
+    ])
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Yellow))
+            .title(format!(" {title} ")),
+    );
+
+    frame.render_widget(content, popup);
+}
+
+pub fn render_input(frame: &mut Frame, area: Rect, title: &str, prompt: &str, value: &str) {
+    let popup = centered_rect(50, 30, area);
+    frame.render_widget(Clear, popup);
+
+    let content = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(Span::raw(prompt)),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("> ", Style::default().fg(Color::Cyan)),
+            Span::styled(value, Style::default().add_modifier(Modifier::UNDERLINED)),
+            Span::styled("_", Style::default().fg(Color::Cyan)),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Enter to submit, Esc to cancel",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ])
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(format!(" {title} ")),
+    );
+
+    frame.render_widget(content, popup);
+}
+
+pub fn render_error(frame: &mut Frame, area: Rect, message: &str) {
+    let popup = centered_rect(50, 25, area);
+    frame.render_widget(Clear, popup);
+
+    let content = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(Span::styled(message, Style::default().fg(Color::Red))),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Press Esc or Enter to dismiss",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ])
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red))
+            .title(" Error "),
+    );
+
+    frame.render_widget(content, popup);
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Percentage(percent_y)])
+        .flex(Flex::Center)
+        .split(area);
+    Layout::horizontal([Constraint::Percentage(percent_x)])
+        .flex(Flex::Center)
+        .split(vertical[0])[0]
+}

--- a/conductor-tui/src/ui/repo_detail.rs
+++ b/conductor-tui/src/ui/repo_detail.rs
@@ -1,0 +1,149 @@
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
+
+use crate::state::{AppState, RepoDetailFocus};
+
+pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
+    let repo = state
+        .selected_repo_id
+        .as_ref()
+        .and_then(|id| state.data.repos.iter().find(|r| &r.id == id));
+
+    let Some(repo) = repo else {
+        let msg = Paragraph::new("No repo selected").block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Repo Detail "),
+        );
+        frame.render_widget(msg, area);
+        return;
+    };
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(5),
+            Constraint::Percentage(50),
+            Constraint::Percentage(50),
+        ])
+        .split(area);
+
+    // Repo info header
+    let info = Paragraph::new(vec![
+        Line::from(vec![
+            Span::styled("Repo: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&repo.slug, Style::default().add_modifier(Modifier::BOLD)),
+        ]),
+        Line::from(vec![
+            Span::styled("Remote: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&repo.remote_url),
+        ]),
+        Line::from(vec![
+            Span::styled("Branch: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&repo.default_branch),
+            Span::styled("  Path: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&repo.local_path),
+        ]),
+        Line::from(vec![
+            Span::styled("Worktrees Dir: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&repo.workspace_dir),
+        ]),
+    ])
+    .block(Block::default().borders(Borders::ALL).title(" Info "));
+
+    frame.render_widget(info, layout[0]);
+
+    // Scoped worktrees
+    let wt_focused = state.repo_detail_focus == RepoDetailFocus::Worktrees;
+    let wt_border = if wt_focused {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let wt_items: Vec<ListItem> = state
+        .detail_worktrees
+        .iter()
+        .map(|wt| {
+            let status_color = match wt.status.as_str() {
+                "active" => Color::Green,
+                "merged" => Color::Blue,
+                _ => Color::Red,
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(&wt.slug, Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(format!("  {}", wt.branch)),
+                Span::raw("  "),
+                Span::styled(
+                    format!("[{}]", wt.status),
+                    Style::default().fg(status_color),
+                ),
+            ]))
+        })
+        .collect();
+
+    let wt_list = List::new(wt_items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(wt_border)
+                .title(" Worktrees "),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    let mut wt_state = ListState::default();
+    if wt_focused && !state.detail_worktrees.is_empty() {
+        wt_state.select(Some(state.detail_wt_index));
+    }
+    frame.render_stateful_widget(wt_list, layout[1], &mut wt_state);
+
+    // Scoped tickets
+    let ticket_focused = state.repo_detail_focus == RepoDetailFocus::Tickets;
+    let ticket_border = if ticket_focused {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let ticket_items: Vec<ListItem> = state
+        .detail_tickets
+        .iter()
+        .map(|t| {
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("#{} ", t.source_id),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::raw(&t.title),
+                Span::raw("  "),
+                Span::styled(format!("[{}]", t.state), Style::default().fg(Color::Green)),
+            ]))
+        })
+        .collect();
+
+    let ticket_list = List::new(ticket_items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(ticket_border)
+                .title(" Tickets "),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    let mut ticket_state = ListState::default();
+    if ticket_focused && !state.detail_tickets.is_empty() {
+        ticket_state.select(Some(state.detail_ticket_index));
+    }
+    frame.render_stateful_widget(ticket_list, layout[2], &mut ticket_state);
+}

--- a/conductor-tui/src/ui/session.rs
+++ b/conductor-tui/src/ui/session.rs
@@ -1,0 +1,114 @@
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+use ratatui::Frame;
+
+use crate::state::AppState;
+
+pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
+    let Some(ref session) = state.data.current_session else {
+        let msg = Paragraph::new("No active session. Press S to start one.")
+            .block(Block::default().borders(Borders::ALL).title(" Session "));
+        frame.render_widget(msg, area);
+        return;
+    };
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(6), Constraint::Min(0)])
+        .split(area);
+
+    // Session info
+    let elapsed = session_elapsed(&session.started_at);
+    let notes = session.notes.as_deref().unwrap_or("(none)");
+
+    let info = Paragraph::new(vec![
+        Line::from(vec![
+            Span::styled("Session: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                &session.id[..13.min(session.id.len())],
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("Started: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&session.started_at),
+        ]),
+        Line::from(vec![
+            Span::styled("Elapsed: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(elapsed, Style::default().fg(Color::Yellow)),
+        ]),
+        Line::from(vec![
+            Span::styled("Notes: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(notes),
+        ]),
+    ])
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(" Session Info "),
+    );
+
+    frame.render_widget(info, layout[0]);
+
+    // Attached worktrees
+    let items: Vec<ListItem> = state
+        .data
+        .session_worktrees
+        .iter()
+        .map(|wt| {
+            let repo_slug = state
+                .data
+                .repo_slug_map
+                .get(&wt.repo_id)
+                .map(|s| s.as_str())
+                .unwrap_or("?");
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{repo_slug}/"),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(&wt.slug, Style::default().add_modifier(Modifier::BOLD)),
+                Span::raw(format!("  {}", wt.branch)),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray))
+                .title(" Attached Worktrees "),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    let mut list_state = ListState::default();
+    if !state.data.session_worktrees.is_empty() {
+        list_state.select(Some(0));
+    }
+
+    frame.render_stateful_widget(list, layout[1], &mut list_state);
+}
+
+fn session_elapsed(started_at: &str) -> String {
+    let Ok(start) = chrono::DateTime::parse_from_rfc3339(started_at) else {
+        return "??:??".to_string();
+    };
+    let elapsed = chrono::Utc::now().signed_duration_since(start);
+    let hours = elapsed.num_hours();
+    let minutes = elapsed.num_minutes() % 60;
+    let seconds = elapsed.num_seconds() % 60;
+    if hours > 0 {
+        format!("{hours}h{minutes:02}m{seconds:02}s")
+    } else {
+        format!("{minutes}m{seconds:02}s")
+    }
+}

--- a/conductor-tui/src/ui/tickets.rs
+++ b/conductor-tui/src/ui/tickets.rs
@@ -1,0 +1,106 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState};
+use ratatui::Frame;
+
+use crate::state::AppState;
+
+pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
+    let filter = if state.filter_active || !state.filter_text.is_empty() {
+        Some(state.filter_text.to_lowercase())
+    } else {
+        None
+    };
+
+    let items: Vec<ListItem> = state
+        .data
+        .tickets
+        .iter()
+        .filter(|t| {
+            if let Some(ref f) = filter {
+                if f.is_empty() {
+                    return true;
+                }
+                t.title.to_lowercase().contains(f)
+                    || t.source_id.contains(f.as_str())
+                    || t.labels.to_lowercase().contains(f)
+            } else {
+                true
+            }
+        })
+        .map(|t| {
+            let repo_slug = state
+                .data
+                .repo_slug_map
+                .get(&t.repo_id)
+                .map(|s| s.as_str())
+                .unwrap_or("?");
+
+            let state_color = match t.state.as_str() {
+                "open" => Color::Green,
+                "closed" => Color::Red,
+                "in_progress" => Color::Yellow,
+                _ => Color::White,
+            };
+
+            let assignee = t.assignee.as_deref().unwrap_or("-");
+
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{repo_slug:<12} "),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(
+                    format!("#{:<6} ", t.source_id),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled(format!("{:<40} ", truncate(&t.title, 40)), Style::default()),
+                Span::styled(
+                    format!("{:<12} ", t.state),
+                    Style::default().fg(state_color),
+                ),
+                Span::styled(assignee, Style::default().fg(Color::DarkGray)),
+            ]))
+        })
+        .collect();
+
+    let title = if let Some(ref f) = filter {
+        if f.is_empty() {
+            " Tickets ".to_string()
+        } else {
+            format!(" Tickets (filter: {f}) ")
+        }
+    } else {
+        " Tickets ".to_string()
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan))
+                .title(title),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    let mut list_state = ListState::default();
+    if !state.data.tickets.is_empty() {
+        list_state.select(Some(state.ticket_index));
+    }
+
+    frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    }
+}

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -1,0 +1,89 @@
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::Frame;
+
+use crate::state::AppState;
+
+pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
+    let wt = state
+        .selected_worktree_id
+        .as_ref()
+        .and_then(|id| state.data.worktrees.iter().find(|w| &w.id == id));
+
+    let Some(wt) = wt else {
+        let msg = Paragraph::new("No worktree selected").block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Worktree Detail "),
+        );
+        frame.render_widget(msg, area);
+        return;
+    };
+
+    let repo_slug = state
+        .data
+        .repo_slug_map
+        .get(&wt.repo_id)
+        .map(|s| s.as_str())
+        .unwrap_or("?");
+
+    let ticket_info = wt
+        .ticket_id
+        .as_ref()
+        .and_then(|tid| state.data.ticket_map.get(tid))
+        .map(|t| format!("#{} — {}", t.source_id, t.title))
+        .unwrap_or_else(|| "None (press l to link)".to_string());
+
+    let status_color = match wt.status.as_str() {
+        "active" => Color::Green,
+        "merged" => Color::Blue,
+        _ => Color::Red,
+    };
+
+    let content = Paragraph::new(vec![
+        Line::from(vec![
+            Span::styled("Worktree: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&wt.slug, Style::default().add_modifier(Modifier::BOLD)),
+        ]),
+        Line::from(vec![
+            Span::styled("Repo: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(repo_slug),
+        ]),
+        Line::from(vec![
+            Span::styled("Branch: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&wt.branch),
+        ]),
+        Line::from(vec![
+            Span::styled("Path: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&wt.path),
+        ]),
+        Line::from(vec![
+            Span::styled("Status: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(&wt.status, Style::default().fg(status_color)),
+        ]),
+        Line::from(vec![
+            Span::styled("Created: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&wt.created_at),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Ticket: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(ticket_info),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Actions: p=push  P=PR  l=link ticket  d=delete  Esc=back",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ])
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(" Worktree Detail "),
+    );
+
+    frame.render_widget(content, area);
+}


### PR DESCRIPTION
## Summary
- Full interactive terminal UI for Conductor (Phase 2 per `docs/SPEC.md`)
- Add `SessionTracker::get_worktrees()` to `conductor-core` for the session view
- Elm-style architecture: Event -> Action -> Update -> Render
- 5 views: Dashboard, Repo Detail, Worktree Detail, Tickets, Session
- Background DB poller (2s) and ticket sync timer (configurable interval)
- Modals: help overlay, confirm dialog, text input, error toast
- All spec keybindings wired up: Tab/j/k/Enter/Esc/c/d/p/P/s/l/?/q

## Test plan
- [x] `cargo build --workspace` compiles cleanly
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — all existing tests pass
- [x] `cargo run --bin conductor-tui` launches TUI, shows dashboard
- [x] Tab between panels, j/k navigation, ? for help, q to quit
- [x] If repos registered: verify data displays, s syncs tickets, c creates worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)