### PR TITLE
Add ticket detail modal with agent data and deduplicate ticket components

### DIFF
--- a/conductor-web/frontend/src/api/client.ts
+++ b/conductor-web/frontend/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
   Worktree,
   Ticket,
   TicketAgentTotals,
+  TicketDetail,
   CreateRepoRequest,
   CreateWorktreeRequest,
   SyncResult,
@@ -67,6 +68,8 @@ export const api = {
     request<Ticket[]>(`/repos/${repoId}/tickets`),
   syncTickets: (repoId: string) =>
     request<SyncResult>(`/repos/${repoId}/tickets/sync`, { method: "POST" }),
+  getTicketDetail: (ticketId: string) =>
+    request<TicketDetail>(`/tickets/${ticketId}/detail`),
 
   // Agent stats (aggregates)
   latestRunsByWorktree: () =>

--- a/conductor-web/frontend/src/api/types.ts
+++ b/conductor-web/frontend/src/api/types.ts
@@ -107,3 +107,8 @@ export interface PushResult {
 export interface CreatePrResult {
   url: string;
 }
+
+export interface TicketDetail {
+  agent_totals: TicketAgentTotals | null;
+  worktrees: Worktree[];
+}

--- a/conductor-web/frontend/src/components/tickets/TicketDetailModal.tsx
+++ b/conductor-web/frontend/src/components/tickets/TicketDetailModal.tsx
@@ -1,0 +1,194 @@
+import { useEffect } from "react";
+import type { Ticket, TicketDetail } from "../../api/types";
+import { api } from "../../api/client";
+import { useApi } from "../../hooks/useApi";
+import { StatusBadge } from "../shared/StatusBadge";
+import { parseLabels } from "../../utils/ticketUtils";
+import { formatCostCompact, formatDuration } from "../../utils/agentStats";
+
+interface TicketDetailModalProps {
+  ticket: Ticket;
+  onClose: () => void;
+}
+
+export function TicketDetailModal({ ticket, onClose }: TicketDetailModalProps) {
+  const {
+    data: detail,
+    loading,
+  } = useApi<TicketDetail>(
+    () => api.getTicketDetail(ticket.id),
+    [ticket.id],
+  );
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const labels = parseLabels(ticket.labels);
+  const totals = detail?.agent_totals;
+  const worktrees = detail?.worktrees ?? [];
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-lg mx-4 max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-5 pb-3 border-b border-gray-100">
+          <h3 className="text-lg font-semibold text-gray-900 truncate pr-4">
+            #{ticket.source_id} {ticket.title}
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+          >
+            &times;
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-4 overflow-y-auto space-y-5">
+          {/* Ticket metadata */}
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+            <dt className="font-medium text-gray-500">State</dt>
+            <dd><StatusBadge status={ticket.state} /></dd>
+
+            <dt className="font-medium text-gray-500">Source</dt>
+            <dd className="text-gray-900">{ticket.source_type} #{ticket.source_id}</dd>
+
+            <dt className="font-medium text-gray-500">Assignee</dt>
+            <dd className="text-gray-900">{ticket.assignee ?? "Unassigned"}</dd>
+
+            <dt className="font-medium text-gray-500">Labels</dt>
+            <dd>
+              {labels.length > 0 ? (
+                <div className="flex flex-wrap gap-1">
+                  {labels.map((l) => (
+                    <span
+                      key={l}
+                      className="px-1.5 py-0.5 text-xs rounded bg-gray-100 text-gray-600"
+                    >
+                      {l}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <span className="text-gray-400">None</span>
+              )}
+            </dd>
+
+            <dt className="font-medium text-gray-500">URL</dt>
+            <dd>
+              {ticket.url ? (
+                <a
+                  href={ticket.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-indigo-600 hover:underline truncate block"
+                >
+                  {ticket.url}
+                </a>
+              ) : (
+                <span className="text-gray-400">-</span>
+              )}
+            </dd>
+          </dl>
+
+          {/* Description */}
+          {ticket.body && (
+            <div>
+              <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-1">
+                Description
+              </h4>
+              <p className="text-sm text-gray-700 whitespace-pre-wrap break-words line-clamp-6">
+                {ticket.body}
+              </p>
+            </div>
+          )}
+
+          {/* Agent Totals */}
+          <div>
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-2">
+              Agent Totals
+            </h4>
+            {loading ? (
+              <p className="text-sm text-gray-400">Loading...</p>
+            ) : totals ? (
+              <div className="grid grid-cols-4 gap-3">
+                <div className="rounded-md bg-gray-50 p-2 text-center">
+                  <div className="text-base font-semibold text-gray-900">{totals.total_runs}</div>
+                  <div className="text-xs text-gray-500">Runs</div>
+                </div>
+                <div className="rounded-md bg-gray-50 p-2 text-center">
+                  <div className="text-base font-semibold text-fuchsia-700">{formatCostCompact(totals.total_cost)}</div>
+                  <div className="text-xs text-gray-500">Cost</div>
+                </div>
+                <div className="rounded-md bg-gray-50 p-2 text-center">
+                  <div className="text-base font-semibold text-gray-900">{totals.total_turns}</div>
+                  <div className="text-xs text-gray-500">Turns</div>
+                </div>
+                <div className="rounded-md bg-gray-50 p-2 text-center">
+                  <div className="text-base font-semibold text-gray-900">{formatDuration(totals.total_duration_ms)}</div>
+                  <div className="text-xs text-gray-500">Duration</div>
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-400">No agent runs recorded</p>
+            )}
+          </div>
+
+          {/* Linked Worktrees */}
+          <div>
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-2">
+              Linked Worktrees
+            </h4>
+            {loading ? (
+              <p className="text-sm text-gray-400">Loading...</p>
+            ) : worktrees.length > 0 ? (
+              <ul className="space-y-1.5">
+                {worktrees.map((wt) => (
+                  <li
+                    key={wt.id}
+                    className="flex items-center gap-2 text-sm"
+                  >
+                    <span
+                      className={`inline-block w-2 h-2 rounded-full ${
+                        wt.status === "active"
+                          ? "bg-green-500"
+                          : wt.status === "merged"
+                            ? "bg-blue-500"
+                            : "bg-gray-400"
+                      }`}
+                    />
+                    <span className="font-mono text-gray-900">{wt.slug}</span>
+                    <span className="text-gray-400">{wt.branch}</span>
+                    <StatusBadge status={wt.status} />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-gray-400">No linked worktrees</p>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-3 border-t border-gray-100 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/conductor-web/frontend/src/components/tickets/TicketRow.tsx
+++ b/conductor-web/frontend/src/components/tickets/TicketRow.tsx
@@ -1,35 +1,27 @@
 import type { Ticket, TicketAgentTotals } from "../../api/types";
 import { StatusBadge } from "../shared/StatusBadge";
 import { formatTicketTotalsFull } from "../../utils/agentStats";
+import { parseLabels } from "../../utils/ticketUtils";
 
-function parseLabels(raw: string): string[] {
-  try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-export function TicketRow({
-  ticket,
-  agentTotals,
-}: {
+interface TicketRowProps {
   ticket: Ticket;
   agentTotals?: TicketAgentTotals;
-}) {
+  repoSlug?: string;
+  onClick: (ticket: Ticket) => void;
+}
+
+export function TicketRow({ ticket, agentTotals, repoSlug, onClick }: TicketRowProps) {
   const labels = parseLabels(ticket.labels);
   return (
-    <tr>
+    <tr
+      className="cursor-pointer hover:bg-gray-50"
+      onClick={() => onClick(ticket)}
+    >
+      {repoSlug !== undefined && (
+        <td className="px-4 py-2 text-gray-500">{repoSlug}</td>
+      )}
       <td className="px-4 py-2">
-        <a
-          href={ticket.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-indigo-600 hover:underline"
-        >
-          {ticket.source_id}
-        </a>
+        <span className="text-indigo-600">{ticket.source_id}</span>
       </td>
       <td className="px-4 py-2 text-gray-900">{ticket.title}</td>
       <td className="px-4 py-2">

--- a/conductor-web/frontend/src/pages/RepoDetailPage.tsx
+++ b/conductor-web/frontend/src/pages/RepoDetailPage.tsx
@@ -3,9 +3,11 @@ import { useParams, Link } from "react-router";
 import { useRepos } from "../components/layout/AppShell";
 import { useApi } from "../hooks/useApi";
 import { api } from "../api/client";
+import type { Ticket } from "../api/types";
 import { WorktreeRow } from "../components/worktrees/WorktreeRow";
 import { CreateWorktreeForm } from "../components/worktrees/CreateWorktreeForm";
 import { TicketRow } from "../components/tickets/TicketRow";
+import { TicketDetailModal } from "../components/tickets/TicketDetailModal";
 import { ConfirmDialog } from "../components/shared/ConfirmDialog";
 import { LoadingSpinner } from "../components/shared/LoadingSpinner";
 import { EmptyState } from "../components/shared/EmptyState";
@@ -70,6 +72,7 @@ export function RepoDetailPage() {
   const [syncResult, setSyncResult] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [deleteRepoConfirm, setDeleteRepoConfirm] = useState(false);
+  const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
 
   async function handleSyncTickets() {
     setSyncing(true);
@@ -217,6 +220,7 @@ export function RepoDetailPage() {
                     key={t.id}
                     ticket={t}
                     agentTotals={ticketTotals?.[t.id]}
+                    onClick={setSelectedTicket}
                   />
                 ))}
               </tbody>
@@ -226,6 +230,12 @@ export function RepoDetailPage() {
       </section>
 
       {/* Dialogs */}
+      {selectedTicket && (
+        <TicketDetailModal
+          ticket={selectedTicket}
+          onClose={() => setSelectedTicket(null)}
+        />
+      )}
       <ConfirmDialog
         open={deleteTarget !== null}
         title="Delete Worktree"

--- a/conductor-web/frontend/src/pages/TicketsPage.tsx
+++ b/conductor-web/frontend/src/pages/TicketsPage.tsx
@@ -2,19 +2,12 @@ import { useMemo, useState } from "react";
 import { useRepos } from "../components/layout/AppShell";
 import { useApi } from "../hooks/useApi";
 import { api } from "../api/client";
-import { StatusBadge } from "../components/shared/StatusBadge";
 import { LoadingSpinner } from "../components/shared/LoadingSpinner";
 import { EmptyState } from "../components/shared/EmptyState";
+import { TicketRow } from "../components/tickets/TicketRow";
+import { TicketDetailModal } from "../components/tickets/TicketDetailModal";
 import type { Ticket, Repo } from "../api/types";
-
-function parseLabels(raw: string): string[] {
-  try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
+import { parseLabels } from "../utils/ticketUtils";
 
 function matchesFilter(ticket: Ticket, filter: string): boolean {
   const lower = filter.toLowerCase();
@@ -25,127 +18,10 @@ function matchesFilter(ticket: Ticket, filter: string): boolean {
   return false;
 }
 
-function TicketDetailModal({
-  ticket,
-  repoSlug,
-  onClose,
-}: {
-  ticket: Ticket;
-  repoSlug: string;
-  onClose: () => void;
-}) {
-  const labels = parseLabels(ticket.labels);
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      onClick={onClose}
-    >
-      <div
-        className="bg-white rounded-lg shadow-lg p-6 max-w-lg w-full mx-4 max-h-[80vh] overflow-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-start justify-between gap-3">
-          <h3 className="text-lg font-semibold text-gray-900">
-            {ticket.source_id}: {ticket.title}
-          </h3>
-          <button
-            onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 text-xl leading-none"
-          >
-            &times;
-          </button>
-        </div>
-
-        <dl className="mt-4 space-y-3 text-sm">
-          <div className="flex gap-2">
-            <dt className="font-medium text-gray-500 w-24 shrink-0">State</dt>
-            <dd>
-              <StatusBadge status={ticket.state} />
-            </dd>
-          </div>
-          <div className="flex gap-2">
-            <dt className="font-medium text-gray-500 w-24 shrink-0">Repo</dt>
-            <dd className="text-gray-900">{repoSlug}</dd>
-          </div>
-          <div className="flex gap-2">
-            <dt className="font-medium text-gray-500 w-24 shrink-0">Source</dt>
-            <dd className="text-gray-900">{ticket.source_type}</dd>
-          </div>
-          {ticket.assignee && (
-            <div className="flex gap-2">
-              <dt className="font-medium text-gray-500 w-24 shrink-0">
-                Assignee
-              </dt>
-              <dd className="text-gray-900">{ticket.assignee}</dd>
-            </div>
-          )}
-          {ticket.priority && (
-            <div className="flex gap-2">
-              <dt className="font-medium text-gray-500 w-24 shrink-0">
-                Priority
-              </dt>
-              <dd className="text-gray-900">{ticket.priority}</dd>
-            </div>
-          )}
-          {labels.length > 0 && (
-            <div className="flex gap-2">
-              <dt className="font-medium text-gray-500 w-24 shrink-0">
-                Labels
-              </dt>
-              <dd className="flex flex-wrap gap-1">
-                {labels.map((l) => (
-                  <span
-                    key={l}
-                    className="px-1.5 py-0.5 text-xs rounded bg-gray-100 text-gray-600"
-                  >
-                    {l}
-                  </span>
-                ))}
-              </dd>
-            </div>
-          )}
-          {ticket.url && (
-            <div className="flex gap-2">
-              <dt className="font-medium text-gray-500 w-24 shrink-0">URL</dt>
-              <dd>
-                <a
-                  href={ticket.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-indigo-600 hover:underline break-all"
-                >
-                  Open in browser
-                </a>
-              </dd>
-            </div>
-          )}
-          <div className="flex gap-2">
-            <dt className="font-medium text-gray-500 w-24 shrink-0">
-              Synced
-            </dt>
-            <dd className="text-gray-500">{ticket.synced_at}</dd>
-          </div>
-        </dl>
-
-        {ticket.body && (
-          <div className="mt-4 pt-4 border-t border-gray-200">
-            <h4 className="text-sm font-medium text-gray-500 mb-2">
-              Description
-            </h4>
-            <p className="text-sm text-gray-700 whitespace-pre-wrap">
-              {ticket.body}
-            </p>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
 export function TicketsPage() {
   const { repos } = useRepos();
   const { data: tickets, loading } = useApi(() => api.listAllTickets(), []);
+  const { data: ticketTotals } = useApi(() => api.ticketAgentTotals(), []);
   const [filter, setFilter] = useState("");
   const [selected, setSelected] = useState<Ticket | null>(null);
 
@@ -193,54 +69,19 @@ export function TicketsPage() {
                 <th className="px-4 py-2">State</th>
                 <th className="px-4 py-2">Labels</th>
                 <th className="px-4 py-2">Assignee</th>
+                <th className="px-4 py-2">Agent</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
-              {filtered.map((t) => {
-                const labels = parseLabels(t.labels);
-                const repo = repoMap[t.repo_id];
-                return (
-                  <tr
-                    key={t.id}
-                    className="hover:bg-gray-50 cursor-pointer"
-                    onClick={() => setSelected(t)}
-                  >
-                    <td className="px-4 py-2 text-gray-500">
-                      {repo?.slug ?? "—"}
-                    </td>
-                    <td className="px-4 py-2">
-                      <a
-                        href={t.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-indigo-600 hover:underline"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        {t.source_id}
-                      </a>
-                    </td>
-                    <td className="px-4 py-2 text-gray-900">{t.title}</td>
-                    <td className="px-4 py-2">
-                      <StatusBadge status={t.state} />
-                    </td>
-                    <td className="px-4 py-2">
-                      <div className="flex flex-wrap gap-1">
-                        {labels.map((l) => (
-                          <span
-                            key={l}
-                            className="px-1.5 py-0.5 text-xs rounded bg-gray-100 text-gray-600"
-                          >
-                            {l}
-                          </span>
-                        ))}
-                      </div>
-                    </td>
-                    <td className="px-4 py-2 text-xs text-gray-500">
-                      {t.assignee ?? "—"}
-                    </td>
-                  </tr>
-                );
-              })}
+              {filtered.map((t) => (
+                <TicketRow
+                  key={t.id}
+                  ticket={t}
+                  repoSlug={repoMap[t.repo_id]?.slug ?? "—"}
+                  agentTotals={ticketTotals?.[t.id]}
+                  onClick={setSelected}
+                />
+              ))}
             </tbody>
           </table>
         </div>
@@ -249,7 +90,6 @@ export function TicketsPage() {
       {selected && (
         <TicketDetailModal
           ticket={selected}
-          repoSlug={repoMap[selected.repo_id]?.slug ?? "Unknown"}
           onClose={() => setSelected(null)}
         />
       )}

--- a/conductor-web/frontend/src/utils/ticketUtils.ts
+++ b/conductor-web/frontend/src/utils/ticketUtils.ts
@@ -1,0 +1,9 @@
+/** Parse a JSON-encoded labels string into an array. */
+export function parseLabels(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}

--- a/conductor-web/src/error.rs
+++ b/conductor-web/src/error.rs
@@ -27,3 +27,9 @@ impl From<ConductorError> for ApiError {
         ApiError(err)
     }
 }
+
+impl From<rusqlite::Error> for ApiError {
+    fn from(err: rusqlite::Error) -> Self {
+        ApiError(ConductorError::Database(err))
+    }
+}

--- a/conductor-web/src/routes/mod.rs
+++ b/conductor-web/src/routes/mod.rs
@@ -36,6 +36,10 @@ pub fn api_router() -> Router<AppState> {
         .route("/api/tickets", get(tickets::list_all_tickets))
         .route("/api/repos/{id}/tickets", get(tickets::list_tickets))
         .route("/api/repos/{id}/tickets/sync", post(tickets::sync_tickets))
+        .route(
+            "/api/tickets/{ticket_id}/detail",
+            get(tickets::ticket_detail),
+        )
         // Agent stats (aggregates)
         .route(
             "/api/worktrees/{id}/agent-runs",

--- a/conductor-web/tests/api_tests.rs
+++ b/conductor-web/tests/api_tests.rs
@@ -258,6 +258,23 @@ async fn test_list_all_tickets_empty() {
 }
 
 #[tokio::test]
+async fn test_ticket_detail_empty() {
+    let base = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Call detail for a ticket with no agent runs or linked worktrees
+    let resp = client
+        .get(format!("{base}/api/tickets/nonexistent-id/detail"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["agent_totals"].is_null());
+    assert_eq!(body["worktrees"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
 async fn test_list_work_targets_default() {
     let base = spawn_test_server().await;
     let client = reqwest::Client::new();


### PR DESCRIPTION
Unify ticket row rendering and detail modal across the global /tickets page
and repo detail page. The global tickets view now shows agent stats in both
the table rows and the detail modal (agent totals + linked worktrees).

- Add /api/tickets/{id}/detail endpoint returning agent totals and worktrees
- Extract shared TicketDetailModal component with full agent data display
- Add repoSlug prop to TicketRow so both pages can reuse it
- Extract parseLabels to shared ticketUtils, remove duplicates from 3 files
- Remove inline TicketDetailModal from TicketsPage in favor of shared one

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
