### PR TITLE
Add per-repo issue source configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "anyhow",
  "clap",
  "conductor-core",
+ "serde_json",
 ]
 
 [[package]]
@@ -241,6 +242,7 @@ dependencies = [
  "crossterm",
  "ratatui",
  "rusqlite",
+ "serde_json",
 ]
 
 [[package]]

--- a/conductor-cli/Cargo.toml
+++ b/conductor-cli/Cargo.toml
@@ -14,3 +14,4 @@ path = "src/main.rs"
 conductor-core = { path = "../conductor-core" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
+serde_json = "1"

--- a/conductor-core/src/error.rs
+++ b/conductor-core/src/error.rs
@@ -28,6 +28,12 @@ pub enum ConductorError {
 
     #[error("ticket sync error: {0}")]
     TicketSync(String),
+
+    #[error("issue source already exists for repo '{repo_slug}' with type '{source_type}'")]
+    IssueSourceAlreadyExists {
+        repo_slug: String,
+        source_type: String,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, ConductorError>;

--- a/conductor-core/src/issue_source.rs
+++ b/conductor-core/src/issue_source.rs
@@ -1,0 +1,253 @@
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{ConductorError, Result};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueSource {
+    pub id: String,
+    pub repo_id: String,
+    pub source_type: String,
+    pub config_json: String,
+}
+
+/// Configuration for a GitHub issue source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubConfig {
+    pub owner: String,
+    pub repo: String,
+}
+
+pub struct IssueSourceManager<'a> {
+    conn: &'a Connection,
+}
+
+impl<'a> IssueSourceManager<'a> {
+    pub fn new(conn: &'a Connection) -> Self {
+        Self { conn }
+    }
+
+    /// Add an issue source for a repo. Rejects duplicates (same repo + source_type).
+    pub fn add(
+        &self,
+        repo_id: &str,
+        source_type: &str,
+        config_json: &str,
+        repo_slug: &str,
+    ) -> Result<IssueSource> {
+        // Check for existing source of same type for this repo
+        let exists: bool = self.conn.query_row(
+            "SELECT COUNT(*) > 0 FROM repo_issue_sources WHERE repo_id = ?1 AND source_type = ?2",
+            params![repo_id, source_type],
+            |row| row.get(0),
+        )?;
+
+        if exists {
+            return Err(ConductorError::IssueSourceAlreadyExists {
+                repo_slug: repo_slug.to_string(),
+                source_type: source_type.to_string(),
+            });
+        }
+
+        let id = ulid::Ulid::new().to_string();
+        self.conn.execute(
+            "INSERT INTO repo_issue_sources (id, repo_id, source_type, config_json) VALUES (?1, ?2, ?3, ?4)",
+            params![id, repo_id, source_type, config_json],
+        )?;
+
+        Ok(IssueSource {
+            id,
+            repo_id: repo_id.to_string(),
+            source_type: source_type.to_string(),
+            config_json: config_json.to_string(),
+        })
+    }
+
+    /// List all issue sources for a repo.
+    pub fn list(&self, repo_id: &str) -> Result<Vec<IssueSource>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo_id, source_type, config_json FROM repo_issue_sources WHERE repo_id = ?1",
+        )?;
+
+        let rows = stmt.query_map(params![repo_id], |row| {
+            Ok(IssueSource {
+                id: row.get(0)?,
+                repo_id: row.get(1)?,
+                source_type: row.get(2)?,
+                config_json: row.get(3)?,
+            })
+        })?;
+
+        let sources = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(sources)
+    }
+
+    /// Remove an issue source by ID.
+    pub fn remove(&self, id: &str) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM repo_issue_sources WHERE id = ?1", params![id])?;
+        Ok(())
+    }
+
+    /// Remove an issue source by repo_id and source_type.
+    pub fn remove_by_type(&self, repo_id: &str, source_type: &str) -> Result<bool> {
+        let count = self.conn.execute(
+            "DELETE FROM repo_issue_sources WHERE repo_id = ?1 AND source_type = ?2",
+            params![repo_id, source_type],
+        )?;
+        Ok(count > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE repos (
+                id TEXT PRIMARY KEY,
+                slug TEXT NOT NULL UNIQUE,
+                local_path TEXT NOT NULL,
+                remote_url TEXT NOT NULL,
+                default_branch TEXT NOT NULL DEFAULT 'main',
+                workspace_dir TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE repo_issue_sources (
+                id TEXT PRIMARY KEY,
+                repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+                source_type TEXT NOT NULL CHECK (source_type IN ('github', 'jira')),
+                config_json TEXT NOT NULL
+            );
+            INSERT INTO repos (id, slug, local_path, remote_url, workspace_dir, created_at)
+            VALUES ('repo1', 'test-repo', '/tmp/repo', 'https://github.com/test/repo', '/tmp/ws', '2024-01-01T00:00:00Z');",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_add_and_list_source() {
+        let conn = setup_db();
+        let mgr = IssueSourceManager::new(&conn);
+
+        let source = mgr
+            .add(
+                "repo1",
+                "github",
+                r#"{"owner":"test","repo":"repo"}"#,
+                "test-repo",
+            )
+            .unwrap();
+
+        assert_eq!(source.repo_id, "repo1");
+        assert_eq!(source.source_type, "github");
+
+        let sources = mgr.list("repo1").unwrap();
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].source_type, "github");
+    }
+
+    #[test]
+    fn test_reject_duplicate_source_type() {
+        let conn = setup_db();
+        let mgr = IssueSourceManager::new(&conn);
+
+        mgr.add(
+            "repo1",
+            "github",
+            r#"{"owner":"test","repo":"repo"}"#,
+            "test-repo",
+        )
+        .unwrap();
+
+        let result = mgr.add(
+            "repo1",
+            "github",
+            r#"{"owner":"other","repo":"other"}"#,
+            "test-repo",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_remove_source() {
+        let conn = setup_db();
+        let mgr = IssueSourceManager::new(&conn);
+
+        let source = mgr
+            .add(
+                "repo1",
+                "github",
+                r#"{"owner":"test","repo":"repo"}"#,
+                "test-repo",
+            )
+            .unwrap();
+
+        mgr.remove(&source.id).unwrap();
+
+        let sources = mgr.list("repo1").unwrap();
+        assert!(sources.is_empty());
+    }
+
+    #[test]
+    fn test_remove_by_type() {
+        let conn = setup_db();
+        let mgr = IssueSourceManager::new(&conn);
+
+        mgr.add(
+            "repo1",
+            "github",
+            r#"{"owner":"test","repo":"repo"}"#,
+            "test-repo",
+        )
+        .unwrap();
+
+        let removed = mgr.remove_by_type("repo1", "github").unwrap();
+        assert!(removed);
+
+        let sources = mgr.list("repo1").unwrap();
+        assert!(sources.is_empty());
+
+        // Removing again returns false
+        let removed = mgr.remove_by_type("repo1", "github").unwrap();
+        assert!(!removed);
+    }
+
+    #[test]
+    fn test_list_empty() {
+        let conn = setup_db();
+        let mgr = IssueSourceManager::new(&conn);
+
+        let sources = mgr.list("repo1").unwrap();
+        assert!(sources.is_empty());
+    }
+
+    #[test]
+    fn test_different_source_types_allowed() {
+        let conn = setup_db();
+        let mgr = IssueSourceManager::new(&conn);
+
+        mgr.add(
+            "repo1",
+            "github",
+            r#"{"owner":"test","repo":"repo"}"#,
+            "test-repo",
+        )
+        .unwrap();
+
+        mgr.add(
+            "repo1",
+            "jira",
+            r#"{"project":"TEST","url":"https://jira.example.com"}"#,
+            "test-repo",
+        )
+        .unwrap();
+
+        let sources = mgr.list("repo1").unwrap();
+        assert_eq!(sources.len(), 2);
+    }
+}

--- a/conductor-core/src/lib.rs
+++ b/conductor-core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod db;
 pub mod error;
 pub mod github;
+pub mod issue_source;
 pub mod repo;
 pub mod session;
 pub mod tickets;

--- a/conductor-tui/Cargo.toml
+++ b/conductor-tui/Cargo.toml
@@ -17,3 +17,4 @@ crossterm = "0.28"
 anyhow = "1"
 chrono = "0.4"
 rusqlite = { version = "0.32", features = ["bundled"] }
+serde_json = "1"

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use conductor_core::config::{db_path, load_config};
 use conductor_core::db::open_database;
 use conductor_core::github;
+use conductor_core::issue_source::{GitHubConfig, IssueSourceManager};
 use conductor_core::repo::RepoManager;
 use conductor_core::session::SessionTracker;
 use conductor_core::tickets::TicketSyncer;
@@ -72,35 +73,76 @@ fn sync_all_tickets(tx: &Sender<Event>) {
     let Ok(repos) = repo_mgr.list() else { return };
 
     let syncer = TicketSyncer::new(&conn);
+    let source_mgr = IssueSourceManager::new(&conn);
+
     for repo in repos {
-        if let Some((owner, name)) = github::parse_github_remote(&repo.remote_url) {
-            let action = match github::sync_github_issues(&owner, &name) {
-                Ok(tickets) => {
-                    let synced_ids: Vec<&str> =
-                        tickets.iter().map(|t| t.source_id.as_str()).collect();
-                    match syncer.upsert_tickets(&repo.id, &tickets) {
-                        Ok(count) => {
-                            let _ = syncer.close_missing_tickets(&repo.id, "github", &synced_ids);
-                            Action::TicketSyncComplete {
+        let sources = source_mgr.list(&repo.id).unwrap_or_default();
+
+        if sources.is_empty() {
+            // Backward compat: auto-detect GitHub from remote_url
+            if let Some((owner, name)) = github::parse_github_remote(&repo.remote_url) {
+                let action = sync_github_repo(&syncer, &repo.id, &repo.slug, &owner, &name);
+                if tx.send(Event::Background(action)).is_err() {
+                    return;
+                }
+            }
+        } else {
+            for source in sources {
+                match source.source_type.as_str() {
+                    "github" => {
+                        let action = match serde_json::from_str::<GitHubConfig>(&source.config_json)
+                        {
+                            Ok(cfg) => sync_github_repo(
+                                &syncer, &repo.id, &repo.slug, &cfg.owner, &cfg.repo,
+                            ),
+                            Err(e) => Action::TicketSyncFailed {
                                 repo_slug: repo.slug.clone(),
-                                count,
-                            }
+                                error: format!("invalid github config: {e}"),
+                            },
+                        };
+                        if tx.send(Event::Background(action)).is_err() {
+                            return;
                         }
-                        Err(e) => Action::TicketSyncFailed {
-                            repo_slug: repo.slug.clone(),
-                            error: e.to_string(),
-                        },
+                    }
+                    "jira" => {
+                        // Jira sync not yet implemented — skip silently in TUI
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+/// Sync GitHub issues for a single repo, returning the appropriate Action.
+fn sync_github_repo(
+    syncer: &TicketSyncer,
+    repo_id: &str,
+    repo_slug: &str,
+    owner: &str,
+    name: &str,
+) -> Action {
+    match github::sync_github_issues(owner, name) {
+        Ok(tickets) => {
+            let synced_ids: Vec<&str> = tickets.iter().map(|t| t.source_id.as_str()).collect();
+            match syncer.upsert_tickets(repo_id, &tickets) {
+                Ok(count) => {
+                    let _ = syncer.close_missing_tickets(repo_id, "github", &synced_ids);
+                    Action::TicketSyncComplete {
+                        repo_slug: repo_slug.to_string(),
+                        count,
                     }
                 }
                 Err(e) => Action::TicketSyncFailed {
-                    repo_slug: repo.slug.clone(),
+                    repo_slug: repo_slug.to_string(),
                     error: e.to_string(),
                 },
-            };
-            if tx.send(Event::Background(action)).is_err() {
-                return;
             }
         }
+        Err(e) => Action::TicketSyncFailed {
+            repo_slug: repo_slug.to_string(),
+            error: e.to_string(),
+        },
     }
 }
 


### PR DESCRIPTION
## Summary
- Wires up the existing `repo_issue_sources` DB table with a new `IssueSourceManager` and `conductor repo sources {add,list,remove}` CLI commands
- Refactors `tickets sync` (CLI + TUI) to use configured sources first, falling back to auto-detect GitHub from remote URL for backward compatibility
- GitHub sources auto-infer `owner/repo` from the remote URL when `--config` is omitted; Jira sources store config but print "not yet implemented" on sync

## Test plan
- [x] `cargo build` compiles without errors
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all 14 tests pass (6 new issue_source tests)
- [x] `cargo fmt --check` — formatted
- [x] `conductor repo sources list <slug>` — shows empty
- [x] `conductor repo sources add <slug> --type github` — auto-infers config
- [x] `conductor repo sources list <slug>` — shows github source
- [x] `conductor tickets sync <slug>` — uses configured source
- [x] `conductor repo sources remove <slug> --type github` — removes it
- [x] `conductor tickets sync <slug>` — falls back to auto-detect

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)