### PR TITLE
Add multiline prompt input for Claude agent (#66)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ dependencies = [
  "ratatui",
  "rusqlite",
  "serde_json",
+ "tui-textarea",
 ]
 
 [[package]]
@@ -2189,6 +2190,17 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm",
+ "ratatui",
+ "unicode-width 0.2.0",
+]
 
 [[package]]
 name = "typenum"

--- a/conductor-tui/Cargo.toml
+++ b/conductor-tui/Cargo.toml
@@ -18,3 +18,4 @@ anyhow = "1"
 chrono = "0.4"
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde_json = "1"
+tui-textarea = "0.7"

--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -1,11 +1,11 @@
+use std::collections::HashMap;
+
+use conductor_core::agent::{AgentRun, TicketAgentTotals};
 use conductor_core::repo::Repo;
 use conductor_core::session::Session;
 use conductor_core::tickets::Ticket;
 use conductor_core::worktree::Worktree;
-
-use std::collections::HashMap;
-
-use conductor_core::agent::{AgentRun, TicketAgentTotals};
+use crossterm::event::KeyEvent;
 
 /// Payload for the DataRefreshed action (boxed to keep Action enum small).
 #[derive(Debug)]
@@ -84,6 +84,7 @@ pub enum Action {
     InputChar(char),
     InputBackspace,
     InputSubmit,
+    TextAreaInput(KeyEvent),
     FormChar(char),
     FormBackspace,
     FormNextField,

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -205,6 +205,14 @@ impl App {
                 }
             }
             Action::InputSubmit => self.handle_input_submit(),
+            Action::TextAreaInput(key) => {
+                if let Modal::AgentPrompt {
+                    ref mut textarea, ..
+                } = self.state.modal
+                {
+                    textarea.input(key);
+                }
+            }
             Action::FormChar(c) => self.handle_form_char(c),
             Action::FormBackspace => self.handle_form_backspace(),
             Action::FormNextField => self.handle_form_next_field(),
