### PR TITLE
Show linked worktree status on tickets in TUI (#69)

### DIFF
--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -179,6 +179,8 @@ pub struct DataCache {
     pub agent_totals: AgentTotals,
     /// ticket_id -> aggregated agent stats across all linked worktrees
     pub ticket_agent_totals: HashMap<String, TicketAgentTotals>,
+    /// ticket_id -> linked worktrees (most recently created first)
+    pub ticket_worktrees: HashMap<String, Vec<Worktree>>,
 }
 
 /// Aggregated stats across all agent runs for a worktree.
@@ -206,11 +208,18 @@ impl DataCache {
         }
 
         self.repo_worktree_count.clear();
+        self.ticket_worktrees.clear();
         for wt in &self.worktrees {
             *self
                 .repo_worktree_count
                 .entry(wt.repo_id.clone())
                 .or_insert(0) += 1;
+            if let Some(ref tid) = wt.ticket_id {
+                self.ticket_worktrees
+                    .entry(tid.clone())
+                    .or_default()
+                    .push(wt.clone());
+            }
         }
     }
 }

--- a/conductor-tui/src/ui/dashboard.rs
+++ b/conductor-tui/src/ui/dashboard.rs
@@ -176,12 +176,10 @@ fn render_tickets(frame: &mut Frame, area: Rect, state: &AppState) {
                 Span::raw("  "),
                 Span::styled(format!("[{}]", t.state), Style::default().fg(state_color)),
             ];
-            if let Some(totals) = state.data.ticket_agent_totals.get(&t.id) {
-                spans.push(Span::styled(
-                    format!("  ${:.2} {}t", totals.total_cost, totals.total_turns),
-                    Style::default().fg(Color::Magenta),
-                ));
-            }
+            spans.extend(super::common::ticket_worktree_spans(state, &t.id, "  "));
+            spans.extend(super::common::ticket_agent_total_spans(
+                state, &t.id, "  ", false,
+            ));
             ListItem::new(Line::from(spans))
         })
         .collect();

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -61,7 +61,8 @@ pub fn render(frame: &mut Frame, state: &AppState) {
         Modal::Error { message } => modal::render_error(frame, area, message),
         Modal::TicketInfo { ticket } => {
             let agent_totals = state.data.ticket_agent_totals.get(&ticket.id);
-            modal::render_ticket_info(frame, area, ticket, agent_totals);
+            let worktrees = state.data.ticket_worktrees.get(&ticket.id);
+            modal::render_ticket_info(frame, area, ticket, agent_totals, worktrees);
         }
         Modal::WorkTargetPicker { targets, selected } => {
             modal::render_work_target_picker(frame, area, targets, *selected)

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -7,6 +7,7 @@ use ratatui::Frame;
 use conductor_core::agent::TicketAgentTotals;
 use conductor_core::config::WorkTarget;
 use conductor_core::tickets::Ticket;
+use conductor_core::worktree::Worktree;
 
 pub fn render_confirm(frame: &mut Frame, area: Rect, title: &str, message: &str) {
     let popup = centered_rect(50, 30, area);
@@ -98,6 +99,7 @@ pub fn render_ticket_info(
     area: Rect,
     ticket: &Ticket,
     agent_totals: Option<&TicketAgentTotals>,
+    worktrees: Option<&Vec<Worktree>>,
 ) {
     let popup = centered_rect(60, 70, area);
     frame.render_widget(Clear, popup);
@@ -191,6 +193,26 @@ pub fn render_ticket_info(
             ),
         ]));
         lines.push(Line::from(""));
+    }
+
+    if let Some(wts) = worktrees {
+        if !wts.is_empty() {
+            lines.push(Line::from(Span::styled("  Worktrees:", label_style)));
+            for wt in wts {
+                let (indicator, color) = if wt.is_active() {
+                    ("●", Color::Green)
+                } else {
+                    ("○", Color::DarkGray)
+                };
+                lines.push(Line::from(vec![
+                    Span::styled(format!("    {indicator} "), Style::default().fg(color)),
+                    Span::styled(&wt.slug, value_style),
+                    Span::styled(format!("  [{}]", wt.status), Style::default().fg(color)),
+                    Span::styled(format!("  {}", wt.branch), dim_style),
+                ]));
+            }
+            lines.push(Line::from(""));
+        }
     }
 
     lines.push(Line::from(Span::styled("  Description:", label_style)));

--- a/conductor-tui/src/ui/repo_detail.rs
+++ b/conductor-tui/src/ui/repo_detail.rs
@@ -106,7 +106,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                 "in_progress" => Color::Yellow,
                 _ => Color::White,
             };
-            ListItem::new(Line::from(vec![
+            let mut spans = vec![
                 Span::styled(
                     format!("#{} ", t.source_id),
                     Style::default().fg(Color::Yellow),
@@ -114,7 +114,12 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                 Span::raw(&t.title),
                 Span::raw("  "),
                 Span::styled(format!("[{}]", t.state), Style::default().fg(state_color)),
-            ]))
+            ];
+            spans.extend(super::common::ticket_worktree_spans(state, &t.id, "  "));
+            spans.extend(super::common::ticket_agent_total_spans(
+                state, &t.id, "  ", false,
+            ));
+            ListItem::new(Line::from(spans))
         })
         .collect();
 

--- a/conductor-tui/src/ui/tickets.rs
+++ b/conductor-tui/src/ui/tickets.rs
@@ -65,18 +65,10 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                     Style::default().fg(Color::DarkGray),
                 ),
             ];
-            if let Some(totals) = state.data.ticket_agent_totals.get(&t.id) {
-                let dur_secs = totals.total_duration_ms as f64 / 1000.0;
-                let mins = (dur_secs / 60.0) as i64;
-                let secs = (dur_secs % 60.0) as i64;
-                spans.push(Span::styled(
-                    format!(
-                        " ${:.2}  {}t  {}m{:02}s",
-                        totals.total_cost, totals.total_turns, mins, secs
-                    ),
-                    Style::default().fg(Color::Magenta),
-                ));
-            }
+            spans.extend(super::common::ticket_worktree_spans(state, &t.id, " "));
+            spans.extend(super::common::ticket_agent_total_spans(
+                state, &t.id, " ", true,
+            ));
             ListItem::new(Line::from(spans))
         })
         .collect();


### PR DESCRIPTION
## Summary
- Adds a worktree indicator (`● slug` green/active, `○ slug` gray/inactive, `● N worktrees` for multiple) to ticket rows in all three views: Dashboard, Tickets, and Repo Detail
- Shows linked worktrees with status and branch in the ticket info popup modal (`Enter`/`o` on a ticket)
- Adds agent cost/turns totals to Repo Detail tickets (was previously missing)
- Extracts shared `ticket_worktree_spans` and `ticket_agent_total_spans` helpers in `common.rs` to keep rendering DRY across all views

Closes #69

## Test plan
- [x] Verify worktree indicator appears on tickets in Dashboard bottom panel
- [x] Verify worktree indicator appears on tickets in full Tickets view
- [x] Verify worktree indicator appears on tickets in Repo Detail view
- [x] Verify ticket info popup shows linked worktrees with slug, status, and branch
- [x] Verify tickets with no linked worktree show no indicator
- [x] Verify tickets with multiple worktrees show count instead of slug
- [x] Run `cargo clippy -- -D warnings`, `cargo fmt --check`, `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)