### PR TITLE
TUI: Ticket info popup on Enter

### DIFF
--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -39,6 +39,7 @@ pub enum Action {
     // Modal
     ShowHelp,
     DismissModal,
+    OpenTicketUrl,
     ConfirmYes,
     ConfirmNo,
     InputChar(char),

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -122,6 +122,7 @@ impl App {
             Action::DismissModal => {
                 self.state.modal = Modal::None;
             }
+            Action::OpenTicketUrl => self.handle_open_ticket_url(),
             Action::ConfirmYes => self.handle_confirm_yes(),
             Action::ConfirmNo => {
                 self.state.modal = Modal::None;
@@ -394,17 +395,63 @@ impl App {
                     }
                 }
                 DashboardFocus::Tickets => {
-                    // Tickets don't have a detail view from dashboard; show full ticket list
-                    self.state.view = View::Tickets;
+                    if let Some(ticket) = self.state.data.tickets.get(self.state.ticket_index) {
+                        self.state.modal = Modal::TicketInfo {
+                            ticket: Box::new(ticket.clone()),
+                        };
+                    }
                 }
             },
-            View::RepoDetail => {
-                if let Some(wt) = self.state.detail_worktrees.get(self.state.detail_wt_index) {
-                    self.state.selected_worktree_id = Some(wt.id.clone());
-                    self.state.view = View::WorktreeDetail;
+            View::RepoDetail => match self.state.repo_detail_focus {
+                RepoDetailFocus::Worktrees => {
+                    if let Some(wt) = self.state.detail_worktrees.get(self.state.detail_wt_index) {
+                        self.state.selected_worktree_id = Some(wt.id.clone());
+                        self.state.view = View::WorktreeDetail;
+                    }
+                }
+                RepoDetailFocus::Tickets => {
+                    if let Some(ticket) = self
+                        .state
+                        .detail_tickets
+                        .get(self.state.detail_ticket_index)
+                    {
+                        self.state.modal = Modal::TicketInfo {
+                            ticket: Box::new(ticket.clone()),
+                        };
+                    }
+                }
+            },
+            View::Tickets => {
+                if let Some(ticket) = self.state.data.tickets.get(self.state.ticket_index) {
+                    self.state.modal = Modal::TicketInfo {
+                        ticket: Box::new(ticket.clone()),
+                    };
                 }
             }
             _ => {}
+        }
+    }
+
+    fn handle_open_ticket_url(&mut self) {
+        if let Modal::TicketInfo { ref ticket } = self.state.modal {
+            let url = ticket.url.clone();
+            if url.is_empty() {
+                self.state.status_message = Some("No URL available".to_string());
+                return;
+            }
+            let result = Command::new("open").arg(&url).output();
+            match result {
+                Ok(o) if o.status.success() => {
+                    self.state.status_message = Some(format!("Opened {url}"));
+                }
+                Ok(o) => {
+                    let stderr = String::from_utf8_lossy(&o.stderr);
+                    self.state.status_message = Some(format!("Failed to open URL: {stderr}"));
+                }
+                Err(e) => {
+                    self.state.status_message = Some(format!("Failed to open URL: {e}"));
+                }
+            }
         }
     }
 

--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -43,6 +43,13 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
                 _ => Action::None,
             };
         }
