### PR TITLE
feat: model picker with curated list, effective default, and suggestions (#122)

### DIFF
--- a/conductor-core/src/lib.rs
+++ b/conductor-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod github;
 pub mod issue_source;
 pub mod jira_acli;
+pub mod models;
 pub mod repo;
 pub mod tickets;
 pub mod worktree;

--- a/conductor-core/src/models.rs
+++ b/conductor-core/src/models.rs
@@ -1,0 +1,228 @@
+use serde::Serialize;
+
+/// Tier indicating model capability/cost tradeoff.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub enum ModelTier {
+    /// Fast & cheap (★)
+    Fast = 1,
+    /// Balanced (★★)
+    Balanced = 2,
+    /// Most capable (★★★)
+    Powerful = 3,
+}
+
+/// A known Claude model with metadata for display in pickers.
+#[derive(Debug, Clone, Serialize)]
+pub struct KnownModel {
+    /// Full model ID (e.g. "claude-opus-4-6")
+    pub id: &'static str,
+    /// Short alias (e.g. "opus")
+    pub alias: &'static str,
+    /// Capability/cost tier
+    pub tier: ModelTier,
+    /// Human-readable description of best use cases
+    pub description: &'static str,
+}
+
+impl KnownModel {
+    /// Returns the tier as a star string for display (e.g. "★★★").
+    pub fn tier_stars(&self) -> &'static str {
+        match self.tier {
+            ModelTier::Fast => "★",
+            ModelTier::Balanced => "★★",
+            ModelTier::Powerful => "★★★",
+        }
+    }
+
+    /// Returns the tier label (e.g. "Fast", "Balanced", "Powerful").
+    pub fn tier_label(&self) -> &'static str {
+        match self.tier {
+            ModelTier::Fast => "Fast",
+            ModelTier::Balanced => "Balanced",
+            ModelTier::Powerful => "Powerful",
+        }
+    }
+}
+
+/// Curated list of known Claude models, ordered by tier (powerful → fast).
+pub const KNOWN_MODELS: &[KnownModel] = &[
+    KnownModel {
+        id: "claude-opus-4-6",
+        alias: "opus",
+        tier: ModelTier::Powerful,
+        description: "Planning, architecture, complex analysis",
+    },
+    KnownModel {
+        id: "claude-sonnet-4-6",
+        alias: "sonnet",
+        tier: ModelTier::Balanced,
+        description: "General implementation (default)",
+    },
+    KnownModel {
+        id: "claude-haiku-4-5-20251001",
+        alias: "haiku",
+        tier: ModelTier::Fast,
+        description: "Commit messages, formatting, quick edits",
+    },
+];
+
+/// Look up a known model by its ID or alias. Returns `None` for custom model strings.
+pub fn find_known_model(id_or_alias: &str) -> Option<&'static KnownModel> {
+    KNOWN_MODELS
+        .iter()
+        .find(|m| m.id == id_or_alias || m.alias == id_or_alias)
+}
+
+/// Keywords that suggest a fast/cheap model (haiku).
+const HAIKU_KEYWORDS: &[&str] = &[
+    "commit",
+    "format",
+    "lint",
+    "rename",
+    "typo",
+    "bump version",
+    "changelog",
+    "formatting",
+    "fix typo",
+    "update version",
+];
+
+/// Keywords that suggest a powerful model (opus).
+const OPUS_KEYWORDS: &[&str] = &[
+    "plan",
+    "architect",
+    "design",
+    "refactor",
+    "analyze",
+    "review",
+    "implement",
+    "rewrite",
+    "migrate",
+    "complex",
+];
+
+/// Suggest a model alias based on prompt text using keyword heuristics.
+///
+/// Returns the alias of the suggested model ("haiku", "opus", or "sonnet").
+/// This is a pure function with no side effects.
+pub fn suggest_model(prompt: &str) -> &'static str {
+    let lower = prompt.to_lowercase();
+
+    // Check haiku keywords first (cheap tasks)
+    for kw in HAIKU_KEYWORDS {
+        if lower.contains(kw) {
+            return "haiku";
+        }
+    }
+
+    // Check opus keywords (complex tasks)
+    for kw in OPUS_KEYWORDS {
+        if lower.contains(kw) {
+            return "opus";
+        }
+    }
+
+    // Default to sonnet
+    "sonnet"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_known_models_count() {
+        assert_eq!(KNOWN_MODELS.len(), 3);
+    }
+
+    #[test]
+    fn test_known_models_order() {
+        // Ordered powerful → fast
+        assert_eq!(KNOWN_MODELS[0].alias, "opus");
+        assert_eq!(KNOWN_MODELS[1].alias, "sonnet");
+        assert_eq!(KNOWN_MODELS[2].alias, "haiku");
+    }
+
+    #[test]
+    fn test_find_known_model_by_id() {
+        let m = find_known_model("claude-sonnet-4-6").unwrap();
+        assert_eq!(m.alias, "sonnet");
+    }
+
+    #[test]
+    fn test_find_known_model_by_alias() {
+        let m = find_known_model("opus").unwrap();
+        assert_eq!(m.id, "claude-opus-4-6");
+    }
+
+    #[test]
+    fn test_find_known_model_unknown() {
+        assert!(find_known_model("gpt-4").is_none());
+    }
+
+    #[test]
+    fn test_suggest_model_commit() {
+        assert_eq!(
+            suggest_model("write a commit message for these changes"),
+            "haiku"
+        );
+    }
+
+    #[test]
+    fn test_suggest_model_format() {
+        assert_eq!(suggest_model("format the code"), "haiku");
+    }
+
+    #[test]
+    fn test_suggest_model_lint() {
+        assert_eq!(suggest_model("fix lint errors"), "haiku");
+    }
+
+    #[test]
+    fn test_suggest_model_plan() {
+        assert_eq!(
+            suggest_model("plan the architecture for authentication"),
+            "opus"
+        );
+    }
+
+    #[test]
+    fn test_suggest_model_refactor() {
+        assert_eq!(suggest_model("refactor the database module"), "opus");
+    }
+
+    #[test]
+    fn test_suggest_model_implement() {
+        assert_eq!(suggest_model("implement the new API endpoint"), "opus");
+    }
+
+    #[test]
+    fn test_suggest_model_default() {
+        assert_eq!(suggest_model("fix the login bug"), "sonnet");
+    }
+
+    #[test]
+    fn test_suggest_model_empty() {
+        assert_eq!(suggest_model(""), "sonnet");
+    }
+
+    #[test]
+    fn test_suggest_model_case_insensitive() {
+        assert_eq!(suggest_model("COMMIT message please"), "haiku");
+        assert_eq!(suggest_model("PLAN the architecture"), "opus");
+    }
+
+    #[test]
+    fn test_tier_stars() {
+        assert_eq!(KNOWN_MODELS[0].tier_stars(), "★★★");
+        assert_eq!(KNOWN_MODELS[1].tier_stars(), "★★");
+        assert_eq!(KNOWN_MODELS[2].tier_stars(), "★");
+    }
+
+    #[test]
+    fn test_tier_labels() {
+        assert_eq!(KNOWN_MODELS[0].tier_label(), "Powerful");
+        assert_eq!(KNOWN_MODELS[1].tier_label(), "Balanced");
+        assert_eq!(KNOWN_MODELS[2].tier_label(), "Fast");
+    }
+}

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -192,16 +192,43 @@ impl App {
             Action::ConfirmNo => {
                 self.state.modal = Modal::None;
             }
-            Action::InputChar(c) => {
-                if let Modal::Input { ref mut value, .. } = self.state.modal {
+            Action::InputChar(c) => match self.state.modal {
+                Modal::Input { ref mut value, .. } => {
                     value.push(c);
                 }
-            }
-            Action::InputBackspace => {
-                if let Modal::Input { ref mut value, .. } = self.state.modal {
+                Modal::ModelPicker {
+                    ref mut custom_input,
+                    custom_active: true,
+                    ..
+                } => {
+                    custom_input.push(c);
+                }
+                _ => {}
+            },
+            Action::InputBackspace => match self.state.modal {
+                Modal::Input { ref mut value, .. } => {
                     value.pop();
                 }
-            }
+                Modal::ModelPicker {
+                    ref mut custom_input,
+                    custom_active: true,
+                    ..
+                } => {
+                    custom_input.pop();
+                }
+                Modal::ModelPicker {
+                    custom_active: false,
+                    ref on_submit,
+                    ..
+                } => {
+                    // Backspace in non-custom mode: clear the model (submit empty value)
+                    let on_submit = on_submit.clone();
+                    self.state.modal = Modal::None;
+                    self.handle_input_submit_with_value(String::new(), on_submit);
+                    return true;
+                }
+                _ => {}
+            },
             Action::InputSubmit => self.handle_input_submit(),
             Action::TextAreaInput(key) => {
                 if let Modal::AgentPrompt {
@@ -580,6 +607,20 @@ impl App {
 
     fn move_up(&mut self) {
         match self.state.modal {
+            Modal::ModelPicker {
+                ref mut selected,
+                ref mut custom_active,
+                ..
+            } => {
+                *custom_active = false;
+                let total = conductor_core::models::KNOWN_MODELS.len() + 1; // +1 for custom
+                if *selected > 0 {
+                    *selected -= 1;
+                } else {
+                    *selected = total - 1;
+                }
+                return;
+            }
             Modal::WorkTargetPicker {
                 ref targets,
                 ref mut selected,
@@ -670,6 +711,20 @@ impl App {
 
     fn move_down(&mut self) {
         match self.state.modal {
+            Modal::ModelPicker {
+                ref mut selected,
+                ref mut custom_active,
+                ..
+            } => {
+                *custom_active = false;
+                let total = conductor_core::models::KNOWN_MODELS.len() + 1; // +1 for custom
+                if *selected + 1 < total {
+                    *selected += 1;
+                } else {
+                    *selected = 0;
+                }
+                return;
+            }
             Modal::WorkTargetPicker {
                 ref targets,
                 ref mut selected,
@@ -1004,7 +1059,7 @@ impl App {
     fn handle_input_submit(&mut self) {
         let modal = std::mem::replace(&mut self.state.modal, Modal::None);
 
-        // Extract (value, on_submit) from either Input or AgentPrompt modals
+        // Extract (value, on_submit) from Input, AgentPrompt, or ModelPicker modals
         let (value, on_submit) = match modal {
             Modal::Input {
                 value, on_submit, ..
@@ -1015,6 +1070,39 @@ impl App {
                 ..
             } => {
                 let value = textarea.lines().join("\n");
+                (value, on_submit)
+            }
+            Modal::ModelPicker {
+                context_label,
+                effective_default,
+                effective_source,
+                selected,
+                custom_input,
+                custom_active,
+                suggested,
+                on_submit,
+            } => {
+                let models = conductor_core::models::KNOWN_MODELS;
+                let value = if custom_active {
+                    custom_input
+                } else if selected < models.len() {
+                    // Selected a known model — use its alias
+                    models[selected].alias.to_string()
+                } else {
+                    // "custom…" was highlighted but Enter pressed without typing:
+                    // re-open the picker with custom mode active
+                    self.state.modal = Modal::ModelPicker {
+                        context_label,
+                        effective_default,
+                        effective_source,
+                        selected,
+                        custom_input,
+                        custom_active: true,
+                        suggested,
+                        on_submit,
+                    };
+                    return;
+                };
                 (value, on_submit)
             }
             _ => return,
@@ -1127,15 +1215,55 @@ impl App {
                     .or(repo_model)
                     .or_else(|| self.config.general.model.clone());
 
-                // Show second step: optional model override
-                let prompt_text = match &resolved_default {
-                    Some(m) => format!("Model (default: {m}, leave blank to use it):"),
-                    None => "Model override (leave blank for claude's default):".to_string(),
+                // Suggest a model based on the prompt text
+                let suggested = conductor_core::models::suggest_model(&value);
+
+                // Pre-select the suggested model in the picker
+                let initial_selected = conductor_core::models::KNOWN_MODELS
+                    .iter()
+                    .position(|m| m.alias == suggested)
+                    .unwrap_or(1); // default to sonnet
+
+                let (effective_default, effective_source) = match &resolved_default {
+                    Some(m) => {
+                        // Determine source
+                        let source = if self
+                            .state
+                            .data
+                            .worktrees
+                            .iter()
+                            .find(|w| w.id == worktree_id)
+                            .and_then(|w| w.model.as_ref())
+                            .is_some()
+                        {
+                            "worktree"
+                        } else if self
+                            .state
+                            .data
+                            .worktrees
+                            .iter()
+                            .find(|w| w.id == worktree_id)
+                            .and_then(|w| self.state.data.repos.iter().find(|r| r.id == w.repo_id))
+                            .and_then(|r| r.model.as_ref())
+                            .is_some()
+                        {
+                            "repo"
+                        } else {
+                            "global config"
+                        };
+                        (Some(m.clone()), source.to_string())
+                    }
+                    None => (None, "not set".to_string()),
                 };
-                self.state.modal = Modal::Input {
-                    title: "Model Override".to_string(),
-                    prompt: prompt_text,
-                    value: String::new(),
+
+                self.state.modal = Modal::ModelPicker {
+                    context_label: "agent run".to_string(),
+                    effective_default,
+                    effective_source,
+                    selected: initial_selected,
+                    custom_input: String::new(),
+                    custom_active: false,
+                    suggested: Some(suggested.to_string()),
                     on_submit: InputAction::AgentModelOverride {
                         prompt: value,
                         worktree_id,
@@ -1221,6 +1349,88 @@ impl App {
                 }
                 let _ = repo_id;
             }
+        }
+    }
+
+    /// Helper: submit a value + action directly (used when clearing model via Backspace).
+    fn handle_input_submit_with_value(&mut self, value: String, on_submit: InputAction) {
+        // Reuse the same match arm logic from handle_input_submit
+        match on_submit {
+            InputAction::SetWorktreeModel {
+                worktree_id,
+                repo_slug,
+                slug,
+            } => {
+                let model = if value.trim().is_empty() {
+                    None
+                } else {
+                    Some(value.trim().to_string())
+                };
+                let mgr = WorktreeManager::new(&self.conn, &self.config);
+                match mgr.set_model(&repo_slug, &slug, model.as_deref()) {
+                    Ok(()) => {
+                        let msg = match &model {
+                            Some(m) => format!("Model for {slug} set to: {m}"),
+                            None => format!("Model for {slug} cleared"),
+                        };
+                        self.state.status_message = Some(msg);
+                        self.refresh_data();
+                    }
+                    Err(e) => {
+                        self.state.modal = Modal::Error {
+                            message: format!("Failed to set model: {e}"),
+                        };
+                    }
+                }
+                let _ = worktree_id;
+            }
+            InputAction::SetRepoModel { repo_id, slug } => {
+                let model = if value.trim().is_empty() {
+                    None
+                } else {
+                    Some(value.trim().to_string())
+                };
+                let mgr = RepoManager::new(&self.conn, &self.config);
+                match mgr.set_model(&slug, model.as_deref()) {
+                    Ok(()) => {
+                        let msg = match &model {
+                            Some(m) => format!("Model for {slug} set to: {m}"),
+                            None => format!("Model for {slug} cleared"),
+                        };
+                        self.state.status_message = Some(msg);
+                        self.refresh_data();
+                    }
+                    Err(e) => {
+                        self.state.modal = Modal::Error {
+                            message: format!("Failed to set model: {e}"),
+                        };
+                    }
+                }
+                let _ = repo_id;
+            }
+            InputAction::AgentModelOverride {
+                prompt,
+                worktree_id,
+                worktree_path,
+                worktree_slug,
+                resume_session_id,
+                resolved_default,
+            } => {
+                let model = if value.trim().is_empty() {
+                    resolved_default
+                } else {
+                    Some(value)
+                };
+                self.start_agent_tmux(
+                    prompt,
+                    worktree_id,
+                    worktree_path,
+                    worktree_slug,
+                    resume_session_id,
+                    model,
+                );
+            }
+            _ => {}
         }
     }
 
@@ -2171,6 +2381,40 @@ impl App {
     // ── Model configuration ────────────────────────────────────────────
 
     fn handle_set_model(&mut self) {
+        // Helper to compute effective default and source for a worktree context
+        let resolve_wt_effective =
+            |wt: &conductor_core::worktree::Worktree,
+             config: &conductor_core::config::Config,
+             repos: &[conductor_core::repo::Repo]| {
+                let repo_model = repos
+                    .iter()
+                    .find(|r| r.id == wt.repo_id)
+                    .and_then(|r| r.model.clone());
+                if let Some(ref m) = wt.model {
+                    (Some(m.clone()), "worktree".to_string())
+                } else if let Some(ref m) = repo_model {
+                    (Some(m.clone()), "repo".to_string())
+                } else if let Some(ref m) = config.general.model {
+                    (Some(m.clone()), "global config".to_string())
+                } else {
+                    (None, "not set".to_string())
+                }
+            };
+
+        // Helper to find the initial selected index matching current model
+        let initial_selected = |current: &Option<String>| -> usize {
+            match current {
+                Some(m) => conductor_core::models::KNOWN_MODELS
+                    .iter()
+                    .position(|km| km.id == m.as_str() || km.alias == m.as_str())
+                    .unwrap_or(conductor_core::models::KNOWN_MODELS.len()),
+                None => {
+                    // Default to sonnet (index 1)
+                    1
+                }
+            }
+        };
+
         match self.state.view {
             View::Dashboard => {
                 use crate::state::DashboardFocus;
@@ -2192,12 +2436,17 @@ impl App {
                             .get(&wt.repo_id)
                             .cloned()
                             .unwrap_or_default();
-                        let current = wt.model.clone().unwrap_or_default();
-                        self.state.modal = Modal::Input {
-                            title: "Set Worktree Model".to_string(),
-                            prompt: "Model (e.g. claude-sonnet-4-6, leave blank to clear):"
-                                .to_string(),
-                            value: current,
+                        let (effective, source) =
+                            resolve_wt_effective(&wt, &self.config, &self.state.data.repos);
+                        let selected = initial_selected(&wt.model);
+                        self.state.modal = Modal::ModelPicker {
+                            context_label: format!("worktree: {}", wt.slug),
+                            effective_default: effective,
+                            effective_source: source,
+                            selected,
+                            custom_input: String::new(),
+                            custom_active: false,
+                            suggested: None,
                             on_submit: InputAction::SetWorktreeModel {
                                 worktree_id: wt.id.clone(),
                                 repo_slug,
@@ -2210,12 +2459,22 @@ impl App {
                         else {
                             return;
                         };
-                        let current = repo.model.clone().unwrap_or_default();
-                        self.state.modal = Modal::Input {
-                            title: "Set Repo Model".to_string(),
-                            prompt: "Model (e.g. claude-sonnet-4-6, leave blank to clear):"
-                                .to_string(),
-                            value: current,
+                        let (effective, source) = if let Some(ref m) = repo.model {
+                            (Some(m.clone()), "repo".to_string())
+                        } else if let Some(ref m) = self.config.general.model {
+                            (Some(m.clone()), "global config".to_string())
+                        } else {
+                            (None, "not set".to_string())
+                        };
+                        let selected = initial_selected(&repo.model);
+                        self.state.modal = Modal::ModelPicker {
+                            context_label: format!("repo: {}", repo.slug),
+                            effective_default: effective,
+                            effective_source: source,
+                            selected,
+                            custom_input: String::new(),
+                            custom_active: false,
+                            suggested: None,
                             on_submit: InputAction::SetRepoModel {
                                 repo_id: repo.id.clone(),
                                 slug: repo.slug.clone(),
@@ -2242,11 +2501,17 @@ impl App {
                     .get(&wt.repo_id)
                     .cloned()
                     .unwrap_or_default();
-                let current = wt.model.clone().unwrap_or_default();
-                self.state.modal = Modal::Input {
-                    title: "Set Worktree Model".to_string(),
-                    prompt: "Model (e.g. claude-sonnet-4-6, leave blank to clear):".to_string(),
-                    value: current,
+                let (effective, source) =
+                    resolve_wt_effective(&wt, &self.config, &self.state.data.repos);
+                let selected = initial_selected(&wt.model);
+                self.state.modal = Modal::ModelPicker {
+                    context_label: format!("worktree: {}", wt.slug),
+                    effective_default: effective,
+                    effective_source: source,
+                    selected,
+                    custom_input: String::new(),
+                    custom_active: false,
+                    suggested: None,
                     on_submit: InputAction::SetWorktreeModel {
                         worktree_id: wt.id.clone(),
                         repo_slug,
@@ -2264,11 +2529,22 @@ impl App {
                 else {
                     return;
                 };
-                let current = repo.model.clone().unwrap_or_default();
-                self.state.modal = Modal::Input {
-                    title: "Set Repo Model".to_string(),
-                    prompt: "Model (e.g. claude-sonnet-4-6, leave blank to clear):".to_string(),
-                    value: current,
+                let (effective, source) = if let Some(ref m) = repo.model {
+                    (Some(m.clone()), "repo".to_string())
+                } else if let Some(ref m) = self.config.general.model {
+                    (Some(m.clone()), "global config".to_string())
+                } else {
+                    (None, "not set".to_string())
+                };
+                let selected = initial_selected(&repo.model);
+                self.state.modal = Modal::ModelPicker {
+                    context_label: format!("repo: {}", repo.slug),
+                    effective_default: effective,
+                    effective_source: source,
+                    selected,
+                    custom_input: String::new(),
+                    custom_active: false,
+                    suggested: None,
                     on_submit: InputAction::SetRepoModel {
                         repo_id: repo.id.clone(),
                         slug: repo.slug.clone(),

--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -75,6 +75,26 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
                 _ => Action::None,
             };
         }
+        Modal::ModelPicker { custom_active, .. } => {
+            if *custom_active {
+                // In custom input mode: type characters, backspace, enter to confirm, esc to leave custom mode
+                return match key.code {
+                    KeyCode::Enter => Action::InputSubmit,
+                    KeyCode::Esc => Action::DismissModal,
+                    KeyCode::Backspace => Action::InputBackspace,
+                    KeyCode::Char(c) => Action::InputChar(c),
+                    _ => Action::None,
+                };
+            }
+            return match key.code {
+                KeyCode::Esc => Action::DismissModal,
+                KeyCode::Up | KeyCode::Char('k') => Action::MoveUp,
+                KeyCode::Down | KeyCode::Char('j') => Action::MoveDown,
+                KeyCode::Enter => Action::InputSubmit,
+                KeyCode::Backspace => Action::InputBackspace,
+                _ => Action::None,
+            };
+        }
         Modal::WorkTargetPicker { targets, .. } => {
             return match key.code {
                 KeyCode::Esc => Action::DismissModal,

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -116,6 +116,25 @@ pub enum Modal {
         loading: bool,
         error: Option<String>,
     },
+    /// Model picker with curated list and effective default display.
+    ModelPicker {
+        /// Label for the context (e.g. "worktree: my-wt" or "repo: my-repo")
+        context_label: String,
+        /// The currently effective model from the resolution chain, if any.
+        effective_default: Option<String>,
+        /// Where the effective default came from (e.g. "global config", "repo", "worktree")
+        effective_source: String,
+        /// Index of the currently selected item in the list (0..=KNOWN_MODELS.len() for custom)
+        selected: usize,
+        /// Custom model input text (when user selects "custom…")
+        custom_input: String,
+        /// Whether the custom input line is active
+        custom_active: bool,
+        /// Suggested model alias based on prompt keywords (e.g. "haiku", "opus"), if any
+        suggested: Option<String>,
+        /// What to do when a model is selected
+        on_submit: InputAction,
+    },
     /// Second level: browse and import repos for a specific owner.
     GithubDiscover {
         /// Owner whose repos are shown ("" = personal account).
@@ -149,6 +168,11 @@ impl fmt::Debug for Modal {
             Modal::WorkTargetPicker { .. } => write!(f, "Modal::WorkTargetPicker"),
             Modal::WorkTargetManager { .. } => write!(f, "Modal::WorkTargetManager"),
             Modal::IssueSourceManager { .. } => write!(f, "Modal::IssueSourceManager"),
+            Modal::ModelPicker {
+                ref context_label, ..
+            } => {
+                write!(f, "Modal::ModelPicker(ctx={context_label:?})")
+            }
             Modal::GithubDiscoverOrgs { loading, .. } => {
                 write!(f, "Modal::GithubDiscoverOrgs(loading={loading})")
             }

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -80,6 +80,26 @@ pub fn render(frame: &mut Frame, state: &AppState) {
             selected,
             ..
         } => modal::render_issue_source_manager(frame, area, repo_slug, sources, *selected),
+        Modal::ModelPicker {
+            context_label,
+            effective_default,
+            effective_source,
+            selected,
+            custom_input,
+            custom_active,
+            suggested,
+            ..
+        } => modal::render_model_picker(
+            frame,
+            area,
+            context_label,
+            effective_default.as_deref(),
+            effective_source,
+            *selected,
+            custom_input,
+            *custom_active,
+            suggested.as_deref(),
+        ),
         Modal::GithubDiscoverOrgs {
             orgs,
             cursor,

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -527,6 +527,173 @@ pub fn render_agent_prompt(
     frame.render_widget(hint, chunks[2]);
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn render_model_picker(
+    frame: &mut Frame,
+    area: Rect,
+    context_label: &str,
+    effective_default: Option<&str>,
+    effective_source: &str,
+    selected: usize,
+    custom_input: &str,
+    custom_active: bool,
+    suggested: Option<&str>,
+) {
+    use conductor_core::models::KNOWN_MODELS;
+
+    let popup = centered_rect(55, 55, area);
+    frame.render_widget(Clear, popup);
+
+    let dim = Style::default().fg(Color::DarkGray);
+    let cyan_bold = Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+
+    let mut lines = vec![Line::from("")];
+
+    // Context label
+    lines.push(Line::from(Span::styled(
+        format!("  {context_label}"),
+        cyan_bold,
+    )));
+    lines.push(Line::from(""));
+
+    // Effective default display
+    let default_display = match effective_default {
+        Some(m) => format!("Using: {m}  (from {effective_source})"),
+        None => format!("Using: claude default  ({effective_source})"),
+    };
+    lines.push(Line::from(Span::styled(
+        format!("  {default_display}"),
+        Style::default().fg(Color::Yellow),
+    )));
+    lines.push(Line::from(Span::styled(
+        "         \u{2191} override with:",
+        dim,
+    )));
+    lines.push(Line::from(""));
+
+    // Known models list
+    for (i, model) in KNOWN_MODELS.iter().enumerate() {
+        let is_selected = !custom_active && i == selected;
+        let is_current = effective_default.is_some_and(|d| d == model.id || d == model.alias);
+
+        let prefix = if is_selected { "\u{25b8} " } else { "  " };
+
+        let current_marker = if is_current { " (current)" } else { "" };
+
+        let suggested_marker = if suggested == Some(model.alias) && !is_current {
+            " [Suggested]"
+        } else {
+            ""
+        };
+
+        let style = if is_selected {
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {prefix}"), style),
+            Span::styled(
+                format!("{} ", model.tier_stars()),
+                Style::default().fg(match model.tier {
+                    conductor_core::models::ModelTier::Powerful => Color::Magenta,
+                    conductor_core::models::ModelTier::Balanced => Color::Cyan,
+                    conductor_core::models::ModelTier::Fast => Color::Green,
+                }),
+            ),
+            Span::styled(format!("{:<7}", model.alias), style),
+            Span::styled(format!(" \u{2014} {}", model.description), dim),
+            Span::styled(current_marker, Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                suggested_marker,
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+    }
+
+    // Custom input option
+    let custom_idx = KNOWN_MODELS.len();
+    let custom_selected = !custom_active && selected == custom_idx;
+    let custom_prefix = if custom_selected || custom_active {
+        "\u{25b8} "
+    } else {
+        "  "
+    };
+    let custom_style = if custom_selected || custom_active {
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::White)
+    };
+
+    if custom_active {
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {custom_prefix}"), custom_style),
+            Span::styled("custom: ", custom_style),
+            Span::styled(
+                custom_input,
+                Style::default().add_modifier(Modifier::UNDERLINED),
+            ),
+            Span::styled("_", Style::default().fg(Color::Cyan)),
+        ]));
+    } else {
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {custom_prefix}"), custom_style),
+            Span::styled("custom\u{2026}", custom_style),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+
+    // Clear option
+    lines.push(Line::from(Span::styled(
+        "  (Backspace to clear model override)",
+        dim,
+    )));
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![
+        Span::styled(
+            "  j/k",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" navigate  ", dim),
+        Span::styled(
+            "Enter",
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" select  ", dim),
+        Span::styled(
+            "Esc",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" cancel", dim),
+    ]));
+
+    let content = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(" Model Picker "),
+    );
+
+    frame.render_widget(content, popup);
+}
+
 pub fn render_issue_source_manager(
     frame: &mut Frame,
     area: Rect,

--- a/conductor-web/frontend/src/api/client.ts
+++ b/conductor-web/frontend/src/api/client.ts
@@ -19,6 +19,7 @@ import type {
   CreateIssueSourceRequest,
   DiscoverableRepo,
   GlobalConfig,
+  KnownModel,
 } from "./types";
 
 const BASE = "/api";
@@ -136,6 +137,12 @@ export const api = {
     request<GlobalConfig>("/config/model", {
       method: "PATCH",
       body: JSON.stringify({ model }),
+    }),
+  listKnownModels: () => request<KnownModel[]>("/config/known-models"),
+  suggestModel: (prompt: string) =>
+    request<{ suggested: string }>("/config/suggest-model", {
+      method: "POST",
+      body: JSON.stringify({ prompt }),
     }),
 
   // Work Targets

--- a/conductor-web/frontend/src/api/types.ts
+++ b/conductor-web/frontend/src/api/types.ts
@@ -151,6 +151,14 @@ export interface GlobalConfig {
   model: string | null;
 }
 
+export interface KnownModel {
+  id: string;
+  alias: string;
+  tier: number;
+  tier_label: string;
+  description: string;
+}
+
 export interface DiscoverableRepo {
   name: string;
   /** "owner/repo" format */

--- a/conductor-web/frontend/src/components/agents/AgentPromptModal.tsx
+++ b/conductor-web/frontend/src/components/agents/AgentPromptModal.tsx
@@ -1,4 +1,27 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
+import type { KnownModel } from "../../api/types";
+import { api } from "../../api/client";
+
+/** Client-side keyword heuristics matching conductor-core's suggest_model(). */
+const HAIKU_KEYWORDS = [
+  "commit", "format", "lint", "rename", "typo", "bump version",
+  "changelog", "formatting", "fix typo", "update version",
+];
+const OPUS_KEYWORDS = [
+  "plan", "architect", "design", "refactor", "analyze", "review",
+  "implement", "rewrite", "migrate", "complex",
+];
+
+function suggestModel(prompt: string): string {
+  const lower = prompt.toLowerCase();
+  for (const kw of HAIKU_KEYWORDS) {
+    if (lower.includes(kw)) return "haiku";
+  }
+  for (const kw of OPUS_KEYWORDS) {
+    if (lower.includes(kw)) return "opus";
+  }
+  return "sonnet";
+}
 
 interface AgentPromptModalProps {
   open: boolean;
@@ -19,6 +42,7 @@ export function AgentPromptModal({
 }: AgentPromptModalProps) {
   const [prompt, setPrompt] = useState(initialPrompt);
   const [useResume, setUseResume] = useState(!!resumeSessionId);
+  const [models, setModels] = useState<KnownModel[]>([]);
 
   useEffect(() => {
     setPrompt(initialPrompt);
@@ -33,6 +57,15 @@ export function AgentPromptModal({
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [open, onCancel]);
+
+  useEffect(() => {
+    if (open && models.length === 0) {
+      api.listKnownModels().then(setModels).catch(() => {});
+    }
+  }, [open, models.length]);
+
+  // Live model suggestion based on prompt text
+  const suggested = useMemo(() => suggestModel(prompt), [prompt]);
 
   if (!open) return null;
 
@@ -65,10 +98,36 @@ export function AgentPromptModal({
         <textarea
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
-          rows={12}
+          rows={10}
           placeholder="Type your prompt here..."
           className="mt-3 w-full rounded-md border border-gray-300 px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 resize-y"
         />
+
+        {/* Model suggestion based on prompt */}
+        {models.length > 0 && prompt.trim() && (
+          <div className="mt-2 flex items-center gap-2 text-xs text-gray-500">
+            <span>Suggested model:</span>
+            {models.map((m) => {
+              const isSuggested = m.alias === suggested;
+              return (
+                <span
+                  key={m.id}
+                  className={`inline-flex items-center px-2 py-0.5 rounded font-medium ${
+                    isSuggested
+                      ? "bg-green-100 text-green-700 ring-1 ring-green-300"
+                      : "bg-gray-100 text-gray-500"
+                  }`}
+                >
+                  {m.alias}
+                  {isSuggested && (
+                    <span className="ml-1 text-green-600">&larr;</span>
+                  )}
+                </span>
+              );
+            })}
+            <span className="text-gray-400 italic ml-1">(hint only)</span>
+          </div>
+        )}
 
         <div className="mt-4 flex justify-end gap-2">
           <button

--- a/conductor-web/frontend/src/components/shared/ModelPicker.tsx
+++ b/conductor-web/frontend/src/components/shared/ModelPicker.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect } from "react";
+import { api } from "../../api/client";
+import type { KnownModel } from "../../api/types";
+
+const TIER_STYLES: Record<number, string> = {
+  3: "text-purple-600",
+  2: "text-blue-600",
+  1: "text-green-600",
+};
+
+const TIER_STARS: Record<number, string> = {
+  3: "\u2605\u2605\u2605",
+  2: "\u2605\u2605",
+  1: "\u2605",
+};
+
+interface ModelPickerProps {
+  /** Currently selected model (id or alias), or null if not set */
+  value: string | null;
+  /** Called when the user selects a model (alias or custom string), or null to clear */
+  onChange: (model: string | null) => void;
+  /** The effective default model from the resolution chain */
+  effectiveDefault?: string | null;
+  /** Where the effective default comes from (e.g. "global config", "repo") */
+  effectiveSource?: string;
+  /** Suggested model alias from prompt analysis */
+  suggested?: string | null;
+  /** Whether the picker is disabled */
+  disabled?: boolean;
+}
+
+export function ModelPicker({
+  value,
+  onChange,
+  effectiveDefault,
+  effectiveSource,
+  suggested,
+  disabled,
+}: ModelPickerProps) {
+  const [models, setModels] = useState<KnownModel[]>([]);
+  const [showCustom, setShowCustom] = useState(false);
+  const [customInput, setCustomInput] = useState("");
+
+  useEffect(() => {
+    api.listKnownModels().then(setModels).catch(() => {});
+  }, []);
+
+  const isCustomValue =
+    value !== null && !models.some((m) => m.alias === value || m.id === value);
+
+  return (
+    <div className="space-y-2">
+      {/* Effective default display */}
+      {effectiveDefault !== undefined && (
+        <div className="text-xs text-gray-500">
+          Using:{" "}
+          <span className="font-mono font-medium text-gray-700">
+            {effectiveDefault ?? "claude default"}
+          </span>
+          {effectiveSource && (
+            <span className="text-gray-400"> (from {effectiveSource})</span>
+          )}
+        </div>
+      )}
+
+      {/* Model options */}
+      <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
+        {models.map((model) => {
+          const isSelected = value === model.alias || value === model.id;
+          const isCurrent =
+            effectiveDefault === model.alias || effectiveDefault === model.id;
+          const isSuggested = suggested === model.alias && !isCurrent;
+
+          return (
+            <button
+              key={model.id}
+              type="button"
+              disabled={disabled}
+              onClick={() => onChange(model.alias)}
+              className={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left transition-colors ${
+                isSelected
+                  ? "bg-indigo-50 border-l-2 border-indigo-500"
+                  : "border-l-2 border-transparent hover:bg-gray-50"
+              } ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+            >
+              <span
+                className={`text-xs w-10 shrink-0 ${TIER_STYLES[model.tier] ?? "text-gray-400"}`}
+              >
+                {TIER_STARS[model.tier] ?? ""}
+              </span>
+              <span className="font-mono font-medium w-16 shrink-0">
+                {model.alias}
+              </span>
+              <span className="text-gray-500 text-xs flex-1">
+                {model.description}
+              </span>
+              <span className="flex items-center gap-1 shrink-0">
+                {isCurrent && (
+                  <span className="text-xs text-gray-400">(current)</span>
+                )}
+                {isSuggested && (
+                  <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
+                    Suggested
+                  </span>
+                )}
+                {isSelected && (
+                  <span className="text-indigo-600 text-xs font-medium">
+                    &#10003;
+                  </span>
+                )}
+              </span>
+            </button>
+          );
+        })}
+
+        {/* Custom option */}
+        {showCustom || isCustomValue ? (
+          <div
+            className={`flex items-center gap-2 px-3 py-2 border-l-2 ${
+              isCustomValue
+                ? "bg-indigo-50 border-indigo-500"
+                : "border-transparent"
+            }`}
+          >
+            <span className="text-xs text-gray-400 w-10 shrink-0">
+              &bull;&bull;&bull;
+            </span>
+            <input
+              type="text"
+              value={isCustomValue ? value ?? "" : customInput}
+              onChange={(e) => {
+                setCustomInput(e.target.value);
+                if (e.target.value.trim()) {
+                  onChange(e.target.value.trim());
+                }
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  setShowCustom(false);
+                  setCustomInput("");
+                }
+              }}
+              placeholder="custom model ID..."
+              className="flex-1 text-sm font-mono border border-gray-300 rounded px-2 py-0.5 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              autoFocus={!isCustomValue}
+              disabled={disabled}
+            />
+            <button
+              type="button"
+              onClick={() => {
+                setShowCustom(false);
+                setCustomInput("");
+              }}
+              className="text-xs text-gray-400 hover:text-gray-600"
+            >
+              &times;
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => setShowCustom(true)}
+            className={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left border-l-2 border-transparent hover:bg-gray-50 text-gray-400 ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+          >
+            <span className="text-xs w-10 shrink-0">&bull;&bull;&bull;</span>
+            <span className="font-mono">custom&hellip;</span>
+          </button>
+        )}
+      </div>
+
+      {/* Clear button */}
+      {value && (
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => {
+            onChange(null);
+            setShowCustom(false);
+            setCustomInput("");
+          }}
+          className="text-xs text-red-600 hover:text-red-700"
+        >
+          Clear model override
+        </button>
+      )}
+    </div>
+  );
+}

--- a/conductor-web/frontend/src/pages/RepoDetailPage.tsx
+++ b/conductor-web/frontend/src/pages/RepoDetailPage.tsx
@@ -12,6 +12,7 @@ import { IssueSourcesSection } from "../components/issue-sources/IssueSourcesSec
 import { ConfirmDialog } from "../components/shared/ConfirmDialog";
 import { LoadingSpinner } from "../components/shared/LoadingSpinner";
 import { EmptyState } from "../components/shared/EmptyState";
+import { ModelPicker } from "../components/shared/ModelPicker";
 import {
   useConductorEvents,
   type ConductorEventType,
@@ -88,7 +89,6 @@ export function RepoDetailPage() {
   const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
   const [createWtOpen, setCreateWtOpen] = useState(false);
   const [editingModel, setEditingModel] = useState(false);
-  const [modelInput, setModelInput] = useState("");
 
   async function handleSyncTickets() {
     setSyncing(true);
@@ -120,11 +120,9 @@ export function RepoDetailPage() {
     window.location.href = "/";
   }
 
-  async function handleSaveModel() {
-    const model = modelInput.trim() || null;
+  async function handleModelChange(model: string | null) {
     try {
       await api.setRepoModel(repoId!, model);
-      setEditingModel(false);
       refreshRepos();
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to save model");
@@ -199,26 +197,27 @@ export function RepoDetailPage() {
           <dt className="font-medium text-gray-500">Model</dt>
           <dd>
             {editingModel ? (
-              <span className="flex items-center gap-2">
-                <input
-                  type="text"
-                  value={modelInput}
-                  onChange={(e) => setModelInput(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") handleSaveModel(); if (e.key === "Escape") setEditingModel(false); }}
-                  placeholder="e.g. claude-sonnet-4-6 (blank to clear)"
-                  className="text-sm border border-gray-300 rounded px-2 py-0.5 w-64 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                  autoFocus
+              <div className="mt-1">
+                <ModelPicker
+                  value={repo.model}
+                  onChange={(m) => { handleModelChange(m); setEditingModel(false); }}
+                  effectiveDefault={repo.model}
+                  effectiveSource="repo"
                 />
-                <button onClick={handleSaveModel} className="px-2 py-0.5 text-xs rounded bg-indigo-600 text-white hover:bg-indigo-700">Save</button>
-                <button onClick={() => setEditingModel(false)} className="px-2 py-0.5 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50">Cancel</button>
-              </span>
+                <button
+                  onClick={() => setEditingModel(false)}
+                  className="mt-2 px-2 py-0.5 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+              </div>
             ) : (
               <span className="flex items-center gap-2">
                 <span className={repo.model ? "" : "text-gray-400"}>
                   {repo.model ?? "Not set"}
                 </span>
                 <button
-                  onClick={() => { setModelInput(repo.model ?? ""); setEditingModel(true); }}
+                  onClick={() => setEditingModel(true)}
                   className="px-2 py-0.5 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
                 >
                   Edit

--- a/conductor-web/frontend/src/pages/SettingsPage.tsx
+++ b/conductor-web/frontend/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import type { WorkTarget } from "../api/types";
 import { LoadingSpinner } from "../components/shared/LoadingSpinner";
 import { EmptyState } from "../components/shared/EmptyState";
 import { ConfirmDialog } from "../components/shared/ConfirmDialog";
+import { ModelPicker } from "../components/shared/ModelPicker";
 
 export function SettingsPage() {
   const {
@@ -17,17 +18,14 @@ export function SettingsPage() {
     () => api.getGlobalModel(),
     [],
   );
-  const [editingGlobalModel, setEditingGlobalModel] = useState(false);
-  const [globalModelInput, setGlobalModelInput] = useState("");
   const [savingGlobalModel, setSavingGlobalModel] = useState(false);
   const [globalModelError, setGlobalModelError] = useState<string | null>(null);
 
-  async function handleSaveGlobalModel() {
+  async function handleGlobalModelChange(model: string | null) {
     setSavingGlobalModel(true);
     setGlobalModelError(null);
     try {
-      await api.setGlobalModel(globalModelInput.trim() || null);
-      setEditingGlobalModel(false);
+      await api.setGlobalModel(model);
       refetchGlobalConfig();
     } catch (err) {
       setGlobalModelError(
@@ -130,75 +128,18 @@ export function SettingsPage() {
         </h3>
         <p className="text-sm text-gray-500 mb-3">
           Default Claude model for all agent runs. Overridden by per-repo and
-          per-worktree model settings. Leave blank to use Claude's default.
+          per-worktree model settings.
         </p>
         {globalModelError && (
           <div className="mb-3 px-3 py-2 text-sm text-red-700 bg-red-50 rounded-md border border-red-200">
             {globalModelError}
           </div>
         )}
-        <div className="rounded-lg border border-gray-200 bg-white px-4 py-3 flex items-center gap-3">
-          <span className="text-sm text-gray-500 w-20 shrink-0">Model</span>
-          {editingGlobalModel ? (
-            <>
-              <input
-                type="text"
-                value={globalModelInput}
-                onChange={(e) => setGlobalModelInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleSaveGlobalModel();
-                  if (e.key === "Escape") setEditingGlobalModel(false);
-                }}
-                placeholder="e.g. claude-sonnet-4-6 or sonnet"
-                className="flex-1 px-2 py-1 text-sm border border-gray-300 rounded focus:ring-indigo-500 focus:border-indigo-500"
-                autoFocus
-              />
-              <button
-                onClick={handleSaveGlobalModel}
-                disabled={savingGlobalModel}
-                className="px-2 py-1 text-xs rounded bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
-              >
-                Save
-              </button>
-              <button
-                onClick={() => setEditingGlobalModel(false)}
-                className="px-2 py-1 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
-              >
-                Cancel
-              </button>
-            </>
-          ) : (
-            <>
-              <span className="flex-1 text-sm">
-                {globalConfig?.model ? (
-                  <span className="font-mono">{globalConfig.model}</span>
-                ) : (
-                  <span className="text-gray-400 italic">not set</span>
-                )}
-              </span>
-              <button
-                onClick={() => {
-                  setGlobalModelInput(globalConfig?.model ?? "");
-                  setEditingGlobalModel(true);
-                }}
-                className="px-2 py-1 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
-              >
-                Edit
-              </button>
-              {globalConfig?.model && (
-                <button
-                  onClick={async () => {
-                    await api.setGlobalModel(null);
-                    refetchGlobalConfig();
-                  }}
-                  className="px-2 py-1 text-xs rounded border border-red-300 text-red-600 hover:bg-red-50"
-                >
-                  Clear
-                </button>
-              )}
-            </>
-          )}
-        </div>
+        <ModelPicker
+          value={globalConfig?.model ?? null}
+          onChange={handleGlobalModelChange}
+          disabled={savingGlobalModel}
+        />
       </section>
 
       {/* Work Targets Section */}

--- a/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
+++ b/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
@@ -8,6 +8,7 @@ import { TimeAgo } from "../components/shared/TimeAgo";
 import { ConfirmDialog } from "../components/shared/ConfirmDialog";
 import { LoadingSpinner } from "../components/shared/LoadingSpinner";
 import { AgentPromptModal } from "../components/agents/AgentPromptModal";
+import { ModelPicker } from "../components/shared/ModelPicker";
 import { AgentStatusDisplay } from "../components/agents/AgentStatusDisplay";
 import { AgentActivityLog } from "../components/agents/AgentActivityLog";
 import { AgentPlanChecklist } from "../components/agents/AgentPlanChecklist";
@@ -45,7 +46,6 @@ export function WorktreeDetailPage() {
   const [linkingTicket, setLinkingTicket] = useState(false);
   const [selectedTicketId, setSelectedTicketId] = useState("");
   const [editingModel, setEditingModel] = useState(false);
-  const [modelInput, setModelInput] = useState("");
 
   // Agent state
   const [latestRun, setLatestRun] = useState<AgentRun | null>(null);
@@ -241,11 +241,9 @@ export function WorktreeDetailPage() {
     }
   }
 
-  async function handleSaveModel() {
-    const model = modelInput.trim() || null;
+  async function handleModelChange(model: string | null) {
     try {
       await api.setWorktreeModel(worktreeId!, model);
-      setEditingModel(false);
       refetchWorktrees();
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to save model");
@@ -342,26 +340,27 @@ export function WorktreeDetailPage() {
             <dt className="font-medium text-gray-500">Model</dt>
             <dd className="mt-1">
               {editingModel ? (
-                <span className="flex items-center gap-2">
-                  <input
-                    type="text"
-                    value={modelInput}
-                    onChange={(e) => setModelInput(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === "Enter") handleSaveModel(); if (e.key === "Escape") setEditingModel(false); }}
-                    placeholder="e.g. claude-sonnet-4-6 (blank to clear)"
-                    className="text-sm border border-gray-300 rounded px-2 py-0.5 w-64 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                    autoFocus
+                <div>
+                  <ModelPicker
+                    value={worktree.model}
+                    onChange={(m) => { handleModelChange(m); setEditingModel(false); }}
+                    effectiveDefault={worktree.model}
+                    effectiveSource="worktree"
                   />
-                  <button onClick={handleSaveModel} className="px-2 py-0.5 text-xs rounded bg-indigo-600 text-white hover:bg-indigo-700">Save</button>
-                  <button onClick={() => setEditingModel(false)} className="px-2 py-0.5 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50">Cancel</button>
-                </span>
+                  <button
+                    onClick={() => setEditingModel(false)}
+                    className="mt-2 px-2 py-0.5 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
               ) : (
                 <span className="flex items-center gap-2">
                   <span className={worktree.model ? "text-gray-900" : "text-gray-400"}>
                     {worktree.model ?? "Not set"}
                   </span>
                   <button
-                    onClick={() => { setModelInput(worktree.model ?? ""); setEditingModel(true); }}
+                    onClick={() => setEditingModel(true)}
                     className="px-2 py-0.5 text-xs rounded border border-gray-300 text-gray-600 hover:bg-gray-50"
                   >
                     Edit

--- a/conductor-web/src/routes/mod.rs
+++ b/conductor-web/src/routes/mod.rs
@@ -100,6 +100,14 @@ pub fn api_router() -> Router<AppState> {
             get(work_targets::get_global_model).patch(work_targets::patch_global_model),
         )
         .route(
+            "/api/config/known-models",
+            get(work_targets::list_known_models),
+        )
+        .route(
+            "/api/config/suggest-model",
+            post(work_targets::suggest_model),
+        )
+        .route(
             "/api/config/work-targets",
             get(work_targets::list_work_targets)
                 .post(work_targets::create_work_target)

--- a/conductor-web/src/routes/work_targets.rs
+++ b/conductor-web/src/routes/work_targets.rs
@@ -4,6 +4,7 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 
 use conductor_core::config::{save_config, WorkTarget};
+use conductor_core::models;
 
 use crate::error::ApiError;
 use crate::events::ConductorEvent;
@@ -111,4 +112,48 @@ pub async fn replace_work_targets(
     let result = config.general.work_targets.clone();
     state.events.emit(ConductorEvent::WorkTargetsChanged);
     Ok(Json(result))
+}
+
+/// Response type for the known models list.
+#[derive(Serialize)]
+pub struct KnownModelResponse {
+    pub id: &'static str,
+    pub alias: &'static str,
+    pub tier: u8,
+    pub tier_label: &'static str,
+    pub description: &'static str,
+}
+
+/// Returns the curated list of known Claude models.
+pub async fn list_known_models() -> Json<Vec<KnownModelResponse>> {
+    let models: Vec<KnownModelResponse> = models::KNOWN_MODELS
+        .iter()
+        .map(|m| KnownModelResponse {
+            id: m.id,
+            alias: m.alias,
+            tier: m.tier as u8,
+            tier_label: m.tier_label(),
+            description: m.description,
+        })
+        .collect();
+    Json(models)
+}
+
+/// Request body for prompt-based model suggestion.
+#[derive(Deserialize)]
+pub struct SuggestModelRequest {
+    pub prompt: String,
+}
+
+/// Response for model suggestion.
+#[derive(Serialize)]
+pub struct SuggestModelResponse {
+    pub suggested: &'static str,
+}
+
+/// Suggest a model based on prompt text using keyword heuristics.
+pub async fn suggest_model(Json(body): Json<SuggestModelRequest>) -> Json<SuggestModelResponse> {
+    Json(SuggestModelResponse {
+        suggested: models::suggest_model(&body.prompt),
+    })
 }


### PR DESCRIPTION
- Add conductor-core/src/models.rs with KnownModel definitions (opus, sonnet, haiku)
- Implement suggest_model() with keyword heuristics for prompt-based suggestions
- TUI: new Modal::ModelPicker with tier display, effective default, and custom input
- TUI: update model selection flows in settings, repo/worktree details, agent launch
- Web: add /api/config/known-models and /api/config/suggest-model endpoints
- Web: new ModelPicker.tsx component with curated list and live suggestions
- Update SettingsPage, RepoDetailPage, WorktreeDetailPage, AgentPromptModal

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
