### PR TITLE
Show aggregate agent cost/time/turns per ticket (#65)

### DIFF
--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -5,7 +5,19 @@ use conductor_core::worktree::Worktree;
 
 use std::collections::HashMap;
 
-use conductor_core::agent::AgentRun;
+use conductor_core::agent::{AgentRun, TicketAgentTotals};
+
+/// Payload for the DataRefreshed action (boxed to keep Action enum small).
+#[derive(Debug)]
+pub struct DataRefreshedPayload {
+    pub repos: Vec<Repo>,
+    pub worktrees: Vec<Worktree>,
+    pub tickets: Vec<Ticket>,
+    pub session: Option<Session>,
+    pub session_worktrees: Vec<Worktree>,
+    pub latest_agent_runs: HashMap<String, AgentRun>,
+    pub ticket_agent_totals: HashMap<String, TicketAgentTotals>,
+}
 
 /// Every user intent or background result flows through this enum.
 #[derive(Debug)]
@@ -79,14 +91,7 @@ pub enum Action {
     FormSubmit,
 
     // Background results
-    DataRefreshed {
-        repos: Vec<Repo>,
-        worktrees: Vec<Worktree>,
-        tickets: Vec<Ticket>,
-        session: Option<Session>,
-        session_worktrees: Vec<Worktree>,
-        latest_agent_runs: HashMap<String, AgentRun>,
-    },
+    DataRefreshed(Box<DataRefreshedPayload>),
     TicketSyncComplete {
         repo_slug: String,
         count: usize,

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -267,20 +267,14 @@ impl App {
             Action::PendingG => unreachable!(),
 
             // Background results
-            Action::DataRefreshed {
-                repos,
-                worktrees,
-                tickets,
-                session,
-                session_worktrees,
-                latest_agent_runs,
-            } => {
-                self.state.data.repos = repos;
-                self.state.data.worktrees = worktrees;
-                self.state.data.tickets = tickets;
-                self.state.data.current_session = session;
-                self.state.data.session_worktrees = session_worktrees;
-                self.state.data.latest_agent_runs = latest_agent_runs;
+            Action::DataRefreshed(payload) => {
+                self.state.data.repos = payload.repos;
+                self.state.data.worktrees = payload.worktrees;
+                self.state.data.tickets = payload.tickets;
+                self.state.data.current_session = payload.session;
+                self.state.data.session_worktrees = payload.session_worktrees;
+                self.state.data.latest_agent_runs = payload.latest_agent_runs;
+                self.state.data.ticket_agent_totals = payload.ticket_agent_totals;
                 self.state.data.rebuild_maps();
                 self.reload_agent_events();
                 self.clamp_indices();

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -12,7 +12,7 @@ use conductor_core::session::SessionTracker;
 use conductor_core::tickets::TicketSyncer;
 use conductor_core::worktree::WorktreeManager;
 
-use crate::action::Action;
+use crate::action::{Action, DataRefreshedPayload};
 use crate::event::BackgroundSender;
 
 /// Spawn the DB poller thread. Polls every `interval` and sends DataRefreshed events.
@@ -49,15 +49,17 @@ pub fn poll_data() -> Option<Action> {
         Vec::new()
     };
     let latest_agent_runs = agent_mgr.latest_runs_by_worktree().unwrap_or_default();
+    let ticket_agent_totals = agent_mgr.totals_by_ticket_all().unwrap_or_default();
 
-    Some(Action::DataRefreshed {
+    Some(Action::DataRefreshed(Box::new(DataRefreshedPayload {
         repos,
         worktrees,
         tickets,
         session,
         session_worktrees,
         latest_agent_runs,
-    })
+        ticket_agent_totals,
+    })))
 }
 
 /// Spawn the ticket sync timer. Syncs all repos every `interval`.

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use conductor_core::agent::{AgentEvent, AgentRun};
+use conductor_core::agent::{AgentEvent, AgentRun, TicketAgentTotals};
 use conductor_core::config::WorkTarget;
 use conductor_core::repo::Repo;
 use conductor_core::session::Session;
@@ -177,6 +177,8 @@ pub struct DataCache {
     pub agent_events: Vec<AgentEvent>,
     /// Aggregate stats across all agent runs for the currently viewed worktree
     pub agent_totals: AgentTotals,
+    /// ticket_id -> aggregated agent stats across all linked worktrees
+    pub ticket_agent_totals: HashMap<String, TicketAgentTotals>,
 }
 
 /// Aggregated stats across all agent runs for a worktree.

--- a/conductor-tui/src/ui/dashboard.rs
+++ b/conductor-tui/src/ui/dashboard.rs
@@ -211,7 +211,7 @@ fn render_tickets(frame: &mut Frame, area: Rect, state: &AppState) {
                 "in_progress" => Color::Yellow,
                 _ => Color::White,
             };
-            ListItem::new(Line::from(vec![
+            let mut spans = vec![
                 Span::styled(
                     format!("{repo_slug} "),
                     Style::default().fg(Color::DarkGray),
@@ -223,7 +223,14 @@ fn render_tickets(frame: &mut Frame, area: Rect, state: &AppState) {
                 Span::raw(&t.title),
                 Span::raw("  "),
                 Span::styled(format!("[{}]", t.state), Style::default().fg(state_color)),
-            ]))
+            ];
+            if let Some(totals) = state.data.ticket_agent_totals.get(&t.id) {
+                spans.push(Span::styled(
+                    format!("  ${:.2} {}t", totals.total_cost, totals.total_turns),
+                    Style::default().fg(Color::Magenta),
+                ));
+            }
+            ListItem::new(Line::from(spans))
         })
         .collect();
 

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -59,7 +59,10 @@ pub fn render(frame: &mut Frame, state: &AppState) {
             ..
         } => modal::render_form(frame, area, title, fields, *active_field),
         Modal::Error { message } => modal::render_error(frame, area, message),
-        Modal::TicketInfo { ticket } => modal::render_ticket_info(frame, area, ticket),
+        Modal::TicketInfo { ticket } => {
+            let agent_totals = state.data.ticket_agent_totals.get(&ticket.id);
+            modal::render_ticket_info(frame, area, ticket, agent_totals);
+        }
         Modal::WorkTargetPicker { targets, selected } => {
             modal::render_work_target_picker(frame, area, targets, *selected)
         }

--- a/conductor-tui/src/ui/tickets.rs
+++ b/conductor-tui/src/ui/tickets.rs
@@ -46,7 +46,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
 
             let assignee = t.assignee.as_deref().unwrap_or("-");
 
-            ListItem::new(Line::from(vec![
+            let mut spans = vec![
                 Span::styled(
                     format!("{repo_slug:<12} "),
                     Style::default().fg(Color::DarkGray),
@@ -60,8 +60,24 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                     format!("{:<12} ", t.state),
                     Style::default().fg(state_color),
                 ),
-                Span::styled(assignee, Style::default().fg(Color::DarkGray)),
-            ]))
+                Span::styled(
+                    format!("{:<12}", assignee),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ];
+            if let Some(totals) = state.data.ticket_agent_totals.get(&t.id) {
+                let dur_secs = totals.total_duration_ms as f64 / 1000.0;
+                let mins = (dur_secs / 60.0) as i64;
+                let secs = (dur_secs % 60.0) as i64;
+                spans.push(Span::styled(
+                    format!(
+                        " ${:.2}  {}t  {}m{:02}s",
+                        totals.total_cost, totals.total_turns, mins, secs
+                    ),
+                    Style::default().fg(Color::Magenta),
+                ));
+            }
+            ListItem::new(Line::from(spans))
         })
         .collect();
 


### PR DESCRIPTION
## Summary
- Add `TicketAgentTotals` struct and `totals_by_ticket_all()` SQL aggregation query to `conductor-core` that joins `agent_runs → worktrees → tickets` to compute per-ticket totals (cost, turns, duration, run count)
- Surface ticket-level agent stats in TUI dashboard, tickets view, and ticket info modal
- Add `conductor tickets stats` CLI subcommand with formatted table output

## Test plan
- [x] `cargo test -p conductor-core` — 2 new tests for `totals_by_ticket_all()` (populated + empty cases)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build` — full workspace builds

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)