### PR TITLE
Persist parsed agent events to the database (#109)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ name = "conductor-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "conductor-core",
  "rusqlite",
@@ -326,6 +327,7 @@ dependencies = [
  "rusqlite",
  "serde_json",
  "tui-textarea",
+ "ulid",
 ]
 
 [[package]]

--- a/conductor-cli/Cargo.toml
+++ b/conductor-cli/Cargo.toml
@@ -17,3 +17,4 @@ anyhow = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
+chrono = { version = "0.4", features = ["serde"] }

--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -4,7 +4,7 @@ use std::process::{Command, Stdio};
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-use conductor_core::agent::AgentManager;
+use conductor_core::agent::{parse_events_from_line, AgentManager};
 use conductor_core::config::{ensure_dirs, load_config};
 use conductor_core::db::open_database;
 use conductor_core::github;
@@ -638,6 +638,9 @@ fn run_agent(
     let mut duration_ms: Option<i64> = None;
     let mut is_error = false;
 
+    // Track the last persisted event span so we can fill its ended_at
+    let mut last_event_id: Option<String> = None;
+
     if let Some(stdout) = child.stdout.take() {
         let reader = std::io::BufReader::new(stdout);
         for line in reader.lines() {
@@ -674,10 +677,34 @@ fn run_agent(
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
             }
+
+            // Persist parsed events to DB as spans
+            let parsed = parse_events_from_line(&line);
+            if !parsed.is_empty() {
+                let now = chrono::Utc::now().to_rfc3339();
+                // Close the previous span
+                if let Some(ref prev_id) = last_event_id {
+                    let _ = mgr.update_event_ended_at(prev_id, &now);
+                }
+                // Create a new span for each parsed event; only the last one stays open
+                for ev in &parsed {
+                    match mgr.create_event(run_id, &ev.kind, &ev.summary, &now, None) {
+                        Ok(db_ev) => last_event_id = Some(db_ev.id),
+                        Err(e) => eprintln!("[conductor] Warning: could not persist event: {e}"),
+                    }
+                }
+            }
         }
     }
 
     let status = child.wait();
+
+    let end_time = chrono::Utc::now().to_rfc3339();
+
+    // Close the last open event span
+    if let Some(ref prev_id) = last_event_id {
+        let _ = mgr.update_event_ended_at(prev_id, &end_time);
+    }
 
     match status {
         Ok(s) if s.success() && !is_error => {
@@ -699,7 +726,7 @@ fn run_agent(
                 );
             }
         }
-        Ok(s) if is_error => {
+        Ok(_) if is_error => {
             let error_msg = result_text.as_deref().unwrap_or("Claude reported an error");
             mgr.update_run_failed(run_id, error_msg)?;
             eprintln!("[conductor] Agent failed: {}", error_msg);

--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -43,6 +43,132 @@ pub struct AgentEvent {
     pub summary: String,
 }
 
+/// A persisted agent run event (trace/span model) stored in `agent_run_events`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentRunEvent {
+    pub id: String,
+    pub run_id: String,
+    pub kind: String,
+    pub summary: String,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub metadata: Option<String>,
+}
+
+impl AgentRunEvent {
+    /// Duration in milliseconds, if both timestamps are present and parseable.
+    pub fn duration_ms(&self) -> Option<i64> {
+        let start = chrono::DateTime::parse_from_rfc3339(&self.started_at).ok()?;
+        let end = chrono::DateTime::parse_from_rfc3339(self.ended_at.as_ref()?).ok()?;
+        Some((end - start).num_milliseconds().max(0))
+    }
+}
+
+/// Parse a single stream-json log line into zero or more display events.
+pub fn parse_events_from_line(line: &str) -> Vec<AgentEvent> {
+    let line = line.trim();
+    if line.is_empty() {
+        return Vec::new();
+    }
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+        return Vec::new();
+    };
+
+    let mut events = Vec::new();
+    let event_type = value.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+    match event_type {
+        "system" => {
+            let subtype = value.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
+            if subtype == "init" {
+                let model = value
+                    .get("model")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                events.push(AgentEvent {
+                    kind: "system".to_string(),
+                    summary: format!("Session started (model: {model})"),
+                });
+            }
+        }
+        "assistant" => {
+            let content = value
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_array());
+
+            if let Some(blocks) = content {
+                for block in blocks {
+                    let block_type = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                    match block_type {
+                        "text" => {
+                            if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
+                                for text_line in text.lines() {
+                                    let trimmed = text_line.trim();
+                                    if !trimmed.is_empty() {
+                                        events.push(AgentEvent {
+                                            kind: "text".to_string(),
+                                            summary: trimmed.to_string(),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                        "tool_use" => {
+                            let tool_name = block
+                                .get("name")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown");
+                            let input = block.get("input");
+                            let desc = tool_summary(tool_name, input);
+                            events.push(AgentEvent {
+                                kind: "tool".to_string(),
+                                summary: desc,
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        "result" => {
+            let cost = value
+                .get("total_cost_usd")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            let turns = value.get("num_turns").and_then(|v| v.as_i64()).unwrap_or(0);
+            let dur_ms = value
+                .get("duration_ms")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            let dur_s = dur_ms as f64 / 1000.0;
+            let is_error = value
+                .get("is_error")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if is_error {
+                let err_text = value
+                    .get("result")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown error");
+                events.push(AgentEvent {
+                    kind: "error".to_string(),
+                    summary: format!("Error: {err_text}"),
+                });
+            } else {
+                events.push(AgentEvent {
+                    kind: "result".to_string(),
+                    summary: format!("${cost:.4} · {turns} turns · {dur_s:.1}s"),
+                });
+            }
+        }
+        // Skip "user" and "rate_limit_event" — noise
+        _ => {}
+    }
+
+    events
+}
+
 /// Parse a stream-json agent log file into displayable events.
 /// Each line is a JSON object with a `type` field.
 pub fn parse_agent_log(path: &str) -> Vec<AgentEvent> {
@@ -51,108 +177,9 @@ pub fn parse_agent_log(path: &str) -> Vec<AgentEvent> {
     };
 
     let mut events = Vec::new();
-
     for line in contents.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-
-        let event_type = value.get("type").and_then(|v| v.as_str()).unwrap_or("");
-
-        match event_type {
-            "system" => {
-                let subtype = value.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
-                if subtype == "init" {
-                    let model = value
-                        .get("model")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("unknown");
-                    events.push(AgentEvent {
-                        kind: "system".to_string(),
-                        summary: format!("Session started (model: {model})"),
-                    });
-                }
-            }
-            "assistant" => {
-                let content = value
-                    .get("message")
-                    .and_then(|m| m.get("content"))
-                    .and_then(|c| c.as_array());
-
-                if let Some(blocks) = content {
-                    for block in blocks {
-                        let block_type = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
-                        match block_type {
-                            "text" => {
-                                if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
-                                    for line in text.lines() {
-                                        let trimmed = line.trim();
-                                        if !trimmed.is_empty() {
-                                            events.push(AgentEvent {
-                                                kind: "text".to_string(),
-                                                summary: trimmed.to_string(),
-                                            });
-                                        }
-                                    }
-                                }
-                            }
-                            "tool_use" => {
-                                let tool_name = block
-                                    .get("name")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("unknown");
-                                let input = block.get("input");
-                                let desc = tool_summary(tool_name, input);
-                                events.push(AgentEvent {
-                                    kind: "tool".to_string(),
-                                    summary: desc,
-                                });
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            }
-            "result" => {
-                let cost = value
-                    .get("total_cost_usd")
-                    .and_then(|v| v.as_f64())
-                    .unwrap_or(0.0);
-                let turns = value.get("num_turns").and_then(|v| v.as_i64()).unwrap_or(0);
-                let dur_ms = value
-                    .get("duration_ms")
-                    .and_then(|v| v.as_i64())
-                    .unwrap_or(0);
-                let dur_s = dur_ms as f64 / 1000.0;
-                let is_error = value
-                    .get("is_error")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
-                if is_error {
-                    let err_text = value
-                        .get("result")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("unknown error");
-                    events.push(AgentEvent {
-                        kind: "error".to_string(),
-                        summary: format!("Error: {err_text}"),
-                    });
-                } else {
-                    events.push(AgentEvent {
-                        kind: "result".to_string(),
-                        summary: format!("${cost:.4} · {turns} turns · {dur_s:.1}s"),
-                    });
-                }
-            }
-            // Skip "user" and "rate_limit_event" — noise
-            _ => {}
-        }
+        events.extend(parse_events_from_line(line));
     }
-
     events
 }
 
@@ -419,6 +446,74 @@ impl<'a> AgentManager<'a> {
         Ok(map)
     }
 
+    /// Persist a new event span for a run. Returns the created event.
+    pub fn create_event(
+        &self,
+        run_id: &str,
+        kind: &str,
+        summary: &str,
+        started_at: &str,
+        metadata: Option<&str>,
+    ) -> Result<AgentRunEvent> {
+        let id = ulid::Ulid::new().to_string();
+        let event = AgentRunEvent {
+            id: id.clone(),
+            run_id: run_id.to_string(),
+            kind: kind.to_string(),
+            summary: summary.to_string(),
+            started_at: started_at.to_string(),
+            ended_at: None,
+            metadata: metadata.map(String::from),
+        };
+        self.conn.execute(
+            "INSERT INTO agent_run_events (id, run_id, kind, summary, started_at, metadata) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                event.id,
+                event.run_id,
+                event.kind,
+                event.summary,
+                event.started_at,
+                event.metadata
+            ],
+        )?;
+        Ok(event)
+    }
+
+    /// Set the ended_at timestamp for a previously created event span.
+    pub fn update_event_ended_at(&self, event_id: &str, ended_at: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE agent_run_events SET ended_at = ?1 WHERE id = ?2",
+            params![ended_at, event_id],
+        )?;
+        Ok(())
+    }
+
+    /// List all events for a run in chronological order.
+    pub fn list_events_for_run(&self, run_id: &str) -> Result<Vec<AgentRunEvent>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, run_id, kind, summary, started_at, ended_at, metadata \
+             FROM agent_run_events WHERE run_id = ?1 ORDER BY started_at ASC",
+        )?;
+        let rows = stmt.query_map(params![run_id], row_to_agent_run_event)?;
+        let events = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(events)
+    }
+
+    /// List all events across all runs for a worktree, in chronological order.
+    pub fn list_events_for_worktree(&self, worktree_id: &str) -> Result<Vec<AgentRunEvent>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT e.id, e.run_id, e.kind, e.summary, e.started_at, e.ended_at, e.metadata \
+             FROM agent_run_events e \
+             JOIN agent_runs r ON e.run_id = r.id \
+             WHERE r.worktree_id = ?1 \
+             ORDER BY e.started_at ASC",
+        )?;
+        let rows = stmt.query_map(params![worktree_id], row_to_agent_run_event)?;
+        let events = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(events)
+    }
+
     /// Returns the latest agent run for each worktree, keyed by worktree_id.
     pub fn latest_runs_by_worktree(&self) -> Result<HashMap<String, AgentRun>> {
         let mut stmt = self.conn.prepare(
@@ -440,6 +535,18 @@ impl<'a> AgentManager<'a> {
         }
         Ok(map)
     }
+}
+
+fn row_to_agent_run_event(row: &rusqlite::Row) -> rusqlite::Result<AgentRunEvent> {
+    Ok(AgentRunEvent {
+        id: row.get(0)?,
+        run_id: row.get(1)?,
+        kind: row.get(2)?,
+        summary: row.get(3)?,
+        started_at: row.get(4)?,
+        ended_at: row.get(5)?,
+        metadata: row.get(6)?,
+    })
 }
 
 fn row_to_agent_run(row: &rusqlite::Row) -> rusqlite::Result<AgentRun> {
@@ -700,5 +807,132 @@ mod tests {
         assert_eq!(result.num_turns, Some(3));
         assert_eq!(result.duration_ms, Some(15000));
         assert_eq!(result.is_error, Some(false));
+    }
+
+    #[test]
+    fn test_create_and_list_events() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None).unwrap();
+        let t0 = "2024-01-01T00:00:00Z";
+        let t1 = "2024-01-01T00:00:02Z";
+        let t2 = "2024-01-01T00:00:05Z";
+
+        let ev1 = mgr
+            .create_event(&run.id, "system", "Session started", t0, None)
+            .unwrap();
+        let ev2 = mgr
+            .create_event(&run.id, "tool", "[Bash] cargo build", t1, None)
+            .unwrap();
+        mgr.update_event_ended_at(&ev1.id, t1).unwrap();
+        mgr.update_event_ended_at(&ev2.id, t2).unwrap();
+
+        let events = mgr.list_events_for_run(&run.id).unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind, "system");
+        assert_eq!(events[0].ended_at.as_deref(), Some(t1));
+        assert_eq!(events[1].kind, "tool");
+        assert_eq!(events[1].summary, "[Bash] cargo build");
+        assert_eq!(events[1].ended_at.as_deref(), Some(t2));
+
+        // duration_ms computed from timestamps
+        let dur = events[1].duration_ms().unwrap();
+        assert_eq!(dur, 3000);
+    }
+
+    #[test]
+    fn test_list_events_for_worktree() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run1 = mgr.create_run("w1", "First task", None).unwrap();
+        let run2 = mgr.create_run("w1", "Second task", None).unwrap();
+        let run3 = mgr.create_run("w2", "Other task", None).unwrap();
+
+        let t = "2024-01-01T00:00:00Z";
+        mgr.create_event(&run1.id, "text", "Planning", t, None)
+            .unwrap();
+        mgr.create_event(&run1.id, "tool", "[Read] file.rs", t, None)
+            .unwrap();
+        mgr.create_event(&run2.id, "result", "$0.0010 · 1 turns · 1.0s", t, None)
+            .unwrap();
+        // run3 belongs to a different worktree
+        mgr.create_event(&run3.id, "text", "Other wt event", t, None)
+            .unwrap();
+
+        let w1_events = mgr.list_events_for_worktree("w1").unwrap();
+        assert_eq!(w1_events.len(), 3);
+
+        let w2_events = mgr.list_events_for_worktree("w2").unwrap();
+        assert_eq!(w2_events.len(), 1);
+        assert_eq!(w2_events[0].summary, "Other wt event");
+    }
+
+    #[test]
+    fn test_events_cascade_delete_on_run_removal() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None).unwrap();
+        let t = "2024-01-01T00:00:00Z";
+        mgr.create_event(&run.id, "text", "hello", t, None).unwrap();
+        mgr.create_event(&run.id, "tool", "[Bash] ls", t, None)
+            .unwrap();
+
+        // Deleting the run should cascade to events
+        conn.execute(
+            "DELETE FROM agent_runs WHERE id = ?1",
+            rusqlite::params![run.id],
+        )
+        .unwrap();
+
+        let events = mgr.list_events_for_run(&run.id).unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_parse_events_from_line_system_init() {
+        let line = r#"{"type":"system","subtype":"init","model":"claude-opus-4-5"}"#;
+        let events = parse_events_from_line(line);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "system");
+        assert!(events[0].summary.contains("claude-opus-4-5"));
+    }
+
+    #[test]
+    fn test_parse_events_from_line_tool_use() {
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"description":"run tests"}}]}}"#;
+        let events = parse_events_from_line(line);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "tool");
+        assert!(events[0].summary.contains("Bash"));
+        assert!(events[0].summary.contains("run tests"));
+    }
+
+    #[test]
+    fn test_parse_events_from_line_unknown_type() {
+        let line = r#"{"type":"rate_limit_event"}"#;
+        let events = parse_events_from_line(line);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_parse_agent_log_uses_from_line() {
+        // parse_agent_log should produce same results as iterating parse_events_from_line
+        let line1 = r#"{"type":"system","subtype":"init","model":"claude-3"}"#;
+        let line2 =
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello"}]}}"#;
+        let content = format!("{line1}\n{line2}\n");
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), &content).unwrap();
+        let path = tmp.path().to_string_lossy().to_string();
+
+        let events = parse_agent_log(&path);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind, "system");
+        assert_eq!(events[1].kind, "text");
+        assert_eq!(events[1].summary, "Hello");
     }
 }

