### PR TITLE
feat: plan-then-execute two-phase agent runs with visible plan (#110)

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -4,7 +4,7 @@ use std::process::{Command, Stdio};
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-use conductor_core::agent::{parse_events_from_line, AgentManager};
+use conductor_core::agent::{parse_events_from_line, AgentManager, PlanStep};
 use conductor_core::config::{ensure_dirs, load_config};
 use conductor_core::db::open_database;
 use conductor_core::github;
@@ -675,6 +675,68 @@ fn truncate_str(s: &str, max: usize) -> String {
     }
 }
 
+/// Generate an implementation plan by asking Claude to produce a JSON step list.
+///
+/// Returns `None` (non-fatal) if plan generation fails or produces no steps.
+fn generate_plan(worktree_path: &str, prompt: &str) -> Option<Vec<PlanStep>> {
+    let plan_prompt = format!(
+        "You are planning a software development task. \
+         Generate a concise implementation plan as a JSON array.\n\n\
+         Task:\n{prompt}\n\n\
+         Respond with ONLY a JSON array of step objects. \
+         Each object must have a \"description\" string field. \
+         No markdown, no backticks, no explanation — just the raw JSON array. \
+         Example: [{{\"description\":\"Read the relevant files\"}},{{\"description\":\"Write tests\"}}]\n\
+         Aim for 3-8 concrete, actionable steps."
+    );
+
+    let output = Command::new("claude")
+        .arg("-p")
+        .arg(&plan_prompt)
+        .arg("--output-format")
+        .arg("json")
+        .arg("--dangerously-skip-permissions")
+        .current_dir(worktree_path)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let response: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let result_text = response.get("result")?.as_str()?;
+
+    // Strip optional markdown code fences that Claude sometimes adds
+    let trimmed = result_text.trim();
+    let json_text = if let Some(inner) = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+    {
+        inner.trim_end_matches("```").trim()
+    } else {
+        trimmed
+    };
+
+    let raw: Vec<serde_json::Value> = serde_json::from_str(json_text).ok()?;
+    let steps: Vec<PlanStep> = raw
+        .into_iter()
+        .filter_map(|v| {
+            let description = v.get("description")?.as_str()?.to_string();
+            Some(PlanStep {
+                description,
+                done: false,
+            })
+        })
+        .collect();
+
+    if steps.is_empty() {
+        None
+    } else {
+        Some(steps)
+    }
+}
+
 /// Run a Claude agent for a worktree. Called inside a tmux window by the TUI.
 ///
 /// Uses `--output-format json` (single JSON result) since the tmux terminal IS the display.
