### PR TITLE
Add keyboard shortcuts to web UI (#86)

### DIFF
--- a/conductor-web/frontend/src/components/agents/AgentPromptModal.tsx
+++ b/conductor-web/frontend/src/components/agents/AgentPromptModal.tsx
@@ -25,6 +25,15 @@ export function AgentPromptModal({
     setUseResume(!!resumeSessionId);
   }, [initialPrompt, resumeSessionId]);
 
+  useEffect(() => {
+    if (!open) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onCancel();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onCancel]);
+
   if (!open) return null;
 
   function handleSubmit() {

--- a/conductor-web/frontend/src/components/layout/AppShell.tsx
+++ b/conductor-web/frontend/src/components/layout/AppShell.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useMemo } from "react";
-import { Outlet } from "react-router";
+import { createContext, useContext, useMemo, useState, useCallback } from "react";
+import { Outlet, useNavigate } from "react-router";
 import { Sidebar } from "./Sidebar";
 import { useApi } from "../../hooks/useApi";
 import { api } from "../../api/client";
@@ -9,6 +9,8 @@ import {
   type ConductorEventType,
   type ConductorEventData,
 } from "../../hooks/useConductorEvents";
+import { useHotkeys } from "../../hooks/useHotkeys";
+import { KeyboardShortcutHelp } from "../shared/KeyboardShortcutHelp";
 
 interface ReposContextValue {
   repos: Repo[];
@@ -28,6 +30,21 @@ export function useRepos() {
 
 export function AppShell() {
   const { data: repos, loading, refetch } = useApi(() => api.listRepos(), []);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const navigate = useNavigate();
+
+  const openHelp = useCallback(() => setHelpOpen(true), []);
+  const closeHelp = useCallback(() => setHelpOpen(false), []);
+  const goToDashboard = useCallback(() => navigate("/"), [navigate]);
+  const goToTickets = useCallback(() => navigate("/tickets"), [navigate]);
+  const goToSettings = useCallback(() => navigate("/settings"), [navigate]);
+
+  useHotkeys([
+    { key: "?", handler: openHelp, description: "Show keyboard shortcuts" },
+    { key: "g d", handler: goToDashboard, description: "Go to Dashboard" },
+    { key: "g t", handler: goToTickets, description: "Go to Tickets" },
+    { key: "g s", handler: goToSettings, description: "Go to Settings" },
+  ]);
 
   const handlers = useMemo(() => {
     const refetchRepos = (_data: ConductorEventData) => refetch();
@@ -53,6 +70,7 @@ export function AppShell() {
           <Outlet />
         </main>
       </div>
+      <KeyboardShortcutHelp open={helpOpen} onClose={closeHelp} />
     </ReposContext.Provider>
   );
 }

--- a/conductor-web/frontend/src/components/layout/Sidebar.tsx
+++ b/conductor-web/frontend/src/components/layout/Sidebar.tsx
@@ -53,6 +53,9 @@ export function Sidebar() {
         <NavLink to="/settings" className={linkClass}>
           Settings
         </NavLink>
+        <div className="mt-2 px-3 text-xs text-gray-400">
+          Press <kbd className="px-1 py-0.5 bg-gray-100 rounded text-gray-500 font-mono text-[10px]">?</kbd> for shortcuts
+        </div>
       </div>
     </aside>
   );

--- a/conductor-web/frontend/src/components/repos/CreateRepoForm.tsx
+++ b/conductor-web/frontend/src/components/repos/CreateRepoForm.tsx
@@ -1,8 +1,18 @@
 import { useState } from "react";
 import { api } from "../../api/client";
 
-export function CreateRepoForm({ onCreated }: { onCreated: () => void }) {
-  const [open, setOpen] = useState(false);
+export function CreateRepoForm({
+  onCreated,
+  open: controlledOpen,
+  onOpenChange,
+}: {
+  onCreated: () => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = onOpenChange ?? setInternalOpen;
   const [remoteUrl, setRemoteUrl] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);

--- a/conductor-web/frontend/src/components/shared/ConfirmDialog.tsx
+++ b/conductor-web/frontend/src/components/shared/ConfirmDialog.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 interface ConfirmDialogProps {
   open: boolean;
   title: string;
@@ -13,6 +15,16 @@ export function ConfirmDialog({
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
+  useEffect(() => {
+    if (!open) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onCancel();
+      if (e.key === "Enter") onConfirm();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onCancel, onConfirm]);
+
   if (!open) return null;
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">

--- a/conductor-web/frontend/src/components/shared/KeyboardShortcutHelp.tsx
+++ b/conductor-web/frontend/src/components/shared/KeyboardShortcutHelp.tsx
@@ -1,0 +1,128 @@
+import { useEffect } from "react";
+
+interface ShortcutHelpProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface ShortcutEntry {
+  keys: string[];
+  description: string;
+}
+
+interface ShortcutGroup {
+  title: string;
+  shortcuts: ShortcutEntry[];
+}
+
+const groups: ShortcutGroup[] = [
+  {
+    title: "Navigation",
+    shortcuts: [
+      { keys: ["g", "d"], description: "Go to Dashboard" },
+      { keys: ["g", "t"], description: "Go to Tickets" },
+      { keys: ["g", "s"], description: "Go to Settings" },
+    ],
+  },
+  {
+    title: "Lists",
+    shortcuts: [
+      { keys: ["j"], description: "Move down" },
+      { keys: ["k"], description: "Move up" },
+      { keys: ["Enter"], description: "Open selected" },
+    ],
+  },
+  {
+    title: "Actions",
+    shortcuts: [
+      { keys: ["c"], description: "Create (repo / worktree)" },
+      { keys: ["d"], description: "Delete (with confirmation)" },
+      { keys: ["/"], description: "Focus search" },
+    ],
+  },
+  {
+    title: "General",
+    shortcuts: [
+      { keys: ["?"], description: "Show this help" },
+      { keys: ["Esc"], description: "Close modal / clear" },
+    ],
+  },
+];
+
+function Kbd({ children }: { children: string }) {
+  return (
+    <kbd className="inline-flex items-center justify-center min-w-[1.5rem] px-1.5 py-0.5 text-xs font-mono font-medium bg-gray-100 border border-gray-300 rounded text-gray-700">
+      {children}
+    </kbd>
+  );
+}
+
+export function KeyboardShortcutHelp({ open, onClose }: ShortcutHelpProps) {
+  useEffect(() => {
+    if (!open) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-md mx-4 p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-gray-900">
+            Keyboard Shortcuts
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+          >
+            &times;
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          {groups.map((group) => (
+            <div key={group.title}>
+              <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-2">
+                {group.title}
+              </h4>
+              <div className="space-y-1.5">
+                {group.shortcuts.map((shortcut) => (
+                  <div
+                    key={shortcut.description}
+                    className="flex items-center justify-between text-sm"
+                  >
+                    <span className="text-gray-600">
+                      {shortcut.description}
+                    </span>
+                    <span className="flex gap-1">
+                      {shortcut.keys.map((k, i) => (
+                        <span key={i} className="flex items-center gap-0.5">
+                          {i > 0 && (
+                            <span className="text-gray-400 text-xs mx-0.5">
+                              then
+                            </span>
+                          )}
+                          <Kbd>{k}</Kbd>
+                        </span>
+                      ))}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/conductor-web/frontend/src/components/tickets/TicketRow.tsx
+++ b/conductor-web/frontend/src/components/tickets/TicketRow.tsx
@@ -8,14 +8,17 @@ interface TicketRowProps {
   agentTotals?: TicketAgentTotals;
   repoSlug?: string;
   onClick: (ticket: Ticket) => void;
+  selected?: boolean;
+  index?: number;
 }
 
-export function TicketRow({ ticket, agentTotals, repoSlug, onClick }: TicketRowProps) {
+export function TicketRow({ ticket, agentTotals, repoSlug, onClick, selected, index }: TicketRowProps) {
   const labels = parseLabels(ticket.labels);
   return (
     <tr
-      className="cursor-pointer hover:bg-gray-50"
+      className={`cursor-pointer hover:bg-gray-50 ${selected ? "bg-indigo-50 ring-1 ring-inset ring-indigo-200" : ""}`}
       onClick={() => onClick(ticket)}
+      data-list-index={index}
     >
       {repoSlug !== undefined && (
         <td className="px-4 py-2 text-gray-500">{repoSlug}</td>

--- a/conductor-web/frontend/src/components/worktrees/CreateWorktreeForm.tsx
+++ b/conductor-web/frontend/src/components/worktrees/CreateWorktreeForm.tsx
@@ -4,11 +4,17 @@ import { api } from "../../api/client";
 export function CreateWorktreeForm({
   repoId,
   onCreated,
+  open: controlledOpen,
+  onOpenChange,
 }: {
   repoId: string;
   onCreated: () => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = onOpenChange ?? setInternalOpen;
   const [name, setName] = useState("");
   const [fromBranch, setFromBranch] = useState("");
   const [error, setError] = useState<string | null>(null);

--- a/conductor-web/frontend/src/components/worktrees/WorktreeRow.tsx
+++ b/conductor-web/frontend/src/components/worktrees/WorktreeRow.tsx
@@ -8,13 +8,17 @@ export function WorktreeRow({
   worktree,
   latestRun,
   onDelete,
+  selected,
+  index,
 }: {
   worktree: Worktree;
   latestRun?: AgentRun;
   onDelete: (id: string) => void;
+  selected?: boolean;
+  index?: number;
 }) {
   return (
-    <tr>
+    <tr className={selected ? "bg-indigo-50 ring-1 ring-inset ring-indigo-200" : ""} data-list-index={index}>
       <td className="px-4 py-2">
         <Link
           to={`/repos/${worktree.repo_id}/worktrees/${worktree.id}`}

--- a/conductor-web/frontend/src/hooks/useHotkeys.ts
+++ b/conductor-web/frontend/src/hooks/useHotkeys.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from "react";
+
+export interface HotkeyDef {
+  key: string;
+  handler: () => void;
+  description: string;
+  enabled?: boolean;
+}
+
+export function useHotkeys(hotkeys: HotkeyDef[]) {
+  const hotkeysRef = useRef(hotkeys);
+  hotkeysRef.current = hotkeys;
+  const pendingRef = useRef<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const el = e.target as HTMLElement;
+      const tag = el?.tagName;
+      const isInput =
+        tag === "INPUT" ||
+        tag === "TEXTAREA" ||
+        tag === "SELECT" ||
+        el?.isContentEditable;
+
+      // Always allow Escape, even in inputs
+      if (isInput && e.key !== "Escape") return;
+
+      // Don't fire on modifier combos (allow Shift for ? etc.)
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      const current = hotkeysRef.current;
+
+      // Check for sequence match first (e.g., "g d")
+      if (pendingRef.current) {
+        const seq = pendingRef.current + " " + e.key;
+        pendingRef.current = null;
+        clearTimeout(timerRef.current);
+        const match = current.find(
+          (h) => h.key === seq && (h.enabled ?? true),
+        );
+        if (match) {
+          e.preventDefault();
+          match.handler();
+          return;
+        }
+        // No sequence match — fall through to check as standalone key
+      }
+
+      // Check if this key starts a sequence
+      const hasSequence = current.some(
+        (h) => h.key.startsWith(e.key + " ") && (h.enabled ?? true),
+      );
+      if (hasSequence) {
+        pendingRef.current = e.key;
+        timerRef.current = setTimeout(() => {
+          pendingRef.current = null;
+        }, 500);
+        return;
+      }
+
+      // Single key match
+      const match = current.find(
+        (h) => h.key === e.key && (h.enabled ?? true),
+      );
+      if (match) {
+        e.preventDefault();
+        match.handler();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      clearTimeout(timerRef.current);
+    };
+  }, []);
+}

--- a/conductor-web/frontend/src/hooks/useListNav.ts
+++ b/conductor-web/frontend/src/hooks/useListNav.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback, useEffect } from "react";
+
+export function useListNav(itemCount: number) {
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+
+  // Clamp selection when list shrinks
+  useEffect(() => {
+    if (selectedIndex >= itemCount) {
+      setSelectedIndex(itemCount > 0 ? itemCount - 1 : -1);
+    }
+  }, [itemCount, selectedIndex]);
+
+  // Scroll selected row into view
+  useEffect(() => {
+    if (selectedIndex < 0) return;
+    const row = document.querySelector(`[data-list-index="${selectedIndex}"]`);
+    row?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [selectedIndex]);
+
+  const moveDown = useCallback(() => {
+    setSelectedIndex((prev) =>
+      prev < itemCount - 1 ? prev + 1 : prev === -1 ? 0 : prev,
+    );
+  }, [itemCount]);
+
+  const moveUp = useCallback(() => {
+    setSelectedIndex((prev) => (prev > 0 ? prev - 1 : prev));
+  }, []);
+
+  const reset = useCallback(() => setSelectedIndex(-1), []);
+
+  return { selectedIndex, setSelectedIndex, moveDown, moveUp, reset };
+}

--- a/conductor-web/frontend/src/pages/SettingsPage.tsx
+++ b/conductor-web/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useApi } from "../hooks/useApi";
 import { api } from "../api/client";
 import type { WorkTarget } from "../api/types";
@@ -20,6 +20,20 @@ export function SettingsPage() {
   const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!showAdd) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setShowAdd(false);
+        setName("");
+        setCommand("");
+        setTargetType("editor");
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [showAdd]);
 
   async function handleAdd(e: React.FormEvent) {
     e.preventDefault();

--- a/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
+++ b/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   type ConductorEventType,
   type ConductorEventData,
 } from "../hooks/useConductorEvents";
+import { useHotkeys } from "../hooks/useHotkeys";
 
 export function WorktreeDetailPage() {
   const { repoId, worktreeId } = useParams<{
@@ -54,6 +55,10 @@ export function WorktreeDetailPage() {
   });
   const [agentLoading, setAgentLoading] = useState(false);
   const [stopConfirm, setStopConfirm] = useState(false);
+
+  useHotkeys([
+    { key: "d", handler: () => setDeleteConfirm(true), description: "Delete worktree", enabled: !deleteConfirm && !promptModalOpen && !stopConfirm },
+  ]);
 
   const worktree = worktrees?.find((w) => w.id === worktreeId);
   const linkedTicket = worktree?.ticket_id


### PR DESCRIPTION
Implements vim-style keyboard shortcuts for power-user navigation:
- Global: ? (help modal), g d/g t/g s (page navigation), Esc (close modals)
- Lists: j/k (navigate), Enter (open selected) on Dashboard, Tickets, Repo detail
- Actions: c (create repo/worktree), d (delete with confirmation), / (focus search)
- Adds useHotkeys hook with input suppression and sequence key support
- Adds useListNav hook for j/k selection state with scroll-into-view
- Adds Esc/Enter handling to ConfirmDialog and AgentPromptModal

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
