### PR TITLE
Add 'o' keybinding to open ticket from Worktree Detail

### DIFF
--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -88,6 +88,7 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
         KeyCode::Char('S') => Action::StartSession,
         KeyCode::Char('l') => Action::LinkTicket,
         KeyCode::Char('w') => Action::StartWork,
+        KeyCode::Char('o') => Action::OpenTicketUrl,
 
         // Direct view navigation
         KeyCode::Char('t') => Action::GoToTickets,

--- a/conductor-tui/src/ui/common.rs
+++ b/conductor-tui/src/ui/common.rs
@@ -57,7 +57,9 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, state: &AppState) {
                 "Tab:panel  j/k:nav  Enter:select  c:create  s:sync  ?:help  q:quit".to_string()
             }
             View::RepoDetail => "j/k:nav  Enter:select  c:create  Esc:back  ?:help".to_string(),
-            View::WorktreeDetail => "p:push  P:PR  l:link  d:delete  Esc:back  ?:help".to_string(),
+            View::WorktreeDetail => {
+                "o:open ticket  p:push  P:PR  l:link  d:delete  Esc:back  ?:help".to_string()
+            }
             View::Tickets => "j/k:nav  /:filter  Esc:back  ?:help".to_string(),
             View::Session => "s:end session  Esc:back  ?:help".to_string(),
         }

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -74,7 +74,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
         ]),
         Line::from(""),
         Line::from(Span::styled(
-            "Actions: w=work  p=push  P=PR  l=link ticket  d=delete  Esc=back",
+            "Actions: w=work  o=open ticket  p=push  P=PR  l=link ticket  d=delete  Esc=back",
             Style::default().fg(Color::DarkGray),
         )),
     ])


### PR DESCRIPTION
## Summary
- Adds `o` keybinding as a normal-mode action that opens the linked ticket URL in the browser from the Worktree Detail view
- Extends `handle_open_ticket_url` to resolve ticket URLs from either the TicketInfo modal (existing) or the WorktreeDetail view (new)
- Shows "No ticket linked to this worktree" status message when no ticket is linked

## Test plan
- [x] `cargo build --bin conductor-tui` compiles without errors
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace` passes
- [ ] Navigate to a worktree with a linked ticket, press `o` — browser opens ticket URL
- [x] Navigate to a worktree without a linked ticket, press `o` — status message shown

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)