### PR TITLE
Show worktree status (merged/abandoned) after deletion

### DIFF
--- a/conductor-core/src/db/migrations/002_worktree_completed_at.sql
+++ b/conductor-core/src/db/migrations/002_worktree_completed_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE worktrees ADD COLUMN completed_at TEXT;

--- a/conductor-core/src/session.rs
+++ b/conductor-core/src/session.rs
@@ -96,7 +96,7 @@ impl<'a> SessionTracker<'a> {
 
     pub fn get_worktrees(&self, session_id: &str) -> Result<Vec<crate::worktree::Worktree>> {
         let mut stmt = self.conn.prepare(
-            "SELECT w.id, w.repo_id, w.slug, w.branch, w.path, w.ticket_id, w.status, w.created_at
+            "SELECT w.id, w.repo_id, w.slug, w.branch, w.path, w.ticket_id, w.status, w.created_at, w.completed_at
              FROM worktrees w
              JOIN session_worktrees sw ON sw.worktree_id = w.id
              WHERE sw.session_id = ?1
@@ -112,6 +112,7 @@ impl<'a> SessionTracker<'a> {
                 ticket_id: row.get(5)?,
                 status: row.get(6)?,
                 created_at: row.get(7)?,
+                completed_at: row.get(8)?,
             })
         })?;
         let worktrees = rows.collect::<std::result::Result<Vec<_>, _>>()?;

--- a/conductor-tui/src/ui/repo_detail.rs
+++ b/conductor-tui/src/ui/repo_detail.rs
@@ -67,14 +67,27 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
         .detail_worktrees
         .iter()
         .map(|wt| {
+            let is_active = wt.is_active();
             let status_color = match wt.status.as_str() {
                 "active" => Color::Green,
                 "merged" => Color::Blue,
                 _ => Color::Red,
             };
+            let text_style = if is_active {
+                Style::default()
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
             let mut spans = vec![
-                Span::styled(&wt.slug, Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(format!("  {}", wt.branch)),
+                Span::styled(
+                    &wt.slug,
+                    text_style.add_modifier(if is_active {
+                        Modifier::BOLD
+                    } else {
+                        Modifier::DIM
+                    }),
+                ),
+                Span::styled(format!("  {}", wt.branch), text_style),
                 Span::raw("  "),
                 Span::styled(
                     format!("[{}]", wt.status),

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -62,7 +62,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
         _ => Color::Red,
     };
 
-    let content = Paragraph::new(vec![
+    let mut lines = vec![
         Line::from(vec![
             Span::styled("Worktree: ", Style::default().fg(Color::DarkGray)),
             Span::styled(&wt.slug, Style::default().add_modifier(Modifier::BOLD)),
@@ -87,15 +87,30 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
             Span::styled("Created: ", Style::default().fg(Color::DarkGray)),
             Span::raw(&wt.created_at),
         ]),
-        Line::from(""),
-        Line::from(ticket_line),
-        Line::from(""),
-        Line::from(Span::styled(
-            "Actions: w=work  o=open ticket  p=push  P=PR  l=link ticket  d=delete  Esc=back",
-            Style::default().fg(Color::DarkGray),
-        )),
-    ])
-    .block(
+    ];
+
+    if let Some(ref completed) = wt.completed_at {
+        lines.push(Line::from(vec![
+            Span::styled("Completed: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(completed),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(ticket_line));
+    lines.push(Line::from(""));
+
+    let actions_text = if wt.is_active() {
+        "Actions: w=work  o=open ticket  p=push  P=PR  l=link ticket  d=delete  Esc=back"
+    } else {
+        "Actions: o=open ticket  Esc=back  (archived)"
+    };
+    lines.push(Line::from(Span::styled(
+        actions_text,
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    let content = Paragraph::new(lines).block(
         Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(Color::Cyan))


### PR DESCRIPTION
## Summary
- Convert worktree deletion to soft-delete: git artifacts removed, DB record preserved with `merged` or `abandoned` status based on `git branch --merged` check
- Add `completed_at` column via migration 002, `update_status()`, `purge()` methods, and slug reuse handling
- CLI: updated delete output, new `worktree purge` subcommand
- TUI: Dashboard shows `(N active, M done)`, completed worktrees dimmed with colored status badges, Worktree Detail shows completion timestamp and `(archived)` actions, all modify actions disabled on non-active worktrees

## Test plan
- [ ] `cargo test --workspace` — 25 tests pass
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Create a worktree, merge its branch, delete it → verify status is `merged`
- [ ] Create a worktree, delete without merging → verify status is `abandoned`
- [ ] Verify Dashboard repos panel shows `(N active, M done)` counts
- [ ] Verify completed worktrees appear dimmed in Dashboard and Repo Detail
- [ ] Verify Worktree Detail shows `Completed:` timestamp and `(archived)` actions
- [ ] Verify push/PR/work/link-ticket are blocked on archived worktrees
- [ ] `conductor worktree purge <repo>` removes completed records
- [ ] Creating a worktree with a previously-used slug succeeds (auto-purges old record)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)