--- a/conductor-core/src/db/migrations.rs
+++ b/conductor-core/src/db/migrations.rs
@@ -90,5 +90,19 @@ pub fn run(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    // Migration 007: add agent_run_events table (trace/span model).
+    let has_agent_run_events: bool = conn
+        .prepare("SELECT id FROM agent_run_events LIMIT 0")
+        .is_ok();
+    if !has_agent_run_events {
+        conn.execute_batch(include_str!("migrations/007_agent_run_events.sql"))?;
+    }
+    if version < 7 {
+        conn.execute(
+            "INSERT OR REPLACE INTO _conductor_meta (key, value) VALUES ('schema_version', '7')",
+            [],
+        )?;
+    }
+
     Ok(())
 }

--- a/conductor-core/src/db/migrations/007_agent_run_events.sql
+++ b/conductor-core/src/db/migrations/007_agent_run_events.sql
@@ -1,0 +1,11 @@
+CREATE TABLE agent_run_events (
+    id         TEXT PRIMARY KEY,
+    run_id     TEXT NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+    kind       TEXT NOT NULL,
+    summary    TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    ended_at   TEXT,
+    metadata   TEXT
+);
+
+CREATE INDEX idx_agent_run_events_run_id ON agent_run_events(run_id);

--- a/conductor-tui/Cargo.toml
+++ b/conductor-tui/Cargo.toml
@@ -19,3 +19,4 @@ chrono = "0.4"
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde_json = "1"
 tui-textarea = "0.7"
