### PR TITLE
Fix ticket state color in repo detail view

### DIFF
--- a/conductor-tui/src/ui/repo_detail.rs
+++ b/conductor-tui/src/ui/repo_detail.rs
@@ -115,6 +115,12 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
         .detail_tickets
         .iter()
         .map(|t| {
+            let state_color = match t.state.as_str() {
+                "open" => Color::Green,
+                "closed" => Color::Red,
+                "in_progress" => Color::Yellow,
+                _ => Color::White,
+            };
             ListItem::new(Line::from(vec![
                 Span::styled(
                     format!("#{} ", t.source_id),
@@ -122,7 +128,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                 ),
                 Span::raw(&t.title),
                 Span::raw("  "),
-                Span::styled(format!("[{}]", t.state), Style::default().fg(Color::Green)),
+                Span::styled(format!("[{}]", t.state), Style::default().fg(state_color)),
             ]))
         })
         .collect();


### PR DESCRIPTION
## Summary
- Fixed hardcoded green color for ticket state badges in the repo detail tickets frame
- Applied the same `state_color` match logic already used in `dashboard.rs`: open → green, closed → red, in_progress → yellow, other → white

Closes #27

## Test plan
- [x] Open the TUI and navigate to a repo detail view with tickets in different states
- [ ] Verify `[open]` shows in green, `[closed]` in red, `[in_progress]` in yellow

🤖 Generated with [Claude Code](https://claude.com/claude-code)