### PR TITLE
Add issue source management to Web UI and TUI (#100)

### DIFF
--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -46,6 +46,9 @@ pub enum Action {
     WorkTargetMoveDown,
     WorkTargetAdd,
     WorkTargetDelete,
+    ManageIssueSources,
+    IssueSourceAdd,
+    IssueSourceDelete,
 
     // Agent triggers (tmux-based)
     LaunchAgent,

--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -104,6 +104,16 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
                 _ => Action::None,
             };
         }
+        Modal::IssueSourceManager { .. } => {
+            return match key.code {
+                KeyCode::Esc => Action::DismissModal,
+                KeyCode::Up | KeyCode::Char('k') => Action::MoveUp,
+                KeyCode::Down | KeyCode::Char('j') => Action::MoveDown,
+                KeyCode::Char('a') => Action::IssueSourceAdd,
+                KeyCode::Char('d') => Action::IssueSourceDelete,
+                _ => Action::None,
+            };
+        }
         Modal::None => {}
     }
 
@@ -181,6 +191,7 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
         KeyCode::Char('l') => Action::LinkTicket,
         KeyCode::Char('w') => Action::StartWork,
         KeyCode::Char('W') => Action::ManageWorkTargets,
+        KeyCode::Char('S') => Action::ManageIssueSources,
         KeyCode::Char('o') => Action::OpenTicketUrl,
 
         // Direct view navigation

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -3,6 +3,7 @@ use std::fmt;
 
 use conductor_core::agent::{AgentEvent, AgentRun, TicketAgentTotals};
 use conductor_core::config::WorkTarget;
+use conductor_core::issue_source::IssueSource;
 use conductor_core::repo::Repo;
 use conductor_core::tickets::Ticket;
 use conductor_core::worktree::Worktree;
@@ -97,6 +98,13 @@ pub enum Modal {
         targets: Vec<WorkTarget>,
         selected: usize,
     },
+    IssueSourceManager {
+        repo_id: String,
+        repo_slug: String,
+        remote_url: String,
+        sources: Vec<IssueSource>,
+        selected: usize,
+    },
 }
 
 impl fmt::Debug for Modal {
@@ -116,6 +124,7 @@ impl fmt::Debug for Modal {
             Modal::TicketInfo { .. } => write!(f, "Modal::TicketInfo"),
             Modal::WorkTargetPicker { .. } => write!(f, "Modal::WorkTargetPicker"),
             Modal::WorkTargetManager { .. } => write!(f, "Modal::WorkTargetManager"),
+            Modal::IssueSourceManager { .. } => write!(f, "Modal::IssueSourceManager"),
         }
     }
 }
@@ -138,6 +147,12 @@ pub enum ConfirmAction {
         worktree_slug: String,
         ticket_id: String,
     },
