### PR TITLE
feat: multi-agent support with parent-child run relationships (#111)

### DIFF
--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -35,6 +35,8 @@ pub struct AgentRun {
     pub model: Option<String>,
     /// Two-phase execution plan: JSON-serialized list of steps with completion state.
     pub plan: Option<Vec<PlanStep>>,
+    /// If this is a child run, the ID of the parent (supervisor) run.
+    pub parent_run_id: Option<String>,
 }
 
 /// Parsed JSON result from `claude -p --output-format json`.
@@ -268,6 +270,15 @@ pub struct TicketAgentTotals {
     pub total_duration_ms: i64,
 }
 
+/// Aggregated stats for a run tree (parent + all descendants).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RunTreeTotals {
+    pub total_runs: i64,
+    pub total_cost: f64,
+    pub total_turns: i64,
+    pub total_duration_ms: i64,
+}
+
 pub struct AgentManager<'a> {
     conn: &'a Connection,
 }
@@ -283,6 +294,28 @@ impl<'a> AgentManager<'a> {
         prompt: &str,
         tmux_window: Option<&str>,
         model: Option<&str>,
+    ) -> Result<AgentRun> {
+        self.create_run_with_parent(worktree_id, prompt, tmux_window, model, None)
+    }
+
+    pub fn create_child_run(
+        &self,
+        worktree_id: &str,
+        prompt: &str,
+        tmux_window: Option<&str>,
+        model: Option<&str>,
+        parent_run_id: &str,
+    ) -> Result<AgentRun> {
+        self.create_run_with_parent(worktree_id, prompt, tmux_window, model, Some(parent_run_id))
+    }
+
+    fn create_run_with_parent(
+        &self,
+        worktree_id: &str,
+        prompt: &str,
+        tmux_window: Option<&str>,
+        model: Option<&str>,
+        parent_run_id: Option<&str>,
     ) -> Result<AgentRun> {
         let id = ulid::Ulid::new().to_string();
         let now = Utc::now().to_rfc3339();
@@ -303,11 +336,12 @@ impl<'a> AgentManager<'a> {
             log_file: None,
             model: model.map(String::from),
             plan: None,
+            parent_run_id: parent_run_id.map(String::from),
         };
 
         self.conn.execute(
-            "INSERT INTO agent_runs (id, worktree_id, prompt, status, started_at, tmux_window, model) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            "INSERT INTO agent_runs (id, worktree_id, prompt, status, started_at, tmux_window, model, parent_run_id) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
             params![
                 run.id,
                 run.worktree_id,
@@ -315,7 +349,8 @@ impl<'a> AgentManager<'a> {
                 run.status,
                 run.started_at,
                 run.tmux_window,
-                run.model
+                run.model,
+                run.parent_run_id
             ],
         )?;
 
@@ -326,7 +361,7 @@ impl<'a> AgentManager<'a> {
         let result = self.conn.query_row(
             "SELECT id, worktree_id, claude_session_id, prompt, status, result_text, \
              cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, \
-             model, plan \
+             model, plan, parent_run_id \
              FROM agent_runs WHERE id = ?1",
             params![run_id],
             row_to_agent_run,
@@ -426,7 +461,7 @@ impl<'a> AgentManager<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT id, worktree_id, claude_session_id, prompt, status, result_text, \
              cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, \
-             model, plan \
+             model, plan, parent_run_id \
              FROM agent_runs WHERE worktree_id = ?1 ORDER BY started_at DESC",
         )?;
         let rows = stmt.query_map(params![worktree_id], row_to_agent_run)?;
@@ -448,7 +483,7 @@ impl<'a> AgentManager<'a> {
         let result = self.conn.query_row(
             "SELECT id, worktree_id, claude_session_id, prompt, status, result_text, \
              cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, \
-             model, plan \
+             model, plan, parent_run_id \
              FROM agent_runs WHERE worktree_id = ?1 ORDER BY started_at DESC LIMIT 1",
             params![worktree_id],
             row_to_agent_run,
@@ -567,7 +602,7 @@ impl<'a> AgentManager<'a> {
         let mut stmt = self.conn.prepare(
             "SELECT a.id, a.worktree_id, a.claude_session_id, a.prompt, a.status, \
              a.result_text, a.cost_usd, a.num_turns, a.duration_ms, a.started_at, \
-             a.ended_at, a.tmux_window, a.log_file, a.model, a.plan \
+             a.ended_at, a.tmux_window, a.log_file, a.model, a.plan, a.parent_run_id \
              FROM agent_runs a \
              INNER JOIN ( \
                  SELECT worktree_id, MAX(started_at) AS max_started \
@@ -582,6 +617,86 @@ impl<'a> AgentManager<'a> {
             map.insert(run.worktree_id.clone(), run);
         }
         Ok(map)
+    }
+
+    // ── Parent/child run tree queries ─────────────────────────────────
+
+    /// List direct child runs of a parent run (newest first).
+    pub fn list_child_runs(&self, parent_run_id: &str) -> Result<Vec<AgentRun>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, worktree_id, claude_session_id, prompt, status, result_text, \
+             cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, \
+             model, plan, parent_run_id \
+             FROM agent_runs WHERE parent_run_id = ?1 ORDER BY started_at DESC",
+        )?;
+        let rows = stmt.query_map(params![parent_run_id], row_to_agent_run)?;
+        let runs = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(runs)
+    }
+
+    /// Get a full run tree: the given run plus all descendants (children, grandchildren, etc.).
+    /// Returns a flat list ordered by started_at ASC. The caller can reconstruct
+    /// the tree using `parent_run_id` references.
+    pub fn get_run_tree(&self, root_run_id: &str) -> Result<Vec<AgentRun>> {
+        // SQLite supports recursive CTEs, which are perfect for tree traversal.
+        let mut stmt = self.conn.prepare(
+            "WITH RECURSIVE tree(id) AS ( \
+                 SELECT id FROM agent_runs WHERE id = ?1 \
+                 UNION ALL \
+                 SELECT a.id FROM agent_runs a JOIN tree t ON a.parent_run_id = t.id \
+             ) \
+             SELECT a.id, a.worktree_id, a.claude_session_id, a.prompt, a.status, \
+                    a.result_text, a.cost_usd, a.num_turns, a.duration_ms, a.started_at, \
+                    a.ended_at, a.tmux_window, a.log_file, a.model, a.plan, a.parent_run_id \
+             FROM agent_runs a \
+             JOIN tree t ON a.id = t.id \
+             ORDER BY a.started_at ASC",
+        )?;
+        let rows = stmt.query_map(params![root_run_id], row_to_agent_run)?;
+        let runs = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(runs)
+    }
+
+    /// List only top-level (root) runs for a worktree — runs with no parent.
+    pub fn list_root_runs_for_worktree(&self, worktree_id: &str) -> Result<Vec<AgentRun>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, worktree_id, claude_session_id, prompt, status, result_text, \
+             cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, \
+             model, plan, parent_run_id \
+             FROM agent_runs WHERE worktree_id = ?1 AND parent_run_id IS NULL \
+             ORDER BY started_at DESC",
+        )?;
+        let rows = stmt.query_map(params![worktree_id], row_to_agent_run)?;
+        let runs = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(runs)
+    }
+
+    /// Compute aggregated cost/turns/duration for a run and all its descendants.
+    pub fn aggregate_run_tree(&self, root_run_id: &str) -> Result<RunTreeTotals> {
+        let row = self.conn.query_row(
+            "WITH RECURSIVE tree(id) AS ( \
+                 SELECT id FROM agent_runs WHERE id = ?1 \
+                 UNION ALL \
+                 SELECT a.id FROM agent_runs a JOIN tree t ON a.parent_run_id = t.id \
+             ) \
+             SELECT COUNT(*) AS total_runs, \
+                    COALESCE(SUM(a.cost_usd), 0.0) AS total_cost, \
+                    COALESCE(SUM(a.num_turns), 0) AS total_turns, \
+                    COALESCE(SUM(a.duration_ms), 0) AS total_duration_ms \
+             FROM agent_runs a \
+             JOIN tree t ON a.id = t.id \
+             WHERE a.status = 'completed'",
+            params![root_run_id],
+            |row| {
+                Ok(RunTreeTotals {
+                    total_runs: row.get(0)?,
+                    total_cost: row.get(1)?,
+                    total_turns: row.get(2)?,
+                    total_duration_ms: row.get(3)?,
+                })
+            },
+        )?;
+        Ok(row)
     }
 }
 
