### PR TITLE
Add shared Claude Code permissions for project workflow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo test)",
+      "Bash(cargo test *)",
+      "Bash(cargo build)",
+      "Bash(cargo build *)",
+      "Bash(cargo clippy *)",
+      "Bash(cargo fmt *)",
+      "Bash(cargo run *)",
+      "Bash(git status)",
+      "Bash(git status *)",
+      "Bash(git log *)",
+      "Bash(git diff *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(git branch *)",
+      "Bash(git worktree *)",
+      "Bash(gh issue *)",
+      "Bash(gh pr *)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with pre-approved permissions for common project commands
- Covers cargo (build, test, clippy, fmt, run), git (status, log, diff, add, commit, push, branch, worktree), and gh (issue, pr)
- Shared via git so all contributors get the same workflow without manual permission setup

## Test plan
- [x] Start a new Claude Code session in the repo
- [x] Verify `cargo test`, `git status`, `gh issue list` run without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)