### PR TITLE
Update worktree status to merged when linked ticket closes during sync

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -543,9 +543,15 @@ fn sync_jira(syncer: &TicketSyncer, repo_id: &str, repo_slug: &str, jql: &str, b
                     let closed = syncer
                         .close_missing_tickets(repo_id, "jira", &synced_ids)
                         .unwrap_or(0);
+                    let merged = syncer
+                        .mark_worktrees_for_closed_tickets(repo_id)
+                        .unwrap_or(0);
                     print!("  {} — synced {count} Jira issues", repo_slug);
                     if closed > 0 {
                         print!(", {closed} marked closed");
+                    }
+                    if merged > 0 {
+                        print!(", {merged} worktrees merged");
                     }
                     println!();
                 }
@@ -570,9 +576,15 @@ fn sync_github(syncer: &TicketSyncer, repo_id: &str, repo_slug: &str, owner: &st
                     let closed = syncer
                         .close_missing_tickets(repo_id, "github", &synced_ids)
                         .unwrap_or(0);
+                    let merged = syncer
+                        .mark_worktrees_for_closed_tickets(repo_id)
+                        .unwrap_or(0);
                     print!("  {} — synced {count} GitHub issues", repo_slug);
                     if closed > 0 {
                         print!(", {closed} marked closed");
+                    }
+                    if merged > 0 {
+                        print!(", {merged} worktrees merged");
                     }
                     println!();
                 }

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -140,6 +140,7 @@ fn sync_jira_repo(
             match syncer.upsert_tickets(repo_id, &tickets) {
                 Ok(count) => {
                     let _ = syncer.close_missing_tickets(repo_id, "jira", &synced_ids);
+                    let _ = syncer.mark_worktrees_for_closed_tickets(repo_id);
                     Action::TicketSyncComplete {
                         repo_slug: repo_slug.to_string(),
                         count,
@@ -172,6 +173,7 @@ fn sync_github_repo(
             match syncer.upsert_tickets(repo_id, &tickets) {
                 Ok(count) => {
                     let _ = syncer.close_missing_tickets(repo_id, "github", &synced_ids);
+                    let _ = syncer.mark_worktrees_for_closed_tickets(repo_id);
                     Action::TicketSyncComplete {
                         repo_slug: repo_slug.to_string(),
                         count,


### PR DESCRIPTION
## Summary
- Adds `mark_worktrees_for_closed_tickets()` to `TicketSyncer` that sets worktree status to `merged` when its linked ticket becomes `closed`
- Called after `close_missing_tickets` in both TUI background sync and CLI sync for GitHub and Jira
- CLI prints merged count (e.g., ", 1 worktrees merged") alongside closed ticket count

## Test plan
- [x] `cargo test -p conductor-core` — 30 tests pass (5 new: active→merged, abandoned→merged, skips unlinked, idempotent, repo-scoped)
- [x] `cargo clippy --workspace` — clean
- [x] Manual: run `conductor tickets sync` and verify worktrees linked to closed tickets show `[merged]`

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)