@@ -616,6 +731,7 @@ fn row_to_agent_run(row: &rusqlite::Row) -> rusqlite::Result<AgentRun> {
         log_file: row.get(12)?,
         model: row.get(13)?,
         plan,
+        parent_run_id: row.get(15)?,
     })
 }
 
@@ -1099,5 +1215,145 @@ mod tests {
 
         let fetched = mgr.get_run(&run.id).unwrap().unwrap();
         assert!(fetched.model.is_none());
+    }
+
+    // ── Parent/child run tests ────────────────────────────────────────
+
+    #[test]
+    fn test_create_child_run() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let parent = mgr.create_run("w1", "Supervisor task", None, None).unwrap();
+        assert!(parent.parent_run_id.is_none());
+
+        let child = mgr
+            .create_child_run("w1", "Sub-task A", None, None, &parent.id)
+            .unwrap();
+        assert_eq!(child.parent_run_id.as_deref(), Some(parent.id.as_str()));
+
+        let fetched = mgr.get_run(&child.id).unwrap().unwrap();
+        assert_eq!(fetched.parent_run_id.as_deref(), Some(parent.id.as_str()));
+    }
+
+    #[test]
+    fn test_list_child_runs() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let parent = mgr.create_run("w1", "Supervisor", None, None).unwrap();
+        let _child1 = mgr
+            .create_child_run("w1", "Child 1", None, None, &parent.id)
+            .unwrap();
+        let _child2 = mgr
+            .create_child_run("w1", "Child 2", None, None, &parent.id)
+            .unwrap();
+
+        // Unrelated run should not appear
+        let _other = mgr.create_run("w1", "Independent", None, None).unwrap();
+
+        let children = mgr.list_child_runs(&parent.id).unwrap();
+        assert_eq!(children.len(), 2);
+        assert!(children
+            .iter()
+            .all(|c| c.parent_run_id.as_deref() == Some(parent.id.as_str())));
+    }
+
+    #[test]
+    fn test_get_run_tree() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        // Build a tree: parent -> child1, child2 -> grandchild
+        let parent = mgr.create_run("w1", "Root task", None, None).unwrap();
+        let child1 = mgr
+            .create_child_run("w1", "Child 1", None, None, &parent.id)
+            .unwrap();
+        let _child2 = mgr
+            .create_child_run("w2", "Child 2", None, None, &parent.id)
+            .unwrap();
+        let _grandchild = mgr
+            .create_child_run("w1", "Grandchild", None, None, &child1.id)
+            .unwrap();
+
+        // Unrelated run
+        let _other = mgr.create_run("w1", "Other", None, None).unwrap();
+
+        let tree = mgr.get_run_tree(&parent.id).unwrap();
+        assert_eq!(tree.len(), 4); // parent + 2 children + 1 grandchild
+        assert_eq!(tree[0].id, parent.id); // root is first (earliest started_at)
+    }
+
+    #[test]
+    fn test_list_root_runs_for_worktree() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let parent = mgr.create_run("w1", "Supervisor", None, None).unwrap();
+        let _child = mgr
+            .create_child_run("w1", "Child", None, None, &parent.id)
+            .unwrap();
+        let standalone = mgr.create_run("w1", "Standalone", None, None).unwrap();
+
+        let root_runs = mgr.list_root_runs_for_worktree("w1").unwrap();
+        assert_eq!(root_runs.len(), 2);
+        // Newest first
+        assert_eq!(root_runs[0].id, standalone.id);
+        assert_eq!(root_runs[1].id, parent.id);
+        assert!(root_runs.iter().all(|r| r.parent_run_id.is_none()));
+    }
+
+    #[test]
+    fn test_aggregate_run_tree() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let parent = mgr.create_run("w1", "Supervisor", None, None).unwrap();
+        mgr.update_run_completed(&parent.id, None, None, Some(0.10), Some(5), Some(30000))
+            .unwrap();
+
+        let child1 = mgr
+            .create_child_run("w1", "Child 1", None, None, &parent.id)
+            .unwrap();
+        mgr.update_run_completed(&child1.id, None, None, Some(0.05), Some(3), Some(15000))
+            .unwrap();
+
+        let child2 = mgr
+            .create_child_run("w2", "Child 2", None, None, &parent.id)
+            .unwrap();
+        mgr.update_run_completed(&child2.id, None, None, Some(0.08), Some(4), Some(20000))
+            .unwrap();
+
+        // Still-running child should NOT be included in totals
+        let _running = mgr
+            .create_child_run("w1", "Still running", None, None, &parent.id)
+            .unwrap();
+
+        let totals = mgr.aggregate_run_tree(&parent.id).unwrap();
+        assert_eq!(totals.total_runs, 3);
+        assert!((totals.total_cost - 0.23).abs() < 0.001);
+        assert_eq!(totals.total_turns, 12);
+        assert_eq!(totals.total_duration_ms, 65000);
+    }
+
+    #[test]
+    fn test_parent_run_id_set_null_on_delete() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let parent = mgr.create_run("w1", "Parent", None, None).unwrap();
+        let child = mgr
+            .create_child_run("w1", "Child", None, None, &parent.id)
+            .unwrap();
+
+        // Delete the parent — ON DELETE SET NULL should clear child's parent_run_id
+        conn.execute(
+            "DELETE FROM agent_runs WHERE id = ?1",
+            rusqlite::params![parent.id],
+        )
+        .unwrap();
+
+        let fetched = mgr.get_run(&child.id).unwrap().unwrap();
+        assert!(fetched.parent_run_id.is_none());
     }
 }