+ulid = "1"

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -358,7 +358,9 @@ impl App {
     }
 
     fn reload_agent_events(&mut self) {
-        use conductor_core::agent::{count_turns_in_log, parse_agent_log, AgentManager};
+        use conductor_core::agent::{
+            count_turns_in_log, parse_agent_log, AgentManager, AgentRunEvent,
+        };
 
         use crate::state::AgentTotals;
 
@@ -395,15 +397,31 @@ impl App {
 
         self.state.data.agent_totals = totals;
 
-        let mut all_events = Vec::new();
-        for run in &runs {
-            if let Some(ref path) = run.log_file {
-                let events = parse_agent_log(path);
-                if !events.is_empty() {
-                    all_events.extend(events);
+        // Load events: prefer DB records, fall back to log file parsing for older runs
+        let db_events = mgr.list_events_for_worktree(wt_id).unwrap_or_default();
+        let all_events = if !db_events.is_empty() {
+            db_events
+        } else {
+            // Backward compat: parse log files and wrap as AgentRunEvent without timing
+            let mut fallback = Vec::new();
+            for run in &runs {
+                if let Some(ref path) = run.log_file {
+                    let events = parse_agent_log(path);
+                    for ev in events {
+                        fallback.push(AgentRunEvent {
+                            id: ulid::Ulid::new().to_string(),
+                            run_id: run.id.clone(),
+                            kind: ev.kind,
+                            summary: ev.summary,
+                            started_at: run.started_at.clone(),
+                            ended_at: None,
+                            metadata: None,
+                        });
+                    }
                 }
             }
-        }
+            fallback
+        };
 
         self.state.data.agent_events = all_events;
         // Clamp scroll index

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use conductor_core::agent::{AgentEvent, AgentRun, TicketAgentTotals};
+use conductor_core::agent::{AgentRun, AgentRunEvent, TicketAgentTotals};
 use conductor_core::config::WorkTarget;
 use conductor_core::issue_source::IssueSource;
 use conductor_core::repo::Repo;
@@ -206,8 +206,8 @@ pub struct DataCache {
     pub repo_worktree_count: HashMap<String, usize>,
     /// worktree_id -> latest AgentRun (populated by DB poller)
     pub latest_agent_runs: HashMap<String, AgentRun>,
-    /// Parsed agent events for the currently viewed worktree
-    pub agent_events: Vec<AgentEvent>,
+    /// Persisted agent events for the currently viewed worktree (from DB)
+    pub agent_events: Vec<AgentRunEvent>,
     /// Aggregate stats across all agent runs for the currently viewed worktree
     pub agent_totals: AgentTotals,
     /// ticket_id -> aggregated agent stats across all linked worktrees

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -167,7 +167,17 @@ fn render_agent_activity(frame: &mut Frame, area: Rect, state: &AppState) {
         .iter()
         .map(|ev| {
             let style = event_style(&ev.kind);
-            Line::from(Span::styled(&ev.summary, style))
+            let mut spans = vec![Span::styled(ev.summary.clone(), style)];
+            if let Some(dur) = ev.duration_ms() {
+                if dur >= 100 {
+                    let dur_s = dur as f64 / 1000.0;
+                    spans.push(Span::styled(
+                        format!("  ({dur_s:.1}s)"),
+                        Style::default().fg(Color::DarkGray),
+                    ));
+                }
+            }
+            Line::from(spans)
         })
         .collect();
 

--- a/conductor-web/frontend/src/api/types.ts
+++ b/conductor-web/frontend/src/api/types.ts
@@ -79,8 +79,14 @@ export interface AgentRun {
 }
 
 export interface AgentEvent {
+  id: string;
+  run_id: string;
   kind: "text" | "tool" | "result" | "system" | "error";
   summary: string;
+  started_at: string;
+  ended_at: string | null;
+  duration_ms: number | null;
+  metadata: string | null;
 }
 
 export interface AgentPromptInfo {

--- a/conductor-web/frontend/src/components/agents/AgentActivityLog.tsx
+++ b/conductor-web/frontend/src/components/agents/AgentActivityLog.tsx
@@ -88,9 +88,16 @@ export function AgentActivityLog({ events, isRunning }: AgentActivityLogProps) {
             >
               {cfg.label}
             </span>
-            <span className={`${cfg.text} leading-snug break-words min-w-0`}>
+            <span className={`${cfg.text} leading-snug break-words min-w-0 flex-1`}>
               {event.summary}
             </span>
+            {event.duration_ms != null && event.duration_ms >= 100 && (
+              <span className="shrink-0 text-[10px] text-gray-500 tabular-nums">
+                {event.duration_ms >= 1000
+                  ? `${(event.duration_ms / 1000).toFixed(1)}s`
+                  : `${event.duration_ms}ms`}
+              </span>
+            )}
           </div>
         );
       })}

--- a/conductor-web/src/routes/agents.rs
+++ b/conductor-web/src/routes/agents.rs
@@ -7,7 +7,7 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 
 use conductor_core::agent::{
-    parse_agent_log, AgentEvent, AgentManager, AgentRun, TicketAgentTotals,
+    parse_agent_log, AgentEvent, AgentManager, AgentRun, AgentRunEvent, TicketAgentTotals,
 };
 use conductor_core::tickets::{build_agent_prompt, TicketSyncer};
 use conductor_core::worktree::WorktreeManager;
@@ -221,20 +221,49 @@ pub async fn stop_agent(
 
 #[derive(Serialize)]
 pub struct AgentEventResponse {
+    pub id: String,
+    pub run_id: String,
     pub kind: String,
     pub summary: String,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub metadata: Option<String>,
+}
+
+impl From<AgentRunEvent> for AgentEventResponse {
+    fn from(e: AgentRunEvent) -> Self {
+        let duration_ms = e.duration_ms();
+        Self {
+            id: e.id,
+            run_id: e.run_id,
+            kind: e.kind,
+            summary: e.summary,
+            started_at: e.started_at,
+            ended_at: e.ended_at,
+            duration_ms,
+            metadata: e.metadata,
+        }
+    }
 }
 
 impl From<AgentEvent> for AgentEventResponse {
     fn from(e: AgentEvent) -> Self {
         Self {
+            id: String::new(),
+            run_id: String::new(),
             kind: e.kind,
             summary: e.summary,
+            started_at: String::new(),
+            ended_at: None,
+            duration_ms: None,
+            metadata: None,
         }
     }
 }
 
-/// Get parsed agent events from the log file of the latest run.
+/// Get parsed agent events for all runs of a worktree.
+/// Uses DB records when available; falls back to log file parsing for older runs.
 pub async fn get_events(
     State(state): State<AppState>,
     Path(worktree_id): Path<String>,
@@ -242,9 +271,20 @@ pub async fn get_events(
     let db = state.db.lock().await;
     let agent_mgr = AgentManager::new(&db);
 
+    // Try DB events first (covers all runs with persisted events)
+    let db_events = agent_mgr.list_events_for_worktree(&worktree_id)?;
+    if !db_events.is_empty() {
+        return Ok(Json(
+            db_events
+                .into_iter()
+                .map(AgentEventResponse::from)
+                .collect(),
+        ));
+    }
+
+    // Backward compat: parse log files for older runs without DB events
     let runs = agent_mgr.list_for_worktree(&worktree_id)?;
     let mut all_events = Vec::new();
-
     for run in runs.iter().rev() {
         if let Some(ref log_file) = run.log_file {
             let events = parse_agent_log(log_file);
@@ -253,6 +293,39 @@ pub async fn get_events(
     }
 
     Ok(Json(all_events))
+}
+
+/// Get events for a specific agent run.
+pub async fn get_run_events(
+    State(state): State<AppState>,
+    Path((_worktree_id, run_id)): Path<(String, String)>,
+) -> Result<Json<Vec<AgentEventResponse>>, ApiError> {
+    let db = state.db.lock().await;
+    let agent_mgr = AgentManager::new(&db);
+
+    let db_events = agent_mgr.list_events_for_run(&run_id)?;
+    if !db_events.is_empty() {
+        return Ok(Json(
+            db_events
+                .into_iter()
+                .map(AgentEventResponse::from)
+                .collect(),
+        ));
+    }
+
+    // Backward compat: parse log file if no DB events
+    let run = agent_mgr.get_run(&run_id)?;
+    let events = run
+        .and_then(|r| r.log_file)
+        .map(|path| {
+            parse_agent_log(&path)
+                .into_iter()
+                .map(AgentEventResponse::from)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Ok(Json(events))
 }
 
 #[derive(Serialize)]

--- a/conductor-web/src/routes/mod.rs
+++ b/conductor-web/src/routes/mod.rs
@@ -57,6 +57,10 @@ pub fn api_router() -> Router<AppState> {
         .route("/api/worktrees/{id}/agent/start", post(agents::start_agent))
         .route("/api/worktrees/{id}/agent/stop", post(agents::stop_agent))
         .route("/api/worktrees/{id}/agent/events", get(agents::get_events))
+        .route(
+            "/api/worktrees/{id}/agent/runs/{run_id}/events",
+            get(agents::get_run_events),
+        )
         .route("/api/worktrees/{id}/agent/prompt", get(agents::get_prompt))
         // Issue Sources
         .route(


### PR DESCRIPTION
Adds an `agent_run_events` table (migration 007) with a span model
(started_at/ended_at) and wires up event persistence throughout the
stack:

- Core: `AgentRunEvent` struct, `create_event`, `update_event_ended_at`,
  `list_events_for_run`, `list_events_for_worktree`; refactors
  `parse_agent_log` into a per-line `parse_events_from_line` helper
- CLI: persists events to DB as open spans in real-time during
  `run_agent`, closing each span when the next event arrives
- Web: `GET /api/worktrees/:id/agent/events` prefers DB records with
  log-file fallback; new `GET .../runs/:run_id/events` endpoint;
  response includes timing fields
- TUI/frontend: display duration suffix for spans ≥ 100 ms

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
