### PR TITLE
Fix Claude Code permission syntax

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,9 +4,9 @@
   ],
   "permissions": {
     "allow": [
-      "Bash(cargo *)",
-      "Bash(git *)",
-      "Bash(gh *)"
+      "Bash(cargo:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Update `.claude/settings.json` permission patterns from space-delimited (`Bash(cargo *)`) to colon-delimited (`Bash(cargo:*)`) syntax

## Test plan
- [x] Verified `git` and `gh` commands execute successfully with updated permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)