### PR TITLE
Filter soft-deleted worktrees from TUI display

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -303,7 +303,7 @@ fn main() -> Result<()> {
             }
             WorktreeCommands::List { repo } => {
                 let mgr = WorktreeManager::new(&conn, &config);
-                let worktrees = mgr.list(repo.as_deref())?;
+                let worktrees = mgr.list(repo.as_deref(), false)?;
                 if worktrees.is_empty() {
                     println!("No worktrees.");
                 } else {

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -243,7 +243,7 @@ impl App {
         let session_tracker = SessionTracker::new(&self.conn);
 
         self.state.data.repos = repo_mgr.list().unwrap_or_default();
-        self.state.data.worktrees = wt_mgr.list(None).unwrap_or_default();
+        self.state.data.worktrees = wt_mgr.list(None, true).unwrap_or_default();
         self.state.data.tickets = ticket_syncer.list(None).unwrap_or_default();
         self.state.data.current_session = session_tracker.current().unwrap_or(None);
         self.state.data.session_worktrees = if let Some(ref s) = self.state.data.current_session {

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -39,7 +39,7 @@ pub fn poll_data() -> Option<Action> {
     let session_tracker = SessionTracker::new(&conn);
 
     let repos = repo_mgr.list().ok()?;
-    let worktrees = wt_mgr.list(None).ok()?;
+    let worktrees = wt_mgr.list(None, true).ok()?;
     let tickets = ticket_syncer.list(None).ok()?;
     let session = session_tracker.current().ok()?;
     let session_worktrees = if let Some(ref s) = session {


### PR DESCRIPTION
## Summary
- Adds `active_only: bool` parameter to `WorktreeManager::list()` that appends `AND status = 'active'` to SQL queries when true
- TUI (dashboard + repo detail) passes `active_only: true`, hiding merged/abandoned worktrees from display
- CLI passes `active_only: false` to retain full listing for auditability

Closes #47

## Test plan
- [x] All 30 existing tests pass
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt --check` passes
- [x] Manual: soft-delete a worktree, verify it no longer appears in TUI
- [x] Manual: verify `conductor worktree list` still shows all statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)