--- a/conductor-core/src/db/migrations.rs
+++ b/conductor-core/src/db/migrations.rs
@@ -152,5 +152,19 @@ pub fn run(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    // Migration 012: add parent_run_id to agent_runs for parent/child relationships.
+    let has_parent_run_id: bool = conn
+        .prepare("SELECT parent_run_id FROM agent_runs LIMIT 0")
+        .is_ok();
+    if !has_parent_run_id {
+        conn.execute_batch(include_str!("migrations/012_parent_run_id.sql"))?;
+    }
+    if version < 12 {
+        conn.execute(
+            "INSERT OR REPLACE INTO _conductor_meta (key, value) VALUES ('schema_version', '12')",
+            [],
+        )?;
+    }
+
     Ok(())
 }

--- a/conductor-core/src/db/migrations/012_parent_run_id.sql
+++ b/conductor-core/src/db/migrations/012_parent_run_id.sql
@@ -1,0 +1,4 @@
+-- Add parent_run_id to agent_runs for parent/child run relationships.
+-- A supervisor agent run can spawn child runs; this FK tracks that tree.
+ALTER TABLE agent_runs ADD COLUMN parent_run_id TEXT REFERENCES agent_runs(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_agent_runs_parent ON agent_runs(parent_run_id);

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -430,6 +430,7 @@ impl App {
         let Some(ref wt_id) = self.state.selected_worktree_id else {
             self.state.data.agent_events = Vec::new();
             self.state.data.agent_totals = AgentTotals::default();
+            self.state.data.child_runs = Vec::new();
             return;
         };
 
@@ -487,6 +488,18 @@ impl App {
         };
 
         self.state.data.agent_events = all_events;
+
+        // Load child runs for the latest root run (for run tree display)
+        if let Some(latest) = runs.last() {
+            if latest.parent_run_id.is_none() {
+                self.state.data.child_runs = mgr.list_child_runs(&latest.id).unwrap_or_default();
+            } else {
+                self.state.data.child_runs = Vec::new();
+            }
+        } else {
+            self.state.data.child_runs = Vec::new();
+        }
+
         // Clamp ListState selection to valid range after events reload.
         // ratatui also clamps during render, but we keep it tidy here.
         let len = self.state.data.agent_events.len();

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -264,6 +264,8 @@ pub struct DataCache {
     pub agent_events: Vec<AgentRunEvent>,
     /// Aggregate stats across all agent runs for the currently viewed worktree
     pub agent_totals: AgentTotals,
+    /// Child runs of the latest root run (for run tree display)
+    pub child_runs: Vec<AgentRun>,
     /// ticket_id -> aggregated agent stats across all linked worktrees
     pub ticket_agent_totals: HashMap<String, TicketAgentTotals>,
     /// ticket_id -> linked worktrees (most recently created first)

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -114,6 +114,11 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
         lines.push(Line::from(""));
         lines.push(render_agent_status_line(run, &state.data.agent_totals));
 
+        // Show child runs if this is a parent (supervisor) run
+        for child in &state.data.child_runs {
+            lines.push(render_child_run_line(child));
+        }
+
         // Plan checklist (if a plan was generated for this run)
         if let Some(ref steps) = run.plan {
             lines.push(Line::from(""));
@@ -345,4 +350,39 @@ fn render_agent_status_line(
             Span::raw(format!("[{other}]")),
         ]),
     }
+}
+
+/// Render a single child run as an indented line under the parent agent status.
+fn render_child_run_line(run: &conductor_core::agent::AgentRun) -> Line<'static> {
+    let (status_text, status_color) = match run.status.as_str() {
+        "running" => ("running", Color::Yellow),
+        "completed" => ("completed", Color::Green),
+        "failed" => ("failed", Color::Red),
+        "cancelled" => ("cancelled", Color::DarkGray),
+        other => (other, Color::White),
+    };
+    let status_str = format!("[{status_text}]");
+
+    let prompt = if run.prompt.len() > 50 {
+        format!("{}...", &run.prompt[..50])
+    } else {
+        run.prompt.clone()
+    };
+
+    let mut spans = vec![
+        Span::styled("  └─ ", Style::default().fg(Color::DarkGray)),
+        Span::styled(status_str, Style::default().fg(status_color)),
+        Span::styled(format!(" {prompt}"), Style::default().fg(Color::DarkGray)),
+    ];
+
+    let cost = run.cost_usd.unwrap_or(0.0);
+    let turns = run.num_turns.unwrap_or(0);
+    if cost > 0.0 || turns > 0 {
+        spans.push(Span::styled(
+            format!("  ${cost:.4} {turns}t"),
+            Style::default().fg(Color::Magenta),
+        ));
+    }
+
+    Line::from(spans)
 }

