### PR TITLE
Extend 'w' command with configurable work targets

### DIFF
--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -31,6 +31,12 @@ pub enum Action {
     StartSession,
     EndSession,
     StartWork,
+    SelectWorkTarget(usize),
+    ManageWorkTargets,
+    WorkTargetMoveUp,
+    WorkTargetMoveDown,
+    WorkTargetAdd,
+    WorkTargetDelete,
 
     // Filter
     EnterFilter,

--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -61,6 +61,35 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
                 _ => Action::None,
             };
         }
+        Modal::WorkTargetPicker { targets, .. } => {
+            return match key.code {
+                KeyCode::Esc => Action::DismissModal,
+                KeyCode::Up | KeyCode::Char('k') => Action::MoveUp,
+                KeyCode::Down | KeyCode::Char('j') => Action::MoveDown,
+                KeyCode::Enter => Action::SelectWorkTarget(usize::MAX), // sentinel: use selected
+                KeyCode::Char(c) if c.is_ascii_digit() => {
+                    let n = c.to_digit(10).unwrap() as usize;
+                    if n >= 1 && n <= targets.len() {
+                        Action::SelectWorkTarget(n - 1)
+                    } else {
+                        Action::None
+                    }
+                }
+                _ => Action::None,
+            };
+        }
+        Modal::WorkTargetManager { .. } => {
+            return match key.code {
+                KeyCode::Esc => Action::DismissModal,
+                KeyCode::Up | KeyCode::Char('k') => Action::MoveUp,
+                KeyCode::Down | KeyCode::Char('j') => Action::MoveDown,
+                KeyCode::Char('K') => Action::WorkTargetMoveUp,
+                KeyCode::Char('J') => Action::WorkTargetMoveDown,
+                KeyCode::Char('a') => Action::WorkTargetAdd,
+                KeyCode::Char('d') => Action::WorkTargetDelete,
+                _ => Action::None,
+            };
+        }
         Modal::None => {}
     }
 
@@ -100,6 +129,7 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
         KeyCode::Char('S') => Action::StartSession,
         KeyCode::Char('l') => Action::LinkTicket,
         KeyCode::Char('w') => Action::StartWork,
+        KeyCode::Char('W') => Action::ManageWorkTargets,
         KeyCode::Char('o') => Action::OpenTicketUrl,
 
         // Direct view navigation

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use conductor_core::config::WorkTarget;
 use conductor_core::repo::Repo;
 use conductor_core::session::Session;
 use conductor_core::tickets::Ticket;
