### PR TITLE
Wire up SSE real-time updates in frontend (#83)

### DIFF
--- a/conductor-web/frontend/src/hooks/useConductorEvents.ts
+++ b/conductor-web/frontend/src/hooks/useConductorEvents.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useCallback } from "react";
+
+/** All SSE event types emitted by the backend. */
+export type ConductorEventType =
+  | "repo_created"
+  | "repo_deleted"
+  | "worktree_created"
+  | "worktree_deleted"
+  | "tickets_synced"
+  | "agent_started"
+  | "agent_stopped"
+  | "agent_event"
+  | "work_targets_changed"
+  | "lagged";
+
+export interface ConductorEventData {
+  event: ConductorEventType;
+  data?: Record<string, string>;
+}
+
+type EventHandler = (data: ConductorEventData) => void;
+
+/**
+ * Subscribe to the backend SSE stream at /api/events.
+ *
+ * Accepts a map of event types to handler functions. The hook manages a single
+ * shared EventSource connection per mount, reconnecting automatically on error.
+ */
+export function useConductorEvents(
+  handlers: Partial<Record<ConductorEventType, EventHandler>>,
+) {
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  const makeHandler = useCallback(
+    (eventType: ConductorEventType) => (e: MessageEvent) => {
+      const handler = handlersRef.current[eventType];
+      if (!handler) return;
+      try {
+        const parsed = JSON.parse(e.data);
+        handler({ event: eventType, data: parsed.data ?? parsed });
+      } catch {
+        handler({ event: eventType });
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const source = new EventSource("/api/events");
+
+    const eventTypes: ConductorEventType[] = [
+      "repo_created",
+      "repo_deleted",
+      "worktree_created",
+      "worktree_deleted",
+      "tickets_synced",
+      "agent_started",
+      "agent_stopped",
+      "agent_event",
+      "work_targets_changed",
+      "lagged",
+    ];
+
+    const boundHandlers: [string, (e: MessageEvent) => void][] = [];
+
+    for (const type of eventTypes) {
+      const handler = makeHandler(type);
+      source.addEventListener(type, handler as EventListener);
+      boundHandlers.push([type, handler]);
+    }
+
+    return () => {
+      for (const [type, handler] of boundHandlers) {
+        source.removeEventListener(type, handler as EventListener);
+      }
+      source.close();
+    };
+  }, [makeHandler]);
+}

--- a/conductor-web/src/events.rs
+++ b/conductor-web/src/events.rs
@@ -19,6 +19,8 @@ pub enum ConductorEvent {
     AgentStarted { run_id: String, worktree_id: String },
     #[serde(rename = "agent_stopped")]
     AgentStopped { run_id: String, worktree_id: String },
+    #[serde(rename = "agent_event")]
+    AgentEvent { run_id: String, worktree_id: String },
     #[serde(rename = "work_targets_changed")]
     WorkTargetsChanged,
 }
@@ -34,6 +36,7 @@ impl ConductorEvent {
             Self::TicketsSynced { .. } => "tickets_synced",
             Self::AgentStarted { .. } => "agent_started",
             Self::AgentStopped { .. } => "agent_stopped",
+            Self::AgentEvent { .. } => "agent_event",
             Self::WorkTargetsChanged => "work_targets_changed",
         }
     }
@@ -137,6 +140,13 @@ mod tests {
                     worktree_id: "".into(),
                 },
                 "agent_stopped",
+            ),
+            (
+                ConductorEvent::AgentEvent {
+                    run_id: "".into(),
+                    worktree_id: "".into(),
+                },
+                "agent_event",
             ),
             (ConductorEvent::WorkTargetsChanged, "work_targets_changed"),
         ];


### PR DESCRIPTION
Connect the frontend to the backend SSE endpoint so the UI auto-refreshes
when repos, worktrees, tickets, or agent runs change. Add agent event
variants to ConductorEvent and expose agent run read endpoints.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