+        Modal::TicketInfo { .. } => {
+            return match key.code {
+                KeyCode::Esc | KeyCode::Char('q') => Action::DismissModal,
+                KeyCode::Char('o') => Action::OpenTicketUrl,
+                _ => Action::None,
+            };
+        }
         Modal::None => {}
     }
 

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -72,6 +72,9 @@ pub enum Modal {
     Error {
         message: String,
     },
+    TicketInfo {
+        ticket: Box<Ticket>,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -53,5 +53,6 @@ pub fn render(frame: &mut Frame, state: &AppState) {
             ..
         } => modal::render_input(frame, area, title, prompt, value),
         Modal::Error { message } => modal::render_error(frame, area, message),
+        Modal::TicketInfo { ticket } => modal::render_ticket_info(frame, area, ticket),
     }
 }

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -1,8 +1,10 @@
 use ratatui::layout::{Constraint, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
+
+use conductor_core::tickets::Ticket;
 
 pub fn render_confirm(frame: &mut Frame, area: Rect, title: &str, message: &str) {
     let popup = centered_rect(50, 30, area);
@@ -85,6 +87,117 @@ pub fn render_error(frame: &mut Frame, area: Rect, message: &str) {
             .border_style(Style::default().fg(Color::Red))
             .title(" Error "),
     );
+
+    frame.render_widget(content, popup);
+}
+
+pub fn render_ticket_info(frame: &mut Frame, area: Rect, ticket: &Ticket) {
+    let popup = centered_rect(60, 70, area);
+    frame.render_widget(Clear, popup);
+
+    let label_style = Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    let value_style = Style::default().fg(Color::White);
+    let dim_style = Style::default().fg(Color::DarkGray);
+
+    let state_color = match ticket.state.as_str() {
+        "open" => Color::Green,
+        "closed" => Color::Red,
+        _ => Color::Yellow,
+    };
+
+    let body_text = if ticket.body.is_empty() {
+        "(no description)".to_string()
+    } else if ticket.body.len() > 500 {
+        format!("{}...", &ticket.body[..500])
+    } else {
+        ticket.body.clone()
+    };
+
+    let assignee_text = ticket.assignee.as_deref().unwrap_or("unassigned");
+
+    let labels_text = if ticket.labels.is_empty() {
+        "none".to_string()
+    } else {
+        ticket.labels.clone()
+    };
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  State:     ", label_style),
+            Span::styled(
+                format!("[{}]", ticket.state),
+                Style::default()
+                    .fg(state_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Source:    ", label_style),
+            Span::styled(
+                format!("#{} ({})", ticket.source_id, ticket.source_type),
+                value_style,
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Assignee:  ", label_style),
+            Span::styled(assignee_text, value_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  Labels:    ", label_style),
+            Span::styled(&labels_text, value_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  URL:       ", label_style),
+            Span::styled(&ticket.url, Style::default().fg(Color::Blue)),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled("  Description:", label_style)),
+    ];
+
+    // Add body lines with word wrapping (indented)
+    for body_line in body_text.lines() {
+        lines.push(Line::from(Span::styled(
+            format!("  {body_line}"),
+            dim_style,
+        )));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(
+            "  o",
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" = open in browser    ", dim_style),
+        Span::styled(
+            "Esc",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" = close", dim_style),
+    ]));
+
+    let title = format!(" #{} {} ", ticket.source_id, ticket.title);
+    let title_display = if title.len() > (popup.width as usize).saturating_sub(2) {
+        format!("{}...", &title[..popup.width as usize - 5])
+    } else {
+        title
+    };
+
+    let content = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan))
+                .title(title_display),
+        )
+        .wrap(Wrap { trim: false });
 
     frame.render_widget(content, popup);
 }


### PR DESCRIPTION
## Summary
- Pressing Enter on a ticket in any view (Dashboard, Repo Detail, Tickets) now shows an info popup modal
- Modal displays: title, state, source ID, assignee, labels, URL, and description (truncated to 500 chars)
- Press `o` to open the ticket URL in the browser, `Esc` or `q` to dismiss

## Changes
- **state.rs** — Added `Modal::TicketInfo { ticket: Box<Ticket> }` variant
- **action.rs** — Added `Action::OpenTicketUrl` for the `o` key in the modal
- **input.rs** — Key handling for TicketInfo modal (`o` opens URL, `Esc`/`q` closes)
- **app.rs** — Updated `select()` to show ticket info from Dashboard tickets, Repo Detail tickets, and Tickets view; added `handle_open_ticket_url()` using `open` command
- **ui/modal.rs** — Added `render_ticket_info()` with styled fields and keybinding hints
- **ui/mod.rs** — Dispatches new `TicketInfo` modal variant to renderer

Closes #14

## Test plan
- [x] Navigate to Dashboard tickets panel, press Enter on a ticket → modal appears with correct details
- [x] Navigate to Repo Detail tickets panel, press Enter → modal appears
- [x] Navigate to full-screen Tickets view, press Enter → modal appears
- [x] Press `o` in the modal → ticket URL opens in browser
- [x] Press `Esc` or `q` → modal dismisses
- [x] Verify long descriptions are truncated at 500 chars with `...`
- [x] Verify modal title truncates gracefully on narrow terminals

🤖 Generated with [Claude Code](https://claude.com/claude-code)