@@ -81,6 +82,14 @@ pub enum Modal {
     TicketInfo {
         ticket: Box<Ticket>,
     },
+    WorkTargetPicker {
+        targets: Vec<WorkTarget>,
+        selected: usize,
+    },
+    WorkTargetManager {
+        targets: Vec<WorkTarget>,
+        selected: usize,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -88,6 +97,7 @@ pub enum ConfirmAction {
     DeleteWorktree { repo_slug: String, wt_slug: String },
     EndSession { session_id: String },
     RemoveRepo { repo_slug: String },
+    DeleteWorkTarget { index: usize },
 }
 
 #[derive(Debug, Clone)]
@@ -102,6 +112,7 @@ pub struct FormField {
 #[derive(Debug, Clone)]
 pub enum FormAction {
     AddRepo,
+    AddWorkTarget,
 }
 
 #[derive(Debug, Clone)]

--- a/conductor-tui/src/ui/help.rs
+++ b/conductor-tui/src/ui/help.rs
@@ -36,7 +36,8 @@ pub fn render(frame: &mut Frame, area: Rect) {
         help_line("s", "Sync tickets / End session"),
         help_line("S", "Start session"),
         help_line("l", "Link ticket to worktree"),
-        help_line("w", "Open editor at worktree"),
+        help_line("w", "Open work target at worktree"),
+        help_line("W", "Manage work targets"),
         help_line("/", "Filter/search"),
         Line::from(""),
         Line::from(Span::styled(

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -60,5 +60,11 @@ pub fn render(frame: &mut Frame, state: &AppState) {
         } => modal::render_form(frame, area, title, fields, *active_field),
         Modal::Error { message } => modal::render_error(frame, area, message),
         Modal::TicketInfo { ticket } => modal::render_ticket_info(frame, area, ticket),
+        Modal::WorkTargetPicker { targets, selected } => {
+            modal::render_work_target_picker(frame, area, targets, *selected)
+        }
+        Modal::WorkTargetManager { targets, selected } => {
+            modal::render_work_target_manager(frame, area, targets, *selected)
+        }
     }
 }

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -4,6 +4,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
 
+use conductor_core::config::WorkTarget;
 use conductor_core::tickets::Ticket;
 
 pub fn render_confirm(frame: &mut Frame, area: Rect, title: &str, message: &str) {
@@ -266,6 +267,150 @@ pub fn render_form(
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Cyan))
             .title(format!(" {title} ")),
+    );
+
+    frame.render_widget(content, popup);
+}
+
+pub fn render_work_target_picker(
+    frame: &mut Frame,
+    area: Rect,
+    targets: &[WorkTarget],
+    selected: usize,
+) {
+    let height = (targets.len() as u16 + 6).min(20);
+    let percent_y = ((height as f32 / area.height as f32) * 100.0) as u16;
+    let popup = centered_rect(50, percent_y.max(25), area);
+    frame.render_widget(Clear, popup);
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Select a work target:",
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(""),
+    ];
+
+    for (i, target) in targets.iter().enumerate() {
+        let is_selected = i == selected;
+        let prefix = if is_selected { "▸ " } else { "  " };
+        let number = format!("{}. ", i + 1);
+        let type_hint = format!(" ({})", target.target_type);
+
+        let style = if is_selected {
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {prefix}{number}"), style),
+            Span::styled(&target.name, style),
+            Span::styled(type_hint, Style::default().fg(Color::DarkGray)),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  1-9 select  Enter confirm  Esc cancel",
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    let content = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(" Work Targets "),
+    );
+
+    frame.render_widget(content, popup);
+}
+
+pub fn render_work_target_manager(
+    frame: &mut Frame,
+    area: Rect,
+    targets: &[WorkTarget],
+    selected: usize,
+) {
+    let popup = centered_rect(55, 60, area);
+    frame.render_widget(Clear, popup);
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Manage Work Targets",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+    ];
+
+    if targets.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  (no targets configured)",
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        for (i, target) in targets.iter().enumerate() {
+            let is_selected = i == selected;
+            let prefix = if is_selected { "▸ " } else { "  " };
+            let type_hint = format!(" [{}] cmd: {}", target.target_type, target.command);
+
+            let style = if is_selected {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+
+            lines.push(Line::from(vec![
+                Span::styled(format!("  {prefix}"), style),
+                Span::styled(&target.name, style),
+                Span::styled(type_hint, Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(
+            "  a",
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" add  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            "d",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" delete  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            "K/J",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" reorder  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            "Esc",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" close", Style::default().fg(Color::DarkGray)),
+    ]));
+
+    let content = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(" Work Target Manager "),
     );
 
     frame.render_widget(content, popup);


### PR DESCRIPTION
## Summary
- Replaces the single `editor` config field with a configurable list of **work targets** (name, command, type) in `config.toml`
- Pressing `w` on a worktree now shows a **picker modal** when multiple targets are configured, or opens directly for a single target
- Adds `W` keybinding to open a **work target manager** modal for adding, deleting, and reordering targets (persisted to config)
- Backward compatibility: migrates the old `editor` field into a work target automatically

## Test plan
- [x] Verify `w` opens the default VS Code target with a fresh config
- [x] Add multiple work targets via `W` manager, verify picker appears on `w`
- [x] Test number keys (1-9) and Enter for selecting targets in the picker
- [x] Test reordering with `K`/`J`, adding with `a`, deleting with `d` in the manager
- [x] Verify old `editor = "cursor"` in config.toml migrates correctly on load
- [x] Verify `cargo clippy -- -D warnings` and `cargo test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)