### PR TITLE
Shorten file paths in agent activity: worktree prefix → {worktree}, home dir → ~

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "chrono",
  "conductor-core",
  "crossterm",
+ "dirs",
  "ratatui",
  "rusqlite",
  "serde_json",

--- a/conductor-tui/Cargo.toml
+++ b/conductor-tui/Cargo.toml
@@ -16,6 +16,7 @@ ratatui = "0.29"
 crossterm = "0.28"
 anyhow = "1"
 chrono = "0.4"
+dirs = "6"
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde_json = "1"
 tui-textarea = "0.7"

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -173,11 +173,21 @@ fn render_agent_activity(frame: &mut Frame, area: Rect, state: &AppState) {
         return;
     }
 
+    let worktree_path = state
+        .selected_worktree_id
+        .as_ref()
+        .and_then(|id| state.data.worktrees.iter().find(|w| &w.id == id))
+        .map(|wt| wt.path.as_str())
+        .unwrap_or("");
+
     let items: Vec<ListItem> = events
         .iter()
         .map(|ev| {
             let style = event_style(&ev.kind);
-            let mut spans = vec![Span::styled(ev.summary.clone(), style)];
+            let mut spans = vec![Span::styled(
+                shorten_paths(&ev.summary, worktree_path),
+                style,
+            )];
             if let Some(dur) = ev.duration_ms() {
                 if dur >= 100 {
                     let dur_s = dur as f64 / 1000.0;
@@ -196,6 +206,19 @@ fn render_agent_activity(frame: &mut Frame, area: Rect, state: &AppState) {
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
 
     frame.render_stateful_widget(list, area, &mut state.agent_list_state.borrow_mut());
+}
+
+fn shorten_paths(summary: &str, worktree_path: &str) -> String {
+    // Replace worktree path first (more specific), then home dir (less specific)
+    let s = if !worktree_path.is_empty() {
+        summary.replacen(worktree_path, "{worktree}", 1)
+    } else {
+        summary.to_string()
+    };
+    match dirs::home_dir() {
+        Some(home) => s.replacen(home.to_string_lossy().as_ref(), "~", 1),
+        None => s,
+    }
 }
 
 fn event_style(kind: &str) -> Style {

--- a/conductor-web/src/routes/agents.rs
+++ b/conductor-web/src/routes/agents.rs
@@ -284,6 +284,13 @@ pub async fn get_events(
     Path(worktree_id): Path<String>,
 ) -> Result<Json<Vec<AgentEventResponse>>, ApiError> {
     let db = state.db.lock().await;
+    let wt_path = {
+        let config = state.config.read().await;
+        WorktreeManager::new(&db, &config)
+            .get_by_id(&worktree_id)
+            .map(|wt| wt.path)
+            .unwrap_or_default()
+    };
     let agent_mgr = AgentManager::new(&db);
 
     // Try DB events first (covers all runs with persisted events)
@@ -292,7 +299,11 @@ pub async fn get_events(
         return Ok(Json(
             db_events
                 .into_iter()
-                .map(AgentEventResponse::from)
+                .map(|e| {
+                    let mut resp = AgentEventResponse::from(e);
+                    resp.summary = strip_worktree_prefix(&resp.summary, &wt_path);
+                    resp
+                })
                 .collect(),
         ));
     }
@@ -303,7 +314,11 @@ pub async fn get_events(
     for run in runs.iter().rev() {
         if let Some(ref log_file) = run.log_file {
             let events = parse_agent_log(log_file);
-            all_events.extend(events.into_iter().map(AgentEventResponse::from));
+            all_events.extend(events.into_iter().map(|e| {
+                let mut resp = AgentEventResponse::from(e);
+                resp.summary = strip_worktree_prefix(&resp.summary, &wt_path);
+                resp
+            }));
         }
     }
 
@@ -313,9 +328,16 @@ pub async fn get_events(
 /// Get events for a specific agent run.
 pub async fn get_run_events(
     State(state): State<AppState>,
-    Path((_worktree_id, run_id)): Path<(String, String)>,
+    Path((worktree_id, run_id)): Path<(String, String)>,
 ) -> Result<Json<Vec<AgentEventResponse>>, ApiError> {
     let db = state.db.lock().await;
+    let wt_path = {
+        let config = state.config.read().await;
+        WorktreeManager::new(&db, &config)
+            .get_by_id(&worktree_id)
+            .map(|wt| wt.path)
+            .unwrap_or_default()
+    };
     let agent_mgr = AgentManager::new(&db);
 
     let db_events = agent_mgr.list_events_for_run(&run_id)?;
@@ -323,7 +345,11 @@ pub async fn get_run_events(
         return Ok(Json(
             db_events
                 .into_iter()
-                .map(AgentEventResponse::from)
+                .map(|e| {
+                    let mut resp = AgentEventResponse::from(e);
+                    resp.summary = strip_worktree_prefix(&resp.summary, &wt_path);
+                    resp
+                })
                 .collect(),
         ));
     }
@@ -335,7 +361,11 @@ pub async fn get_run_events(
         .map(|path| {
             parse_agent_log(&path)
                 .into_iter()
-                .map(AgentEventResponse::from)
+                .map(|e| {
+                    let mut resp = AgentEventResponse::from(e);
+                    resp.summary = strip_worktree_prefix(&resp.summary, &wt_path);
+                    resp
+                })
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
@@ -382,6 +412,16 @@ pub async fn get_prompt(
         prompt,
         resume_session_id,
     }))
+}
+
+fn strip_worktree_prefix(summary: &str, worktree_path: &str) -> String {
+    if worktree_path.is_empty() {
+        return summary.to_string();
+    }
+    match summary.strip_prefix(worktree_path) {
+        Some(rest) => format!("{{worktree}}{rest}"),
+        None => summary.to_string(),
+    }
 }
 
 /// Best-effort capture of tmux scrollback to `~/.conductor/agent-logs/<run_id>.log`.


### PR DESCRIPTION
In the TUI, replace the worktree path anywhere in the event summary (not
just at the start) with {worktree}, then replace the home directory with ~
for any remaining absolute paths. Also apply worktree prefix shortening in
the web API agent event responses.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