@@ -849,134 +857,147 @@ impl App {
 
     fn handle_input_submit(&mut self) {
         let modal = std::mem::replace(&mut self.state.modal, Modal::None);
-        if let Modal::Input {
-            value, on_submit, ..
-        } = modal
-        {
-            // SessionNotes allows empty input (skip notes); others require a value
-            if value.is_empty() && !matches!(on_submit, InputAction::SessionNotes { .. }) {
-                return;
+
+        // Extract (value, on_submit) from either Input or AgentPrompt modals
+        let (value, on_submit) = match modal {
+            Modal::Input {
+                value, on_submit, ..
+            } => (value, on_submit),
+            Modal::AgentPrompt {
+                textarea,
+                on_submit,
+                ..
+            } => {
+                let value = textarea.lines().join("\n");
+                (value, on_submit)
             }
-            match on_submit {
-                InputAction::CreateWorktree {
-                    repo_slug,
-                    ticket_id,
-                } => {
-                    let wt_mgr = WorktreeManager::new(&self.conn, &self.config);
-                    match wt_mgr.create(&repo_slug, &value, None, ticket_id.as_deref()) {
-                        Ok(wt) => {
-                            let msg = if let Some(ref tid) = ticket_id {
-                                let source_id = self
-                                    .state
-                                    .data
-                                    .ticket_map
-                                    .get(tid)
-                                    .map(|t| t.source_id.as_str())
-                                    .unwrap_or("?");
-                                format!("Created worktree: {} (linked to #{})", wt.slug, source_id)
-                            } else {
-                                format!("Created worktree: {}", wt.slug)
-                            };
-                            self.state.status_message = Some(msg);
-                            self.refresh_data();
-                        }
-                        Err(e) => {
-                            self.state.modal = Modal::Error {
-                                message: format!("Create failed: {e}"),
-                            };
-                        }
+            _ => return,
+        };
+
+        // SessionNotes allows empty input (skip notes); others require a value
+        if value.is_empty() && !matches!(on_submit, InputAction::SessionNotes { .. }) {
+            return;
+        }
+        match on_submit {
+            InputAction::CreateWorktree {
+                repo_slug,
+                ticket_id,
+            } => {
+                let wt_mgr = WorktreeManager::new(&self.conn, &self.config);
+                match wt_mgr.create(&repo_slug, &value, None, ticket_id.as_deref()) {
+                    Ok(wt) => {
+                        let msg = if let Some(ref tid) = ticket_id {
+                            let source_id = self
+                                .state
+                                .data
+                                .ticket_map
+                                .get(tid)
+                                .map(|t| t.source_id.as_str())
+                                .unwrap_or("?");
+                            format!("Created worktree: {} (linked to #{})", wt.slug, source_id)
+                        } else {
+                            format!("Created worktree: {}", wt.slug)
+                        };
+                        self.state.status_message = Some(msg);
+                        self.refresh_data();
                     }
-                }
-                InputAction::LinkTicket { worktree_id } => {
-                    let syncer = TicketSyncer::new(&self.conn);
-                    // Find ticket by source_id, scoped to the worktree's repo
-                    let wt_repo_id = self
-                        .state
-                        .data
-                        .worktrees
-                        .iter()
-                        .find(|w| w.id == worktree_id)
-                        .map(|w| w.repo_id.as_str());
-                    let ticket =
-                        self.state.data.tickets.iter().find(|t| {
-                            t.source_id == value && Some(t.repo_id.as_str()) == wt_repo_id
-                        });
-                    if let Some(t) = ticket {
-                        match syncer.link_to_worktree(&t.id, &worktree_id) {
-                            Ok(()) => {
-                                self.state.status_message =
-                                    Some(format!("Linked ticket #{}", t.source_id));
-                                self.refresh_data();
-                            }
-                            Err(e) => {
-                                self.state.modal = Modal::Error {
-                                    message: format!("Link failed: {e}"),
-                                };
-                            }
-                        }
-                    } else {
+                    Err(e) => {
                         self.state.modal = Modal::Error {
-                            message: format!("Ticket #{value} not found"),
+                            message: format!("Create failed: {e}"),
                         };
                     }
                 }
-                InputAction::SessionNotes { session_id } => {
-                    let tracker = SessionTracker::new(&self.conn);
-                    let notes = if value.is_empty() {
-                        None
-                    } else {
-                        Some(value.as_str())
-                    };
-                    match tracker.end(&session_id, notes) {
+            }
+            InputAction::LinkTicket { worktree_id } => {
+                let syncer = TicketSyncer::new(&self.conn);
+                // Find ticket by source_id, scoped to the worktree's repo
+                let wt_repo_id = self
+                    .state
+                    .data
+                    .worktrees
+                    .iter()
+                    .find(|w| w.id == worktree_id)
+                    .map(|w| w.repo_id.as_str());
+                let ticket = self
+                    .state
+                    .data
+                    .tickets
+                    .iter()
+                    .find(|t| t.source_id == value && Some(t.repo_id.as_str()) == wt_repo_id);
+                if let Some(t) = ticket {
+                    match syncer.link_to_worktree(&t.id, &worktree_id) {
                         Ok(()) => {
                             self.state.status_message =
-                                Some("Session ended with notes".to_string());
+                                Some(format!("Linked ticket #{}", t.source_id));
                             self.refresh_data();
                         }
                         Err(e) => {
                             self.state.modal = Modal::Error {
-                                message: format!("End session failed: {e}"),
+                                message: format!("Link failed: {e}"),
                             };
                         }
                     }
+                } else {
+                    self.state.modal = Modal::Error {
+                        message: format!("Ticket #{value} not found"),
+                    };
                 }
-                InputAction::AttachWorktree { session_id } => {
-                    // Look up worktree by slug
-                    let wt = self.state.data.worktrees.iter().find(|w| w.slug == value);
-                    if let Some(wt) = wt {
-                        let tracker = SessionTracker::new(&self.conn);
-                        match tracker.add_worktree(&session_id, &wt.id) {
-                            Ok(()) => {
-                                self.state.status_message =
-                                    Some(format!("Attached worktree '{}'", value));
-                                self.refresh_data();
-                            }
-                            Err(e) => {
-                                self.state.modal = Modal::Error {
-                                    message: format!("Attach failed: {e}"),
-                                };
-                            }
-                        }
-                    } else {
+            }
+            InputAction::SessionNotes { session_id } => {
+                let tracker = SessionTracker::new(&self.conn);
+                let notes = if value.is_empty() {
+                    None
+                } else {
+                    Some(value.as_str())
+                };
+                match tracker.end(&session_id, notes) {
+                    Ok(()) => {
+                        self.state.status_message = Some("Session ended with notes".to_string());
+                        self.refresh_data();
+                    }
+                    Err(e) => {
                         self.state.modal = Modal::Error {
-                            message: format!("Worktree '{value}' not found"),
+                            message: format!("End session failed: {e}"),
                         };
                     }
                 }
-                InputAction::AgentPrompt {
+            }
+            InputAction::AttachWorktree { session_id } => {
+                // Look up worktree by slug
+                let wt = self.state.data.worktrees.iter().find(|w| w.slug == value);
+                if let Some(wt) = wt {
+                    let tracker = SessionTracker::new(&self.conn);
+                    match tracker.add_worktree(&session_id, &wt.id) {
+                        Ok(()) => {
+                            self.state.status_message =
+                                Some(format!("Attached worktree '{}'", value));
+                            self.refresh_data();
+                        }
+                        Err(e) => {
+                            self.state.modal = Modal::Error {
+                                message: format!("Attach failed: {e}"),
+                            };
+                        }
+                    }
+                } else {
+                    self.state.modal = Modal::Error {
+                        message: format!("Worktree '{value}' not found"),
+                    };
+                }
+            }
+            InputAction::AgentPrompt {
+                worktree_id,
+                worktree_path,
+                worktree_slug,
+                resume_session_id,
+            } => {
+                self.start_agent_tmux(
+                    value,
                     worktree_id,
                     worktree_path,
                     worktree_slug,
                     resume_session_id,
-                } => {
-                    self.start_agent_tmux(
-                        value,
-                        worktree_id,
-                        worktree_path,
-                        worktree_slug,
-                        resume_session_id,
-                    );
-                }
+                );
             }
         }
     }
@@ -1807,10 +1828,19 @@ impl App {
             ("Claude Agent".to_string(), prefill)
         };
 
-        self.state.modal = Modal::Input {
+        let lines = if prefill.is_empty() {
+            vec![String::new()]
+        } else {
+            prefill.lines().map(String::from).collect()
+        };
+        let mut textarea = tui_textarea::TextArea::new(lines);
+        textarea.set_cursor_line_style(ratatui::style::Style::default());
+        textarea.set_placeholder_text("Type your prompt here...");
+
+        self.state.modal = Modal::AgentPrompt {
             title,
             prompt: "Enter prompt for Claude:".to_string(),
-            value: prefill,
+            textarea: Box::new(textarea),
             on_submit: InputAction::AgentPrompt {
                 worktree_id: wt.id.clone(),
                 worktree_path: wt.path.clone(),

--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -37,6 +37,16 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
                 _ => Action::None,
             };
         }
+        Modal::AgentPrompt { .. } => {
+            // Ctrl+S submits; Enter inserts a newline; Esc cancels
+            if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('s') {
+                return Action::InputSubmit;
+            }
+            return match key.code {
+                KeyCode::Esc => Action::DismissModal,
+                _ => Action::TextAreaInput(key),
+            };
+        }
         Modal::Form { .. } => {
             return match key.code {
                 KeyCode::Enter => Action::FormSubmit,

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 
 use conductor_core::agent::{AgentEvent, AgentRun, TicketAgentTotals};
 use conductor_core::config::WorkTarget;
@@ -6,6 +7,7 @@ use conductor_core::repo::Repo;
 use conductor_core::session::Session;
 use conductor_core::tickets::Ticket;
 use conductor_core::worktree::Worktree;
+use tui_textarea::TextArea;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum View {
@@ -71,7 +73,7 @@ impl RepoDetailFocus {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum Modal {
     None,
     Help,
@@ -84,6 +86,12 @@ pub enum Modal {
         title: String,
         prompt: String,
         value: String,
+        on_submit: InputAction,
+    },
+    AgentPrompt {
+        title: String,
+        prompt: String,
+        textarea: Box<TextArea<'static>>,
         on_submit: InputAction,
     },
     Form {
@@ -106,6 +114,27 @@ pub enum Modal {
         targets: Vec<WorkTarget>,
         selected: usize,
     },
+}
+
+impl fmt::Debug for Modal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Modal::None => write!(f, "Modal::None"),
+            Modal::Help => write!(f, "Modal::Help"),
+            Modal::Confirm { title, .. } => {
+                f.debug_struct("Confirm").field("title", title).finish()
+            }
+            Modal::Input { title, .. } => f.debug_struct("Input").field("title", title).finish(),
+            Modal::AgentPrompt { title, .. } => {
+                f.debug_struct("AgentPrompt").field("title", title).finish()
+            }
+            Modal::Form { title, .. } => f.debug_struct("Form").field("title", title).finish(),
+            Modal::Error { message } => f.debug_struct("Error").field("message", message).finish(),
+            Modal::TicketInfo { .. } => write!(f, "Modal::TicketInfo"),
+            Modal::WorkTargetPicker { .. } => write!(f, "Modal::WorkTargetPicker"),
+            Modal::WorkTargetManager { .. } => write!(f, "Modal::WorkTargetManager"),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -52,6 +52,12 @@ pub fn render(frame: &mut Frame, state: &AppState) {
             value,
             ..
         } => modal::render_input(frame, area, title, prompt, value),
+        Modal::AgentPrompt {
+            title,
+            prompt,
+            textarea,
+            ..
+        } => modal::render_agent_prompt(frame, area, title, prompt, textarea),
         Modal::Form {
             title,
             fields,

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -1,8 +1,9 @@
-use ratatui::layout::{Constraint, Flex, Layout, Rect};
+use ratatui::layout::{Constraint, Direction, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
+use tui_textarea::TextArea;
 
 use conductor_core::agent::TicketAgentTotals;
 use conductor_core::config::WorkTarget;
@@ -473,6 +474,55 @@ pub fn render_work_target_manager(
     );
 
     frame.render_widget(content, popup);
+}
+
+pub fn render_agent_prompt(
+    frame: &mut Frame,
+    area: Rect,
+    title: &str,
+    prompt: &str,
+    textarea: &TextArea<'_>,
+) {
+    let popup = centered_rect(70, 50, area);
+    frame.render_widget(Clear, popup);
+
+    // Outer block for the modal border
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(format!(" {title} "));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    // Split inner area: prompt line + textarea + hint line
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2), // prompt text
+            Constraint::Min(3),    // textarea
+            Constraint::Length(1), // hint
+        ])
+        .split(inner);
+
+    // Prompt label
+    let prompt_widget = Paragraph::new(vec![
+        Line::from(Span::styled(
+            format!(" {prompt}"),
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(""),
+    ]);
+    frame.render_widget(prompt_widget, chunks[0]);
+
+    // Textarea (renders itself with cursor)
+    frame.render_widget(textarea, chunks[1]);
+
+    // Hint line
+    let hint = Paragraph::new(Line::from(Span::styled(
+        " Enter for newline, Ctrl+S to submit, Esc to cancel",
+        Style::default().fg(Color::DarkGray),
+    )));
+    frame.render_widget(hint, chunks[2]);
 }
 
 fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {


### PR DESCRIPTION
## Summary
- Replace single-line `Input` modal with a `TextArea`-based `AgentPrompt` modal using `tui-textarea` for multiline editing
- Enter inserts newlines naturally; Ctrl+S submits the prompt; Esc cancels
- Unify submit handling so both `Input` and `AgentPrompt` modals flow through the same `handle_input_submit` logic

## Test plan
- [x] Open a worktree detail, press `r` to launch agent prompt
- [x] Verify Enter inserts newlines in the textarea
- [x] Verify Ctrl+S submits the prompt and launches the agent
- [x] Verify Esc dismisses the modal
- [x] Verify hint text at bottom reads "Enter for newline, Ctrl+S to submit, Esc to cancel"

🤖 Generated with [Claude Code](https://claude.com/claude-code)