+    DeleteIssueSource {
+        source_id: String,
+        repo_id: String,
+        repo_slug: String,
+        remote_url: String,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -150,9 +165,15 @@ pub struct FormField {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::enum_variant_names)]
 pub enum FormAction {
     AddRepo,
     AddWorkTarget,
+    AddIssueSource {
+        repo_id: String,
+        repo_slug: String,
+        remote_url: String,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/conductor-tui/src/ui/common.rs
+++ b/conductor-tui/src/ui/common.rs
@@ -46,7 +46,7 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, state: &AppState) {
                     .to_string()
             }
             View::RepoDetail => {
-                "j/k:nav  Enter:select  c:create  d:remove repo  Esc:back  ?:help".to_string()
+                "j/k:nav  Enter:select  c:create  d:remove  S:sources  Esc:back  ?:help".to_string()
             }
             View::WorktreeDetail => {
                 let has_running = state

--- a/conductor-tui/src/ui/help.rs
+++ b/conductor-tui/src/ui/help.rs
@@ -40,6 +40,7 @@ pub fn render(frame: &mut Frame, area: Rect) {
         help_line("l", "Link ticket to worktree"),
         help_line("w", "Open work target at worktree"),
         help_line("W", "Manage work targets"),
+        help_line("S", "Manage issue sources (repo detail)"),
         help_line("/", "Filter/search"),
         Line::from(""),
         Line::from(Span::styled(

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -74,5 +74,11 @@ pub fn render(frame: &mut Frame, state: &AppState) {
         Modal::WorkTargetManager { targets, selected } => {
             modal::render_work_target_manager(frame, area, targets, *selected)
         }
+        Modal::IssueSourceManager {
+            repo_slug,
+            sources,
+            selected,
+            ..
+        } => modal::render_issue_source_manager(frame, area, repo_slug, sources, *selected),
     }
 }

--- a/conductor-web/frontend/src/api/client.ts
+++ b/conductor-web/frontend/src/api/client.ts
@@ -14,6 +14,8 @@ import type {
   CreateWorkTargetRequest,
   PushResult,
   CreatePrResult,
+  IssueSource,
+  CreateIssueSourceRequest,
 } from "./types";
 
 const BASE = "/api";
@@ -114,5 +116,18 @@ export const api = {
     request<WorkTarget[]>("/config/work-targets", {
       method: "PUT",
       body: JSON.stringify(targets),
+    }),
+
+  // Issue Sources
+  listIssueSources: (repoId: string) =>
+    request<IssueSource[]>(`/repos/${repoId}/sources`),
+  createIssueSource: (repoId: string, data: CreateIssueSourceRequest) =>
+    request<IssueSource>(`/repos/${repoId}/sources`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  deleteIssueSource: (repoId: string, sourceId: string) =>
+    request<void>(`/repos/${repoId}/sources/${sourceId}`, {
+      method: "DELETE",
     }),
 };

--- a/conductor-web/frontend/src/api/types.ts
+++ b/conductor-web/frontend/src/api/types.ts
@@ -112,3 +112,15 @@ export interface TicketDetail {
   agent_totals: TicketAgentTotals | null;
   worktrees: Worktree[];
 }
+
+export interface IssueSource {
+  id: string;
+  repo_id: string;
+  source_type: string;
+  config_json: string;
+}
+
+export interface CreateIssueSourceRequest {
+  source_type: string;
+  config_json?: string;
+}

--- a/conductor-web/frontend/src/components/issue-sources/IssueSourcesSection.tsx
+++ b/conductor-web/frontend/src/components/issue-sources/IssueSourcesSection.tsx
@@ -1,0 +1,358 @@
+import { useState, useEffect } from "react";
+import { api } from "../../api/client";
+import type { IssueSource } from "../../api/types";
+import { LoadingSpinner } from "../shared/LoadingSpinner";
+import { EmptyState } from "../shared/EmptyState";
+import { ConfirmDialog } from "../shared/ConfirmDialog";
+
+interface Props {
+  repoId: string;
+  remoteUrl: string;
+  sources: IssueSource[];
+  loading: boolean;
+  onChanged: () => void;
+}
+
+function parseConfig(source: IssueSource): Record<string, string> {
+  try {
+    return JSON.parse(source.config_json);
+  } catch {
+    return {};
+  }
+}
+
+function formatConfig(source: IssueSource): string {
+  const cfg = parseConfig(source);
+  if (source.source_type === "github") {
+    return `${cfg.owner}/${cfg.repo}`;
+  }
+  if (source.source_type === "jira") {
+    return `${cfg.url} (${cfg.jql})`;
+  }
+  return source.config_json;
+}
+
+export function IssueSourcesSection({
+  repoId,
+  remoteUrl,
+  sources,
+  loading,
+  onChanged,
+}: Props) {
+  const [showAdd, setShowAdd] = useState(false);
+  const [sourceType, setSourceType] = useState<"github" | "jira">("github");
+  const [jiraUrl, setJiraUrl] = useState("");
+  const [jiraJql, setJiraJql] = useState("");
+  const [githubOwner, setGithubOwner] = useState("");
+  const [githubRepo, setGithubRepo] = useState("");
+  const [autoInferred, setAutoInferred] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<IssueSource | null>(null);
+
+  // Auto-infer GitHub owner/repo from remote URL
+  useEffect(() => {
+    if (sourceType !== "github") return;
+    const match =
+      remoteUrl.match(/github\.com[:/]([^/]+)\/([^/.]+)/) ?? null;
+    if (match) {
+      setGithubOwner(match[1]);
+      setGithubRepo(match[2]);
+      setAutoInferred(true);
+    } else {
+      setAutoInferred(false);
+    }
+  }, [remoteUrl, sourceType]);
+
+  useEffect(() => {
+    if (!showAdd) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        resetForm();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [showAdd]);
+
+  function resetForm() {
+    setShowAdd(false);
+    setSourceType("github");
+    setJiraUrl("");
+    setJiraJql("");
+    setGithubOwner("");
+    setGithubRepo("");
+    setAutoInferred(false);
+    setError(null);
+  }
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      if (sourceType === "github") {
+        // If user hasn't modified the auto-inferred values, let the backend infer
+        const configJson = autoInferred
+          ? undefined
+          : JSON.stringify({ owner: githubOwner.trim(), repo: githubRepo.trim() });
+        if (!autoInferred && (!githubOwner.trim() || !githubRepo.trim())) {
+          setError("GitHub owner and repo are required");
+          setSaving(false);
+          return;
+        }
+        await api.createIssueSource(repoId, {
+          source_type: "github",
+          config_json: configJson,
+        });
+      } else {
+        if (!jiraUrl.trim() || !jiraJql.trim()) {
+          setError("Jira URL and JQL are required");
+          setSaving(false);
+          return;
+        }
+        await api.createIssueSource(repoId, {
+          source_type: "jira",
+          config_json: JSON.stringify({
+            url: jiraUrl.trim(),
+            jql: jiraJql.trim(),
+          }),
+        });
+      }
+      resetForm();
+      onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add source");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await api.deleteIssueSource(repoId, deleteTarget.id);
+      setDeleteTarget(null);
+      onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const hasGithub = sources.some((s) => s.source_type === "github");
+  const hasJira = sources.some((s) => s.source_type === "jira");
+  const canAdd = !hasGithub || !hasJira;
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-400">
+            Issue Sources
+          </h3>
+          <p className="text-sm text-gray-500 mt-1">
+            Configure where tickets are synced from for this repo.
+          </p>
+        </div>
+        {canAdd && (
+          <button
+            onClick={() => {
+              // Default to whichever type isn't already added
+              if (hasGithub && !hasJira) setSourceType("jira");
+              else setSourceType("github");
+              setShowAdd(true);
+            }}
+            className="px-3 py-1.5 text-sm rounded-md bg-indigo-600 text-white hover:bg-indigo-700"
+          >
+            Add Source
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <div className="mb-3 px-3 py-2 text-sm text-red-700 bg-red-50 rounded-md border border-red-200">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <LoadingSpinner />
+      ) : sources.length === 0 ? (
+        <EmptyState message="No issue sources configured" />
+      ) : (
+        <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-left text-xs text-gray-500 uppercase">
+              <tr>
+                <th className="px-4 py-2">Type</th>
+                <th className="px-4 py-2">Config</th>
+                <th className="px-4 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {sources.map((source) => (
+                <tr key={source.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-2">
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                        source.source_type === "github"
+                          ? "bg-gray-800 text-white"
+                          : "bg-blue-100 text-blue-700"
+                      }`}
+                    >
+                      {source.source_type}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-gray-600 font-mono text-xs">
+                    {formatConfig(source)}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <button
+                      onClick={() => setDeleteTarget(source)}
+                      disabled={saving}
+                      className="px-2 py-1 text-xs rounded border border-red-300 text-red-600 hover:bg-red-50 disabled:opacity-50"
+                    >
+                      Remove
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Add Issue Source Dialog */}
+      {showAdd && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-lg shadow-lg p-6 max-w-sm w-full mx-4">
+            <h3 className="text-lg font-semibold text-gray-900">
+              Add Issue Source
+            </h3>
+            <form onSubmit={handleAdd} className="mt-4 space-y-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Source Type
+                </label>
+                <select
+                  value={sourceType}
+                  onChange={(e) =>
+                    setSourceType(e.target.value as "github" | "jira")
+                  }
+                  className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500"
+                >
+                  {!hasGithub && <option value="github">GitHub</option>}
+                  {!hasJira && <option value="jira">Jira</option>}
+                </select>
+              </div>
+
+              {sourceType === "github" && (
+                <>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Owner
+                    </label>
+                    <input
+                      type="text"
+                      value={githubOwner}
+                      onChange={(e) => {
+                        setGithubOwner(e.target.value);
+                        setAutoInferred(false);
+                      }}
+                      placeholder="e.g. octocat"
+                      className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Repository
+                    </label>
+                    <input
+                      type="text"
+                      value={githubRepo}
+                      onChange={(e) => {
+                        setGithubRepo(e.target.value);
+                        setAutoInferred(false);
+                      }}
+                      placeholder="e.g. my-project"
+                      className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500"
+                    />
+                  </div>
+                  {autoInferred && (
+                    <p className="text-xs text-green-600">
+                      Auto-inferred from remote URL
+                    </p>
+                  )}
+                </>
+              )}
+
+              {sourceType === "jira" && (
+                <>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Jira URL
+                    </label>
+                    <input
+                      type="text"
+                      value={jiraUrl}
+                      onChange={(e) => setJiraUrl(e.target.value)}
+                      placeholder="e.g. https://mycompany.atlassian.net"
+                      className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500"
+                      autoFocus
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      JQL Query
+                    </label>
+                    <input
+                      type="text"
+                      value={jiraJql}
+                      onChange={(e) => setJiraJql(e.target.value)}
+                      placeholder='e.g. project = PROJ AND status != Done'
+                      className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500"
+                    />
+                  </div>
+                </>
+              )}
+
+              <div className="flex justify-end gap-2 pt-2">
+                <button
+                  type="button"
+                  onClick={resetForm}
+                  className="px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className="px-3 py-1.5 text-sm rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
+                >
+                  {saving ? "Adding..." : "Add"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation */}
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title="Remove Issue Source"
+        message={
+          deleteTarget
+            ? `Remove ${deleteTarget.source_type} source? You will need to re-add it to sync tickets from this source.`
+            : ""
+        }
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </section>
+  );
+}

--- a/conductor-web/frontend/src/hooks/useConductorEvents.ts
+++ b/conductor-web/frontend/src/hooks/useConductorEvents.ts
@@ -11,6 +11,7 @@ export type ConductorEventType =
   | "agent_stopped"
   | "agent_event"
   | "work_targets_changed"
+  | "issue_sources_changed"
   | "lagged";
 
 export interface ConductorEventData {
@@ -59,6 +60,7 @@ export function useConductorEvents(
       "agent_stopped",
       "agent_event",
       "work_targets_changed",
+      "issue_sources_changed",
       "lagged",
     ];
 

--- a/conductor-web/frontend/src/pages/RepoDetailPage.tsx
+++ b/conductor-web/frontend/src/pages/RepoDetailPage.tsx
@@ -8,6 +8,7 @@ import { WorktreeRow } from "../components/worktrees/WorktreeRow";
 import { CreateWorktreeForm } from "../components/worktrees/CreateWorktreeForm";
 import { TicketRow } from "../components/tickets/TicketRow";
 import { TicketDetailModal } from "../components/tickets/TicketDetailModal";
+import { IssueSourcesSection } from "../components/issue-sources/IssueSourcesSection";
 import { ConfirmDialog } from "../components/shared/ConfirmDialog";
 import { LoadingSpinner } from "../components/shared/LoadingSpinner";
 import { EmptyState } from "../components/shared/EmptyState";
@@ -45,6 +46,12 @@ export function RepoDetailPage() {
     [],
   );
 
+  const {
+    data: issueSources,
+    loading: sourcesLoading,
+    refetch: refetchSources,
+  } = useApi(() => api.listIssueSources(repoId!), [repoId]);
+
   const sseHandlers = useMemo(() => {
     const handleWorktreeChange = (ev: ConductorEventData) => {
       if (!ev.data || ev.data.repo_id === repoId) refetchWorktrees();
@@ -64,9 +71,12 @@ export function RepoDetailPage() {
       tickets_synced: handleTicketsChange,
       agent_started: handleAgentChange,
       agent_stopped: handleAgentChange,
+      issue_sources_changed: (ev: ConductorEventData) => {
+        if (!ev.data || ev.data.repo_id === repoId) refetchSources();
+      },
     };
     return map;
-  }, [repoId, refetchWorktrees, refetchTickets, refetchRuns, refetchTotals]);
+  }, [repoId, refetchWorktrees, refetchTickets, refetchRuns, refetchTotals, refetchSources]);
 
   useConductorEvents(sseHandlers);
 
@@ -175,6 +185,15 @@ export function RepoDetailPage() {
           <dd>{repo.default_branch}</dd>
         </dl>
       </div>
+
+      {/* Issue Sources */}
+      <IssueSourcesSection
+        repoId={repoId!}
+        remoteUrl={repo.remote_url}
+        sources={issueSources ?? []}
+        loading={sourcesLoading}
+        onChanged={refetchSources}
+      />
 
       {/* Worktrees */}
       <section>

--- a/conductor-web/src/events.rs
+++ b/conductor-web/src/events.rs
@@ -23,6 +23,8 @@ pub enum ConductorEvent {
     AgentEvent { run_id: String, worktree_id: String },
     #[serde(rename = "work_targets_changed")]
     WorkTargetsChanged,
+    #[serde(rename = "issue_sources_changed")]
+    IssueSourcesChanged { repo_id: String },
 }
 
 impl ConductorEvent {
@@ -38,6 +40,7 @@ impl ConductorEvent {
             Self::AgentStopped { .. } => "agent_stopped",
             Self::AgentEvent { .. } => "agent_event",
             Self::WorkTargetsChanged => "work_targets_changed",
+            Self::IssueSourcesChanged { .. } => "issue_sources_changed",
         }
     }
 }
@@ -149,6 +152,10 @@ mod tests {
                 "agent_event",
             ),
             (ConductorEvent::WorkTargetsChanged, "work_targets_changed"),
+            (
+                ConductorEvent::IssueSourcesChanged { repo_id: "".into() },
+                "issue_sources_changed",
+            ),
         ];
         for (event, expected) in cases {
             assert_eq!(event.event_name(), expected);

--- a/conductor-web/src/routes/issue_sources.rs
+++ b/conductor-web/src/routes/issue_sources.rs
@@ -1,0 +1,105 @@
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde::Deserialize;
+
+use conductor_core::github::parse_github_remote;
+use conductor_core::issue_source::{IssueSource, IssueSourceManager};
+use conductor_core::repo::RepoManager;
+
+use crate::error::ApiError;
+use crate::events::ConductorEvent;
+use crate::state::AppState;
+
+#[derive(Deserialize)]
+pub struct CreateIssueSourceRequest {
+    pub source_type: String,
+    pub config_json: Option<String>,
+}
+
+pub async fn list_issue_sources(
+    State(state): State<AppState>,
+    Path(repo_id): Path<String>,
+) -> Result<Json<Vec<IssueSource>>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = IssueSourceManager::new(&db);
+    let sources = mgr.list(&repo_id)?;
+    Ok(Json(sources))
+}
+
+pub async fn create_issue_source(
+    State(state): State<AppState>,
+    Path(repo_id): Path<String>,
+    Json(body): Json<CreateIssueSourceRequest>,
+) -> Result<(StatusCode, Json<IssueSource>), ApiError> {
+    let db = state.db.lock().await;
+    let config = state.config.read().await;
+    let repo_mgr = RepoManager::new(&db, &config);
+
+    // Look up the repo to get its slug and remote_url
+    let repos = repo_mgr.list()?;
+    let repo = repos.iter().find(|r| r.id == repo_id).ok_or_else(|| {
+        conductor_core::error::ConductorError::RepoNotFound {
+            slug: repo_id.clone(),
+        }
+    })?;
+
+    let config_json = match body.source_type.as_str() {
+        "github" => {
+            if let Some(ref json) = body.config_json {
+                json.clone()
+            } else {
+                // Auto-infer from remote URL
+                let (owner, repo_name) = parse_github_remote(&repo.remote_url).ok_or_else(
+                    || {
+                        conductor_core::error::ConductorError::TicketSync(
+                            "Cannot infer GitHub owner/repo from remote URL. Provide config_json manually.".to_string(),
+                        )
+                    },
+                )?;
+                serde_json::json!({"owner": owner, "repo": repo_name}).to_string()
+            }
+        }
+        "jira" => body.config_json.clone().ok_or_else(|| {
+            conductor_core::error::ConductorError::TicketSync(
+                "Jira sources require config_json with jql and url fields".to_string(),
+            )
+        })?,
+        _ => {
+            return Err(ApiError(conductor_core::error::ConductorError::TicketSync(
+                format!("Unknown source type: {}", body.source_type),
+            )));
+        }
+    };
+
+    // Validate JSON
+    serde_json::from_str::<serde_json::Value>(&config_json).map_err(|e| {
+        ApiError(conductor_core::error::ConductorError::TicketSync(format!(
+            "Invalid config JSON: {e}"
+        )))
+    })?;
+
+    let source_mgr = IssueSourceManager::new(&db);
+    let source = source_mgr.add(&repo_id, &body.source_type, &config_json, &repo.slug)?;
+
+    state.events.emit(ConductorEvent::IssueSourcesChanged {
+        repo_id: repo_id.clone(),
+    });
+
+    Ok((StatusCode::CREATED, Json(source)))
+}
+
+pub async fn delete_issue_source(
+    State(state): State<AppState>,
+    Path((repo_id, source_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = IssueSourceManager::new(&db);
+    mgr.remove(&source_id)?;
+
+    state
+        .events
+        .emit(ConductorEvent::IssueSourcesChanged { repo_id });
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/conductor-web/src/routes/mod.rs
+++ b/conductor-web/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod agents;
 pub mod events;
+pub mod issue_sources;
 pub mod repos;
 pub mod tickets;
 pub mod work_targets;
@@ -57,6 +58,15 @@ pub fn api_router() -> Router<AppState> {
         .route("/api/worktrees/{id}/agent/stop", post(agents::stop_agent))
         .route("/api/worktrees/{id}/agent/events", get(agents::get_events))
         .route("/api/worktrees/{id}/agent/prompt", get(agents::get_prompt))
+        // Issue Sources
+        .route(
+            "/api/repos/{id}/sources",
+            get(issue_sources::list_issue_sources).post(issue_sources::create_issue_source),
+        )
+        .route(
+            "/api/repos/{id}/sources/{source_id}",
+            delete(issue_sources::delete_issue_source),
+        )
         // Work Targets
         .route(
             "/api/config/work-targets",


### PR DESCRIPTION
Add full CRUD for issue sources (GitHub and Jira) in both the web UI and
TUI. GitHub sources auto-infer owner/repo from the remote URL; Jira
sources accept a base URL and JQL query.

Web UI:
- New API routes: GET/POST /api/repos/:id/sources, DELETE /api/repos/:id/sources/:source_id
- IssueSourcesSection component on the repo detail page
- SSE event for real-time source updates

TUI:
- S keybinding opens Issue Source Manager modal from repo detail view
- Dynamic form: typing "jira" reveals JQL and URL fields inline
- Source list displays config on indented lines with line wrapping
- S:sources shown in repo detail status bar and help screen

Includes 8 new API integration tests.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
