### PR TITLE
add build.sh to build frontend and Rust workspace together

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Build script: build frontend then Rust workspace.
+# Run this after pulling main or setting up a new worktree.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+echo "==> Building frontend..."
+cd "$REPO_ROOT/conductor-web/frontend"
+npm install
+npm run build
+
+echo "==> Building Rust workspace..."
+cd "$REPO_ROOT"
+cargo build --workspace
+
+echo "==> Done."


### PR DESCRIPTION
## Summary
- Adds `build.sh` script to the repo root
- Runs `npm install && npm run build` in `conductor-web/frontend`, then `cargo build --workspace`
- Uses `set -e` to fail fast and resolves the repo root from the script location (works from any worktree)

## Test plan
- [x] Run `./build.sh` from repo root and verify frontend and Rust workspace both build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)