### PR TITLE
Add pre-commit hook for cargo fmt

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Pre-commit hook: enforce rustfmt formatting.
+# Enable with: git config core.hooksPath .githooks
+
+set -e
+
+if ! cargo fmt --all --check 2>/dev/null; then
+  echo "error: rustfmt check failed. Run 'cargo fmt --all' to fix." >&2
+  exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ cargo test                     # Run all tests
 cargo test --lib github        # Run specific module tests (e.g., github)
 cargo test -p conductor-core   # Test a single crate
 cargo clippy -- -D warnings    # Lint (CI enforces -D warnings)
-cargo fmt --check              # Check formatting
+cargo fmt --all                # Auto-format
+cargo fmt --all --check        # Check formatting (CI gate)
 cargo build --bin conductor     # Build CLI only
 cargo build --bin conductor-tui # Build TUI only
 cargo build --bin conductor-web # Build web UI (requires frontend built first)
@@ -21,6 +22,9 @@ cd conductor-web/frontend && npm install && npm run build
 ```
 
 No Makefile/justfile — use `cargo` directly.
+
+# One-time dev setup: enable pre-commit hook that runs cargo fmt --all --check
+git config core.hooksPath .githooks
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Adds a pre-commit hook that runs `cargo fmt --all --check` to catch formatting issues before commit

## Test plan
- [x] Clone fresh and run `git config core.hooksPath .githooks` to enable the hook
- [x] Make an unformatted change and verify the commit is blocked
- [x] Verify formatted code commits normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)