### PR TITLE
Show ticket status alongside worktrees in TUI views

### DIFF
--- a/conductor-tui/src/ui/dashboard.rs
+++ b/conductor-tui/src/ui/dashboard.rs
@@ -91,7 +91,7 @@ fn render_worktrees(frame: &mut Frame, area: Rect, state: &AppState) {
                 "abandoned" => Color::Red,
                 _ => Color::White,
             };
-            ListItem::new(Line::from(vec![
+            let mut spans = vec![
                 Span::styled(
                     format!("{repo_slug}/"),
                     Style::default().fg(Color::DarkGray),
@@ -102,7 +102,25 @@ fn render_worktrees(frame: &mut Frame, area: Rect, state: &AppState) {
                     format!("[{}]", wt.status),
                     Style::default().fg(status_color),
                 ),
-            ]))
+            ];
+            if let Some(ticket) = wt
+                .ticket_id
+                .as_ref()
+                .and_then(|tid| state.data.ticket_map.get(tid))
+            {
+                let ticket_state_color = match ticket.state.as_str() {
+                    "open" => Color::Green,
+                    "closed" => Color::DarkGray,
+                    "in_progress" => Color::Yellow,
+                    _ => Color::White,
+                };
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled(
+                    format!("#{} {}", ticket.source_id, ticket.state),
+                    Style::default().fg(ticket_state_color),
+                ));
+            }
+            ListItem::new(Line::from(spans))
         })
         .collect();
 

--- a/conductor-tui/src/ui/repo_detail.rs
+++ b/conductor-tui/src/ui/repo_detail.rs
@@ -72,7 +72,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                 "merged" => Color::Blue,
                 _ => Color::Red,
             };
-            ListItem::new(Line::from(vec![
+            let mut spans = vec![
                 Span::styled(&wt.slug, Style::default().add_modifier(Modifier::BOLD)),
                 Span::raw(format!("  {}", wt.branch)),
                 Span::raw("  "),
@@ -80,7 +80,25 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                     format!("[{}]", wt.status),
                     Style::default().fg(status_color),
                 ),
-            ]))
+            ];
+            if let Some(ticket) = wt
+                .ticket_id
+                .as_ref()
+                .and_then(|tid| state.data.ticket_map.get(tid))
+            {
+                let ticket_state_color = match ticket.state.as_str() {
+                    "open" => Color::Green,
+                    "closed" => Color::DarkGray,
+                    "in_progress" => Color::Yellow,
+                    _ => Color::White,
+                };
+                spans.push(Span::raw("  "));
+                spans.push(Span::styled(
+                    format!("#{} {}", ticket.source_id, ticket.state),
+                    Style::default().fg(ticket_state_color),
+                ));
+            }
+            ListItem::new(Line::from(spans))
         })
         .collect();
 

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -29,12 +29,32 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
         .map(|s| s.as_str())
         .unwrap_or("?");
 
-    let ticket_info = wt
+    let ticket_line: Vec<Span> = if let Some(ticket) = wt
         .ticket_id
         .as_ref()
         .and_then(|tid| state.data.ticket_map.get(tid))
-        .map(|t| format!("#{} — {}", t.source_id, t.title))
-        .unwrap_or_else(|| "None (press l to link)".to_string());
+    {
+        let ticket_state_color = match ticket.state.as_str() {
+            "open" => Color::Green,
+            "closed" => Color::DarkGray,
+            "in_progress" => Color::Yellow,
+            _ => Color::White,
+        };
+        vec![
+            Span::styled("Ticket: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(format!("#{} — {}", ticket.source_id, ticket.title)),
+            Span::raw("  "),
+            Span::styled(
+                format!("[{}]", ticket.state),
+                Style::default().fg(ticket_state_color),
+            ),
+        ]
+    } else {
+        vec![
+            Span::styled("Ticket: ", Style::default().fg(Color::DarkGray)),
+            Span::raw("None (press l to link)"),
+        ]
+    };
 
     let status_color = match wt.status.as_str() {
         "active" => Color::Green,
@@ -68,10 +88,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
             Span::raw(&wt.created_at),
         ]),
         Line::from(""),
-        Line::from(vec![
-            Span::styled("Ticket: ", Style::default().fg(Color::DarkGray)),
-            Span::raw(ticket_info),
-        ]),
+        Line::from(ticket_line),
         Line::from(""),
         Line::from(Span::styled(
             "Actions: w=work  o=open ticket  p=push  P=PR  l=link ticket  d=delete  Esc=back",


### PR DESCRIPTION
## Summary
- Display color-coded ticket state badge (`open`/`in_progress`/`closed`) next to worktrees in all three TUI views: dashboard, repo detail, and worktree detail
- Uses existing `ticket_map` data — no new queries or data fetching needed
- Colors: green for open, yellow for in_progress, dark gray for closed

## Test plan
- [x] Open TUI and verify dashboard worktree list shows `#<id> <state>` after `[status]` for linked worktrees
- [x] Navigate to repo detail and verify same badge appears on scoped worktrees
- [x] Open worktree detail and verify ticket line shows `[state]` badge with correct color
- [ ] Verify worktrees without linked tickets display unchanged

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)