@@ -693,6 +755,26 @@ fn run_agent(
     let run = mgr.get_run(run_id)?;
     if run.is_none() {
         anyhow::bail!("agent run not found: {run_id}");
+    }
+
+    // Phase 1: Plan generation (only for new runs, not resumes)
+    if resume_session_id.is_none() {
+        eprintln!("[conductor] Phase 1: Generating plan...");
+        match generate_plan(worktree_path, prompt) {
+            Some(steps) => {
+                eprintln!("[conductor] Plan ({} steps):", steps.len());
+                for (i, step) in steps.iter().enumerate() {
+                    eprintln!("  {}. {}", i + 1, step.description);
+                }
+                if let Err(e) = mgr.update_run_plan(run_id, &steps) {
+                    eprintln!("[conductor] Warning: could not save plan to DB: {e}");
+                }
+            }
+            None => {
+                eprintln!("[conductor] Plan generation skipped (no steps returned)");
+            }
+        }
+        eprintln!("[conductor] Phase 2: Executing...");
     }
 
     // Build the claude command in print mode with stream-json output.
@@ -832,6 +914,10 @@ fn run_agent(
                 num_turns,
                 duration_ms,
             )?;
+            // Mark all plan steps done now that the run succeeded
+            if let Err(e) = mgr.mark_plan_done(run_id) {
+                eprintln!("[conductor] Warning: could not mark plan done: {e}");
+            }
             eprintln!("[conductor] Agent completed successfully");
             if let Some(cost) = cost_usd {
                 eprintln!(

--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -8,6 +8,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 
+/// A single step in an agent's two-phase execution plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanStep {
+    pub description: String,
+    #[serde(default)]
+    pub done: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentRun {
     pub id: String,
@@ -25,6 +33,8 @@ pub struct AgentRun {
     pub log_file: Option<String>,
     /// The model used for this run (e.g. "claude-sonnet-4-6"). None means claude's default.
     pub model: Option<String>,
+    /// Two-phase execution plan: JSON-serialized list of steps with completion state.
+    pub plan: Option<Vec<PlanStep>>,
 }
 
 /// Parsed JSON result from `claude -p --output-format json`.
@@ -292,6 +302,7 @@ impl<'a> AgentManager<'a> {
             tmux_window: tmux_window.map(String::from),
             log_file: None,
             model: model.map(String::from),
+            plan: None,
         };
 
         self.conn.execute(
@@ -314,7 +325,8 @@ impl<'a> AgentManager<'a> {
     pub fn get_run(&self, run_id: &str) -> Result<Option<AgentRun>> {
         let result = self.conn.query_row(
             "SELECT id, worktree_id, claude_session_id, prompt, status, result_text, \
-             cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, model \
+             cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, \
+             model, plan \
              FROM agent_runs WHERE id = ?1",
             params![run_id],
             row_to_agent_run,
@@ -381,10 +393,40 @@ impl<'a> AgentManager<'a> {
         Ok(())
     }
 
+    /// Store the two-phase plan for a run. Replaces any existing plan.
+    pub fn update_run_plan(&self, run_id: &str, steps: &[PlanStep]) -> Result<()> {
+        let plan_json = serde_json::to_string(steps)
+            .map_err(|e| crate::error::ConductorError::Agent(e.to_string()))?;
+        self.conn.execute(
+            "UPDATE agent_runs SET plan = ?1 WHERE id = ?2",
+            params![plan_json, run_id],
+        )?;
+        Ok(())
+    }
+
+    /// Mark all steps in the plan as done (called on successful run completion).
+    pub fn mark_plan_done(&self, run_id: &str) -> Result<()> {
+        if let Some(run) = self.get_run(run_id)? {
+            if let Some(mut steps) = run.plan {
+                for step in &mut steps {
+                    step.done = true;
+                }
+                let plan_json = serde_json::to_string(&steps)
+                    .map_err(|e| crate::error::ConductorError::Agent(e.to_string()))?;
+                self.conn.execute(
+                    "UPDATE agent_runs SET plan = ?1 WHERE id = ?2",
+                    params![plan_json, run_id],
+                )?;
+            }
+        }
+        Ok(())
+    }
+
     pub fn list_for_worktree(&self, worktree_id: &str) -> Result<Vec<AgentRun>> {
         let mut stmt = self.conn.prepare(
             "SELECT id, worktree_id, claude_session_id, prompt, status, result_text, \
-             cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, model \
+             cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, \
+             model, plan \
              FROM agent_runs WHERE worktree_id = ?1 ORDER BY started_at DESC",
         )?;
         let rows = stmt.query_map(params![worktree_id], row_to_agent_run)?;
@@ -405,7 +447,8 @@ impl<'a> AgentManager<'a> {
     pub fn latest_for_worktree(&self, worktree_id: &str) -> Result<Option<AgentRun>> {
         let result = self.conn.query_row(
             "SELECT id, worktree_id, claude_session_id, prompt, status, result_text, \
-             cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, model \
+             cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, \
+             model, plan \
              FROM agent_runs WHERE worktree_id = ?1 ORDER BY started_at DESC LIMIT 1",
             params![worktree_id],
             row_to_agent_run,
@@ -524,7 +567,7 @@ impl<'a> AgentManager<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT a.id, a.worktree_id, a.claude_session_id, a.prompt, a.status, \
              a.result_text, a.cost_usd, a.num_turns, a.duration_ms, a.started_at, \
-             a.ended_at, a.tmux_window, a.log_file, a.model \
+             a.ended_at, a.tmux_window, a.log_file, a.model, a.plan \
              FROM agent_runs a \
              INNER JOIN ( \
                  SELECT worktree_id, MAX(started_at) AS max_started \
@@ -555,6 +598,8 @@ fn row_to_agent_run_event(row: &rusqlite::Row) -> rusqlite::Result<AgentRunEvent
 }
 
 fn row_to_agent_run(row: &rusqlite::Row) -> rusqlite::Result<AgentRun> {
+    let plan_json: Option<String> = row.get(14)?;
+    let plan = plan_json.and_then(|json| serde_json::from_str(&json).ok());
     Ok(AgentRun {
         id: row.get(0)?,
         worktree_id: row.get(1)?,
@@ -570,6 +615,7 @@ fn row_to_agent_run(row: &rusqlite::Row) -> rusqlite::Result<AgentRun> {
         tmux_window: row.get(11)?,
         log_file: row.get(12)?,
         model: row.get(13)?,
+        plan,
     })
 }
 
@@ -802,6 +848,93 @@ mod tests {
 
         let totals = mgr.totals_by_ticket_all().unwrap();
         assert!(totals.is_empty());
+    }
+
+    #[test]
+    fn test_update_run_plan() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        assert!(run.plan.is_none());
+
+        let steps = vec![
+            PlanStep {
+                description: "Investigate the issue".to_string(),
+                done: false,
+            },
+            PlanStep {
+                description: "Write a fix".to_string(),
+                done: false,
+            },
+        ];
+        mgr.update_run_plan(&run.id, &steps).unwrap();
+
+        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
+        let plan = fetched.plan.unwrap();
+        assert_eq!(plan.len(), 2);
+        assert_eq!(plan[0].description, "Investigate the issue");
+        assert!(!plan[0].done);
+        assert_eq!(plan[1].description, "Write a fix");
+        assert!(!plan[1].done);
+    }
+
+    #[test]
+    fn test_mark_plan_done() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        let steps = vec![
+            PlanStep {
+                description: "Step one".to_string(),
+                done: false,
+            },
+            PlanStep {
+                description: "Step two".to_string(),
+                done: false,
+            },
+        ];
+        mgr.update_run_plan(&run.id, &steps).unwrap();
+        mgr.mark_plan_done(&run.id).unwrap();
+
+        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
+        let plan = fetched.plan.unwrap();
+        assert!(plan[0].done);
+        assert!(plan[1].done);
+    }
+
+    #[test]
+    fn test_mark_plan_done_no_plan() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        // Should not error when no plan exists
+        mgr.mark_plan_done(&run.id).unwrap();
+
+        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
+        assert!(fetched.plan.is_none());
+    }
+
+    #[test]
+    fn test_plan_roundtrip_in_latest_runs() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        let steps = vec![PlanStep {
+            description: "Do the thing".to_string(),
+            done: true,
+        }];
+        mgr.update_run_plan(&run.id, &steps).unwrap();
+
+        let map = mgr.latest_runs_by_worktree().unwrap();
+        let latest = map.get("w1").unwrap();
+        let plan = latest.plan.as_ref().unwrap();
+        assert_eq!(plan.len(), 1);
+        assert_eq!(plan[0].description, "Do the thing");
+        assert!(plan[0].done);
     }
 
     #[test]

--- a/conductor-core/src/db/migrations.rs
+++ b/conductor-core/src/db/migrations.rs
@@ -140,5 +140,17 @@ pub fn run(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    // Migration 011: add plan column to agent_runs.
+    let has_plan: bool = conn.prepare("SELECT plan FROM agent_runs LIMIT 0").is_ok();
+    if !has_plan {
+        conn.execute_batch(include_str!("migrations/011_agent_plan.sql"))?;
+    }
+    if version < 11 {
+        conn.execute(
+            "INSERT OR REPLACE INTO _conductor_meta (key, value) VALUES ('schema_version', '11')",
+            [],
+        )?;
+    }
+
     Ok(())
 }

--- a/conductor-core/src/db/migrations/011_agent_plan.sql
+++ b/conductor-core/src/db/migrations/011_agent_plan.sql
@@ -1,0 +1,3 @@
+-- Migration 007: add plan column to agent_runs
+-- Stores the two-phase plan as a JSON array of {description, done} objects.
+ALTER TABLE agent_runs ADD COLUMN plan TEXT;

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -109,10 +109,42 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
     lines.push(Line::from(""));
     lines.push(Line::from(ticket_line));
 
-    // Agent status line from DB poll
+    // Agent status line and plan checklist from DB poll
     if let Some(run) = state.data.latest_agent_runs.get(&wt.id) {
         lines.push(Line::from(""));
         lines.push(render_agent_status_line(run, &state.data.agent_totals));
+
+        // Plan checklist (if a plan was generated for this run)
+        if let Some(ref steps) = run.plan {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Plan:",
+                Style::default().fg(Color::DarkGray),
+            )));
+            for step in steps {
+                let (checkbox, style) = if step.done {
+                    (
+                        "[x]",
+                        Style::default()
+                            .fg(Color::Green)
+                            .add_modifier(Modifier::DIM),
+                    )
+                } else {
+                    ("[ ]", Style::default().fg(Color::White))
+                };
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("  {checkbox} "),
+                        Style::default().fg(if step.done {
+                            Color::Green
+                        } else {
+                            Color::DarkGray
+                        }),
+                    ),
+                    Span::styled(&step.description, style),
+                ]));
+            }
+        }
     }
 
     lines.push(Line::from(""));

--- a/conductor-web/frontend/src/api/types.ts
+++ b/conductor-web/frontend/src/api/types.ts
@@ -64,6 +64,11 @@ export interface SyncResult {
   closed: number;
 }
 
+export interface PlanStep {
+  description: string;
+  done: boolean;
+}
+
 export interface AgentRun {
   id: string;
   worktree_id: string;
@@ -78,6 +83,7 @@ export interface AgentRun {
   ended_at: string | null;
   tmux_window: string | null;
   log_file: string | null;
+  plan: PlanStep[] | null;
 }
 
 export interface AgentEvent {

--- a/conductor-web/frontend/src/components/agents/AgentPlanChecklist.tsx
+++ b/conductor-web/frontend/src/components/agents/AgentPlanChecklist.tsx
@@ -1,0 +1,48 @@
+import type { PlanStep } from "../../api/types";
+
+interface AgentPlanChecklistProps {
+  steps: PlanStep[];
+}
+
+export function AgentPlanChecklist({ steps }: AgentPlanChecklistProps) {
+  const doneCount = steps.filter((s) => s.done).length;
+  const allDone = doneCount === steps.length;
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-sm font-semibold uppercase tracking-wider text-gray-400">
+          Plan
+        </h4>
+        <span className="text-xs text-gray-400">
+          {doneCount}/{steps.length} completed
+        </span>
+      </div>
+      <ul className="space-y-1.5">
+        {steps.map((step, i) => (
+          <li key={i} className="flex items-start gap-2 text-sm">
+            <span
+              className={`mt-0.5 flex-shrink-0 w-4 h-4 rounded border flex items-center justify-center text-xs ${
+                step.done
+                  ? "bg-green-100 border-green-400 text-green-600"
+                  : "border-gray-300 text-transparent"
+              }`}
+            >
+              {step.done && "\u2713"}
+            </span>
+            <span
+              className={
+                step.done ? "text-gray-400 line-through" : "text-gray-900"
+              }
+            >
+              {step.description}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {allDone && (
+        <p className="mt-3 text-xs text-green-600">All steps completed</p>
+      )}
+    </div>
+  );
+}

--- a/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
+++ b/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
@@ -10,6 +10,7 @@ import { LoadingSpinner } from "../components/shared/LoadingSpinner";
 import { AgentPromptModal } from "../components/agents/AgentPromptModal";
 import { AgentStatusDisplay } from "../components/agents/AgentStatusDisplay";
 import { AgentActivityLog } from "../components/agents/AgentActivityLog";
+import { AgentPlanChecklist } from "../components/agents/AgentPlanChecklist";
 import {
   useConductorEvents,
   type ConductorEventType,
@@ -506,6 +507,13 @@ export function WorktreeDetailPage() {
           </div>
         )}
       </section>
+
+      {/* Agent Plan Checklist */}
+      {latestRun?.plan && latestRun.plan.length > 0 && (
+        <section>
+          <AgentPlanChecklist steps={latestRun.plan} />
+        </section>
+      )}
 
       {/* Agent Activity Log */}
       {(agentEvents.length > 0 || isRunning) && (


### PR DESCRIPTION
Add a plan generation phase before agent execution. Claude generates a
structured JSON checklist of implementation steps, stored in the DB and
surfaced in both TUI and Web UI. On successful completion all steps are
marked done; on failure the plan shows where execution stopped.

- Migration 011: add `plan` TEXT column to agent_runs
- PlanStep struct, update_run_plan/mark_plan_done on AgentManager
- CLI generate_plan() runs a separate claude call before execution
- TUI worktree detail renders plan as [x]/[ ] checklist
- Web UI AgentPlanChecklist component on WorktreeDetailPage
- 4 new unit tests for plan CRUD and round-trip

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
