### PR TITLE
Fix ticket link matching wrong repo on source_id collision

### DIFF
--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -474,13 +474,18 @@ impl App {
                 }
                 InputAction::LinkTicket { worktree_id } => {
                     let syncer = TicketSyncer::new(&self.conn);
-                    // Find ticket by source_id
-                    let ticket = self
+                    // Find ticket by source_id, scoped to the worktree's repo
+                    let wt_repo_id = self
                         .state
                         .data
-                        .tickets
+                        .worktrees
                         .iter()
-                        .find(|t| t.source_id == value);
+                        .find(|w| w.id == worktree_id)
+                        .map(|w| w.repo_id.as_str());
+                    let ticket =
+                        self.state.data.tickets.iter().find(|t| {
+                            t.source_id == value && Some(t.repo_id.as_str()) == wt_repo_id
+                        });
                     if let Some(t) = ticket {
                         match syncer.link_to_worktree(&t.id, &worktree_id) {
                             Ok(()) => {


### PR DESCRIPTION
## Summary
- Ticket link (`l` in Worktree Detail) searched all tickets by `source_id`, so if multiple repos had the same issue number (e.g. #15), it grabbed the first match regardless of repo
- Now scopes the ticket search to the worktree's `repo_id`

## Test plan
- [x] Register two repos that both have an issue with the same number
- [x] Create a worktree for repo B, press `l`, enter the shared issue number
- [x] Verify the linked ticket belongs to repo B, not repo A

🤖 Generated with [Claude Code](https://claude.com/claude-code)