### PR TITLE
Fix agent activity pane scrolling with List + ListState (#114)

### DIFF
--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 use std::time::Duration;
 
 use anyhow::Result;
+use ratatui::widgets::ListState;
 use ratatui::DefaultTerminal;
 use rusqlite::Connection;
 
@@ -260,13 +261,14 @@ impl App {
             Action::StopAgent => self.handle_stop_agent(),
             Action::ViewAgentLog => self.handle_view_agent_log(),
             Action::AgentActivityDown => {
-                let max = self.state.data.agent_events.len().saturating_sub(1);
-                if self.state.agent_event_index < max {
-                    self.state.agent_event_index += 1;
+                let len = self.state.data.agent_events.len();
+                let cur = self.state.agent_list_state.borrow().selected().unwrap_or(0);
+                if len > 0 && cur + 1 < len {
+                    self.state.agent_list_state.borrow_mut().select_next();
                 }
             }
             Action::AgentActivityUp => {
-                self.state.agent_event_index = self.state.agent_event_index.saturating_sub(1);
+                self.state.agent_list_state.borrow_mut().select_previous();
             }
             // Scroll navigation (all views + discover modals)
             Action::GoToTop => match self.state.modal {
@@ -482,10 +484,19 @@ impl App {
         };
 
         self.state.data.agent_events = all_events;
-        // Clamp scroll index
-        let max = self.state.data.agent_events.len().saturating_sub(1);
-        if self.state.agent_event_index > max {
-            self.state.agent_event_index = max;
+        // Clamp ListState selection to valid range after events reload.
+        // ratatui also clamps during render, but we keep it tidy here.
+        let len = self.state.data.agent_events.len();
+        let cur = self.state.agent_list_state.borrow().selected();
+        if let Some(idx) = cur {
+            if len == 0 {
+                self.state.agent_list_state.borrow_mut().select(None);
+            } else if idx >= len {
+                self.state
+                    .agent_list_state
+                    .borrow_mut()
+                    .select(Some(len - 1));
+            }
         }
     }
 
@@ -783,7 +794,7 @@ impl App {
                         self.state.selected_worktree_id = Some(wt_id);
                         self.state.selected_repo_id = None;
                         self.state.view = View::WorktreeDetail;
-                        self.state.agent_event_index = 0;
+                        *self.state.agent_list_state.borrow_mut() = ListState::default();
                         self.reload_agent_events();
                     }
                 }
@@ -801,7 +812,7 @@ impl App {
                         let wt_id = wt.id.clone();
                         self.state.selected_worktree_id = Some(wt_id);
                         self.state.view = View::WorktreeDetail;
-                        self.state.agent_event_index = 0;
+                        *self.state.agent_list_state.borrow_mut() = ListState::default();
                         self.reload_agent_events();
                     }
                 }

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -8,6 +9,7 @@ use conductor_core::issue_source::IssueSource;
 use conductor_core::repo::Repo;
 use conductor_core::tickets::Ticket;
 use conductor_core::worktree::Worktree;
+use ratatui::widgets::ListState;
 use tui_textarea::TextArea;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -309,8 +311,8 @@ pub struct AppState {
     pub detail_wt_index: usize,
     pub detail_ticket_index: usize,
 
-    // Agent activity scroll
-    pub agent_event_index: usize,
+    // Agent activity list navigation (replaces the old Paragraph scroll offset)
+    pub agent_list_state: RefCell<ListState>,
     /// Tracks pending `g` keypress for `gg` chord (go to top)
     pub pending_g: bool,
 
@@ -344,7 +346,7 @@ impl AppState {
             detail_tickets: Vec::new(),
             detail_wt_index: 0,
             detail_ticket_index: 0,
-            agent_event_index: 0,
+            agent_list_state: RefCell::new(ListState::default()),
             pending_g: false,
             filter_active: false,
             filter_text: String::new(),
@@ -366,7 +368,10 @@ impl AppState {
                 RepoDetailFocus::Worktrees => (self.detail_wt_index, self.detail_worktrees.len()),
                 RepoDetailFocus::Tickets => (self.detail_ticket_index, self.detail_tickets.len()),
             },
-            View::WorktreeDetail => (self.agent_event_index, self.data.agent_events.len()),
+            View::WorktreeDetail => {
+                let idx = self.agent_list_state.borrow().selected().unwrap_or(0);
+                (idx, self.data.agent_events.len())
+            }
             View::Tickets => (self.ticket_index, self.data.tickets.len()),
         }
     }
@@ -383,7 +388,9 @@ impl AppState {
                 RepoDetailFocus::Worktrees => self.detail_wt_index = index,
                 RepoDetailFocus::Tickets => self.detail_ticket_index = index,
             },
-            View::WorktreeDetail => self.agent_event_index = index,
+            View::WorktreeDetail => {
+                self.agent_list_state.borrow_mut().select(Some(index));
+            }
             View::Tickets => self.ticket_index = index,
         }
     }

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 use ratatui::Frame;
 
 use crate::state::AppState;
@@ -163,7 +163,7 @@ fn render_agent_activity(frame: &mut Frame, area: Rect, state: &AppState) {
         return;
     }
 
-    let lines: Vec<Line> = events
+    let items: Vec<ListItem> = events
         .iter()
         .map(|ev| {
             let style = event_style(&ev.kind);
@@ -177,16 +177,15 @@ fn render_agent_activity(frame: &mut Frame, area: Rect, state: &AppState) {
                     ));
                 }
             }
-            Line::from(spans)
+            ListItem::new(Line::from(spans))
         })
         .collect();
 
-    let paragraph = Paragraph::new(lines)
+    let list = List::new(items)
         .block(activity_block)
-        .wrap(Wrap { trim: false })
-        .scroll((state.agent_event_index as u16, 0));
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
 
-    frame.render_widget(paragraph, area);
+    frame.render_stateful_widget(list, area, &mut state.agent_list_state.borrow_mut());
 }
 
 fn event_style(kind: &str) -> Style {


### PR DESCRIPTION
Replace the Paragraph+scroll approach with a StatefulWidget List so
ratatui handles viewport tracking automatically.

- Replace `agent_event_index: usize` (raw scroll offset) with
  `agent_list_state: RefCell<ListState>` in AppState
- Wire j/k to select_next/select_previous; G/gg/^d/^u route through
  the existing focused_index_and_len + set_focused_index helpers
- Replace Paragraph::scroll in render_agent_activity with
  render_stateful_widget(List, ...) — each AgentRunEvent is one
  ListItem so the viewport is item-accurate by definition
- Selected item is highlighted with reversed video to show cursor

The old approach required manually computing total visual line counts
and pane heights to derive a correct max scroll offset, which was
fragile (off-by-one with wrapping, unstable ratatui API dependency).
ListState eliminates all of that: ratatui scrolls to keep the selected
item visible automatically.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
