### PR TITLE
Simplify Claude Code permissions and add worktree directory trust

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,26 +1,12 @@
 {
+  "additionalDirectories": [
+      "~/.conductor/workspaces/conductor-ai"
+  ],
   "permissions": {
     "allow": [
-      "Bash(cargo test)",
-      "Bash(cargo test *)",
-      "Bash(cargo build)",
-      "Bash(cargo build *)",
-      "Bash(cargo clippy *)",
-      "Bash(cargo fmt)",
-      "Bash(cargo fmt *)",
-      "Bash(cargo run *)",
-      "Bash(git status)",
-      "Bash(git status *)",
-      "Bash(git log *)",
-      "Bash(git diff *)",
-      "Bash(git add *)",
-      "Bash(git commit *)",
-      "Bash(git push *)",
-      "Bash(git branch *)",
-      "Bash(git worktree *)",
-      "Bash(gh issue *)",
-      "Bash(gh pr)",
-      "Bash(gh pr *)"
+      "Bash(cargo *)",
+      "Bash(git *)",
+      "Bash(gh *)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Consolidate per-subcommand permission rules (`cargo test`, `git status *`, `gh pr *`, etc.) into wildcard patterns (`cargo *`, `git *`, `gh *`)
- Add `~/.conductor/workspaces/conductor-ai` as a trusted `additionalDirectories` entry so worktree operations (e.g. `git -C <worktree-path> status`) don't require approval

## Test plan
- [x] Verify `git -C <worktree-path> status` no longer prompts for approval
- [x] Verify `cargo build`, `gh pr list`, etc. still auto-approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)