--- a/conductor-web/frontend/src/api/client.ts
+++ b/conductor-web/frontend/src/api/client.ts
@@ -10,6 +10,7 @@ import type {
   AgentRun,
   AgentEvent,
   AgentPromptInfo,
+  RunTreeTotals,
   WorkTarget,
   CreateWorkTargetRequest,
   PushResult,
@@ -96,12 +97,18 @@ export const api = {
     request<AgentRun[]>(`/worktrees/${worktreeId}/agent/runs`),
   latestAgentRun: (worktreeId: string) =>
     request<AgentRun | null>(`/worktrees/${worktreeId}/agent/latest`),
-  startAgent: (worktreeId: string, prompt: string, resumeSessionId?: string) =>
+  startAgent: (
+    worktreeId: string,
+    prompt: string,
+    resumeSessionId?: string,
+    parentRunId?: string,
+  ) =>
     request<AgentRun>(`/worktrees/${worktreeId}/agent/start`, {
       method: "POST",
       body: JSON.stringify({
         prompt,
         resume_session_id: resumeSessionId ?? null,
+        parent_run_id: parentRunId ?? null,
       }),
     }),
   stopAgent: (worktreeId: string) =>
@@ -112,6 +119,16 @@ export const api = {
     request<AgentEvent[]>(`/worktrees/${worktreeId}/agent/events`),
   getAgentPrompt: (worktreeId: string) =>
     request<AgentPromptInfo>(`/worktrees/${worktreeId}/agent/prompt`),
+  listChildRuns: (worktreeId: string, runId: string) =>
+    request<AgentRun[]>(
+      `/worktrees/${worktreeId}/agent/runs/${runId}/children`,
+    ),
+  getRunTree: (worktreeId: string, runId: string) =>
+    request<AgentRun[]>(`/worktrees/${worktreeId}/agent/runs/${runId}/tree`),
+  getRunTreeTotals: (worktreeId: string, runId: string) =>
+    request<RunTreeTotals>(
+      `/worktrees/${worktreeId}/agent/runs/${runId}/tree-totals`,
+    ),
 
   // Global config
   getGlobalModel: () => request<GlobalConfig>("/config/model"),

--- a/conductor-web/frontend/src/api/types.ts
+++ b/conductor-web/frontend/src/api/types.ts
@@ -84,6 +84,14 @@ export interface AgentRun {
   tmux_window: string | null;
   log_file: string | null;
   plan: PlanStep[] | null;
+  parent_run_id: string | null;
+}
+
+export interface RunTreeTotals {
+  total_runs: number;
+  total_cost: number;
+  total_turns: number;
+  total_duration_ms: number;
 }
 
 export interface AgentEvent {

--- a/conductor-web/frontend/src/components/agents/AgentStatusDisplay.tsx
+++ b/conductor-web/frontend/src/components/agents/AgentStatusDisplay.tsx
@@ -1,5 +1,6 @@
 import type { AgentRun } from "../../api/types";
 import { TimeAgo } from "../shared/TimeAgo";
+import { ChildRunsList } from "./ChildRunsList";
 
 const statusColors: Record<string, string> = {
   running: "bg-yellow-100 text-yellow-700",
@@ -23,6 +24,7 @@ function formatCost(usd: number): string {
 interface AgentStatusDisplayProps {
   run: AgentRun;
   runs: AgentRun[];
+  childRuns?: AgentRun[];
   onLaunch: () => void;
   onStop: () => void;
 }
@@ -30,12 +32,14 @@ interface AgentStatusDisplayProps {
 export function AgentStatusDisplay({
   run,
   runs,
+  childRuns,
   onLaunch,
   onStop,
 }: AgentStatusDisplayProps) {
   const color = statusColors[run.status] ?? "bg-gray-100 text-gray-600";
+  const hasChildren = childRuns && childRuns.length > 0;
 
-  // Aggregate totals across all completed runs
+  // Aggregate totals across all completed runs (top-level only)
   const completedRuns = runs.filter((r) => r.status === "completed");
   const totalCost = completedRuns.reduce((s, r) => s + (r.cost_usd ?? 0), 0);
   const totalTurns = completedRuns.reduce((s, r) => s + (r.num_turns ?? 0), 0);
@@ -54,6 +58,21 @@ export function AgentStatusDisplay({
       ? totalDurationMs + (run.duration_ms ?? 0)
       : totalDurationMs;
 
+  // If the latest run has child runs, compute aggregated (parent + children) totals
+  const childCost = hasChildren
+    ? childRuns.reduce((s, r) => s + (r.cost_usd ?? 0), 0)
+    : 0;
+  const childTurns = hasChildren
+    ? childRuns.reduce((s, r) => s + (r.num_turns ?? 0), 0)
+    : 0;
+  const childDurationMs = hasChildren
+    ? childRuns.reduce((s, r) => s + (r.duration_ms ?? 0), 0)
+    : 0;
+
+  const treeCost = displayCost + childCost;
+  const treeTurns = displayTurns + childTurns;
+  const treeDuration = displayDuration + childDurationMs;
+
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-4">
       <div className="flex items-center justify-between mb-3">
@@ -68,6 +87,11 @@ export function AgentStatusDisplay({
           </span>
           {run.status === "running" && (
             <span className="inline-block w-2 h-2 rounded-full bg-yellow-400 animate-pulse" />
+          )}
+          {hasChildren && (
+            <span className="inline-block px-2 py-0.5 text-xs font-medium rounded-full bg-indigo-100 text-indigo-700">
+              {childRuns.length} child{childRuns.length !== 1 ? "ren" : ""}
+            </span>
           )}
         </div>
         <div className="flex gap-2">
@@ -90,25 +114,31 @@ export function AgentStatusDisplay({
       </div>
 
       <dl className="grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-2 text-sm">
-        {displayCost > 0 && (
+        {treeCost > 0 && (
           <div>
-            <dt className="text-gray-500">Cost</dt>
+            <dt className="text-gray-500">
+              Cost{hasChildren ? " (tree)" : ""}
+            </dt>
             <dd className="font-medium text-gray-900">
-              {formatCost(displayCost)}
+              {formatCost(treeCost)}
             </dd>
           </div>
         )}
-        {displayTurns > 0 && (
+        {treeTurns > 0 && (
           <div>
-            <dt className="text-gray-500">Turns</dt>
-            <dd className="font-medium text-gray-900">{displayTurns}</dd>
+            <dt className="text-gray-500">
+              Turns{hasChildren ? " (tree)" : ""}
+            </dt>
+            <dd className="font-medium text-gray-900">{treeTurns}</dd>
           </div>
         )}
-        {displayDuration > 0 && (
+        {treeDuration > 0 && (
           <div>
-            <dt className="text-gray-500">Duration</dt>
+            <dt className="text-gray-500">
+              Duration{hasChildren ? " (tree)" : ""}
+            </dt>
             <dd className="font-medium text-gray-900">
-              {formatDuration(displayDuration)}
+              {formatDuration(treeDuration)}
             </dd>
           </div>
         )}
@@ -145,6 +175,8 @@ export function AgentStatusDisplay({
           {run.result_text}
         </div>
       )}
+
+      {hasChildren && <ChildRunsList children={childRuns} />}
     </div>
   );
 }

--- a/conductor-web/frontend/src/components/agents/ChildRunsList.tsx
+++ b/conductor-web/frontend/src/components/agents/ChildRunsList.tsx
@@ -1,0 +1,77 @@
+import type { AgentRun } from "../../api/types";
+import { TimeAgo } from "../shared/TimeAgo";
+
+const statusColors: Record<string, string> = {
+  running: "bg-yellow-100 text-yellow-700",
+  completed: "bg-green-100 text-green-700",
+  failed: "bg-red-100 text-red-700",
+  cancelled: "bg-gray-100 text-gray-600",
+};
+
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  return `${minutes}m ${remaining}s`;
+}
+
+function formatCost(usd: number): string {
+  return `$${usd.toFixed(4)}`;
+}
+
+interface ChildRunsListProps {
+  children: AgentRun[];
+}
+
+export function ChildRunsList({ children }: ChildRunsListProps) {
+  if (children.length === 0) return null;
+
+  return (
+    <div className="mt-3 border-t border-gray-100 pt-3">
+      <h4 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-2">
+        Child Runs ({children.length})
+      </h4>
+      <div className="space-y-2">
+        {children.map((child) => {
+          const color =
+            statusColors[child.status] ?? "bg-gray-100 text-gray-600";
+          return (
+            <div
+              key={child.id}
+              className="flex items-center gap-3 rounded-md border border-gray-100 bg-gray-50 px-3 py-2 text-sm"
+            >
+              <span
+                className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${color}`}
+              >
+                {child.status}
+              </span>
+              {child.status === "running" && (
+                <span className="inline-block w-2 h-2 rounded-full bg-yellow-400 animate-pulse" />
+              )}
+              <span className="text-gray-700 truncate flex-1" title={child.prompt}>
+                {child.prompt.length > 80
+                  ? child.prompt.slice(0, 80) + "..."
+                  : child.prompt}
+              </span>
+              <span className="shrink-0 text-xs text-gray-500 tabular-nums space-x-2">
+                {child.cost_usd != null && child.cost_usd > 0 && (
+                  <span>{formatCost(child.cost_usd)}</span>
+                )}
+                {child.num_turns != null && child.num_turns > 0 && (
+                  <span>{child.num_turns}t</span>
+                )}
+                {child.duration_ms != null && child.duration_ms > 0 && (
+                  <span>{formatDuration(child.duration_ms)}</span>
+                )}
+              </span>
+              <span className="shrink-0 text-xs text-gray-400">
+                <TimeAgo date={child.started_at} />
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
+++ b/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
@@ -50,6 +50,7 @@ export function WorktreeDetailPage() {
   // Agent state
   const [latestRun, setLatestRun] = useState<AgentRun | null>(null);
   const [agentRuns, setAgentRuns] = useState<AgentRun[]>([]);
+  const [childRuns, setChildRuns] = useState<AgentRun[]>([]);
   const [agentEvents, setAgentEvents] = useState<AgentEvent[]>([]);
   const [promptModalOpen, setPromptModalOpen] = useState(false);
   const [promptInfo, setPromptInfo] = useState({
@@ -87,6 +88,18 @@ export function WorktreeDetailPage() {
       setLatestRun(latest);
       setAgentRuns(runs);
       setAgentEvents(events);
+
+      // Fetch child runs for the latest run (if it has no parent — i.e. it's a root run)
+      if (latest && !latest.parent_run_id) {
+        try {
+          const children = await api.listChildRuns(worktreeId, latest.id);
+          setChildRuns(children);
+        } catch {
+          setChildRuns([]);
+        }
+      } else {
+        setChildRuns([]);
+      }
     } catch {
       // Silently ignore — agent data may not exist yet
     }
@@ -491,6 +504,7 @@ export function WorktreeDetailPage() {
           <AgentStatusDisplay
             run={latestRun}
             runs={agentRuns}
+            childRuns={childRuns}
             onLaunch={handleLaunchClick}
             onStop={() => setStopConfirm(true)}
           />

--- a/conductor-web/src/routes/agents.rs
+++ b/conductor-web/src/routes/agents.rs
@@ -7,7 +7,8 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 
 use conductor_core::agent::{
-    parse_agent_log, AgentEvent, AgentManager, AgentRun, AgentRunEvent, TicketAgentTotals,
+    parse_agent_log, AgentEvent, AgentManager, AgentRun, AgentRunEvent, RunTreeTotals,
+    TicketAgentTotals,
 };
 use conductor_core::repo::RepoManager;
 use conductor_core::tickets::{build_agent_prompt, TicketSyncer};
@@ -75,6 +76,7 @@ pub async fn latest_run(
 pub struct StartAgentRequest {
     pub prompt: String,
     pub resume_session_id: Option<String>,
+    pub parent_run_id: Option<String>,
 }
 
 /// Start an agent for a worktree. Creates a DB record and spawns a tmux window.
@@ -110,8 +112,18 @@ pub async fn start_agent(
         .or(config.general.model.as_deref())
         .map(str::to_string);
 
-    // Create DB record
-    let run = agent_mgr.create_run(&worktree_id, &body.prompt, Some(&wt.slug), model.as_deref())?;
+    // Create DB record (child or top-level)
+    let run = if let Some(ref parent_id) = body.parent_run_id {
+        agent_mgr.create_child_run(
+            &worktree_id,
+            &body.prompt,
+            Some(&wt.slug),
+            model.as_deref(),
+            parent_id,
+        )?
+    } else {
+        agent_mgr.create_run(&worktree_id, &body.prompt, Some(&wt.slug), model.as_deref())?
+    };
 
     // Build conductor agent run command
     let mut args = vec![
@@ -412,6 +424,41 @@ pub async fn get_prompt(
         prompt,
         resume_session_id,
     }))
+}
+
+// ── Parent/child run tree endpoints ───────────────────────────────────
+
+/// List direct child runs of a given parent run.
+pub async fn list_child_runs(
+    State(state): State<AppState>,
+    Path((_worktree_id, run_id)): Path<(String, String)>,
+) -> Result<Json<Vec<AgentRun>>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = AgentManager::new(&db);
+    let children = mgr.list_child_runs(&run_id)?;
+    Ok(Json(children))
+}
+
+/// Get a full run tree: the root run plus all descendants.
+pub async fn get_run_tree(
+    State(state): State<AppState>,
+    Path((_worktree_id, run_id)): Path<(String, String)>,
+) -> Result<Json<Vec<AgentRun>>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = AgentManager::new(&db);
+    let tree = mgr.get_run_tree(&run_id)?;
+    Ok(Json(tree))
+}
+
+/// Get aggregated cost/turns/duration for a run tree.
+pub async fn get_run_tree_totals(
+    State(state): State<AppState>,
+    Path((_worktree_id, run_id)): Path<(String, String)>,
+) -> Result<Json<RunTreeTotals>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = AgentManager::new(&db);
+    let totals = mgr.aggregate_run_tree(&run_id)?;
+    Ok(Json(totals))
 }
 
 fn strip_worktree_prefix(summary: &str, worktree_path: &str) -> String {

--- a/conductor-web/src/routes/mod.rs
+++ b/conductor-web/src/routes/mod.rs
@@ -72,6 +72,18 @@ pub fn api_router() -> Router<AppState> {
             "/api/worktrees/{id}/agent/runs/{run_id}/events",
             get(agents::get_run_events),
         )
+        .route(
+            "/api/worktrees/{id}/agent/runs/{run_id}/children",
+            get(agents::list_child_runs),
+        )
+        .route(
+            "/api/worktrees/{id}/agent/runs/{run_id}/tree",
+            get(agents::get_run_tree),
+        )
+        .route(
+            "/api/worktrees/{id}/agent/runs/{run_id}/tree-totals",
+            get(agents::get_run_tree_totals),
+        )
         .route("/api/worktrees/{id}/agent/prompt", get(agents::get_prompt))
         // Issue Sources
         .route(


### PR DESCRIPTION
Add parent_run_id to agent_runs for hierarchical run tracking. Includes
migration 012, child-run listing/tree API endpoints, TUI child-run
display, and web UI ChildRunsList component with tree-totals support.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
