### PR TITLE
Leave agent prompt blank when worktree has prior agent activity

### DIFF
--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -77,6 +77,7 @@ pub enum Action {
     InputBackspace,
     InputSubmit,
     TextAreaInput(KeyEvent),
+    TextAreaClear,
     FormChar(char),
     FormBackspace,
     FormNextField,

--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -38,9 +38,13 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
             };
         }
         Modal::AgentPrompt { .. } => {
-            // Ctrl+S submits; Enter inserts a newline; Esc cancels
-            if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('s') {
-                return Action::InputSubmit;
+            // Ctrl+S submits; Ctrl+D clears; Enter inserts a newline; Esc cancels
+            if key.modifiers.contains(KeyModifiers::CONTROL) {
+                match key.code {
+                    KeyCode::Char('s') => return Action::InputSubmit,
+                    KeyCode::Char('d') => return Action::TextAreaClear,
+                    _ => {}
+                }
             }
             return match key.code {
                 KeyCode::Esc => Action::DismissModal,

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -519,7 +519,7 @@ pub fn render_agent_prompt(
 
     // Hint line
     let hint = Paragraph::new(Line::from(Span::styled(
-        " Enter for newline, Ctrl+S to submit, Esc to cancel",
+        " Enter for newline, Ctrl+S to submit, Ctrl+D to clear, Esc to cancel",
         Style::default().fg(Color::DarkGray),
     )));
     frame.render_widget(hint, chunks[2]);


### PR DESCRIPTION
## Summary
- Skip pre-filling the agent prompt modal with ticket context when the worktree already has prior agent runs, since the agent already has context from earlier activity
- Add `Ctrl+D` shortcut to clear the entire prompt textarea, so users can quickly start fresh even when the prompt is pre-filled
- Add `AgentManager::has_runs_for_worktree()` query with unit test

Closes #90

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test -p conductor-core --lib agent` — all 18 tests pass (including new `test_has_runs_for_worktree`)
- [x] `cargo fmt --check` passes
- [x] Manual: launch agent on a worktree with no prior runs → prompt pre-fills with ticket context
- [x] Manual: launch agent on a worktree with prior runs → prompt opens empty
- [x] Manual: press `Ctrl+D` in prompt modal → textarea clears
- [x] Manual: hint text shows "Ctrl+D to clear"

🤖 Generated with [Claude Code](https://claude.com/claude-code)