### PR TITLE
feat: show user prompts and per-run boundaries in agent activity (#121)

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -804,6 +804,14 @@ fn run_agent(
         run_id, worktree_path
     );
 
+    // Emit the user's prompt as the first event so it appears in the activity log
+    {
+        let now = chrono::Utc::now().to_rfc3339();
+        if let Err(e) = mgr.create_event(run_id, "prompt", prompt, &now, None) {
+            eprintln!("[conductor] Warning: could not persist prompt event: {e}");
+        }
+    }
+
     let mut child = match cmd.spawn() {
         Ok(child) => child,
         Err(e) => {

--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -1125,6 +1125,41 @@ mod tests {
     }
 
     #[test]
+    fn test_prompt_event_appears_first() {
+        // Simulates what run_agent does: emit a "prompt" event before spawning claude,
+        // then subsequent agent events follow. Verifies the prompt is first in the list.
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let prompt_text = "Fix the login bug";
+        let run = mgr.create_run("w1", prompt_text, None, None).unwrap();
+
+        let t0 = "2024-01-01T00:00:00Z";
+        let t1 = "2024-01-01T00:00:01Z";
+        let t2 = "2024-01-01T00:00:05Z";
+
+        // This mirrors what run_agent now does before spawning claude
+        mgr.create_event(&run.id, "prompt", prompt_text, t0, None)
+            .unwrap();
+        mgr.create_event(&run.id, "system", "Session started", t1, None)
+            .unwrap();
+        mgr.create_event(&run.id, "tool", "[Bash] cargo test", t2, None)
+            .unwrap();
+
+        let events = mgr.list_events_for_run(&run.id).unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].kind, "prompt");
+        assert_eq!(events[0].summary, prompt_text);
+        assert_eq!(events[1].kind, "system");
+        assert_eq!(events[2].kind, "tool");
+
+        // Also verify via list_events_for_worktree
+        let wt_events = mgr.list_events_for_worktree("w1").unwrap();
+        assert_eq!(wt_events[0].kind, "prompt");
+        assert_eq!(wt_events[0].run_id, run.id);
+    }
+
+    #[test]
     fn test_events_cascade_delete_on_run_removal() {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -456,6 +456,7 @@ impl App {
 
         let Some(ref wt_id) = self.state.selected_worktree_id else {
             self.state.data.agent_events = Vec::new();
+            self.state.data.agent_run_info = std::collections::HashMap::new();
             self.state.data.agent_totals = AgentTotals::default();
             self.state.data.child_runs = Vec::new();
             return;
@@ -513,6 +514,16 @@ impl App {
             }
             fallback
         };
+
+        // Build run_id -> (run_number, model, started_at) map for boundary headers
+        let mut run_info = std::collections::HashMap::new();
+        for (i, run) in runs.iter().enumerate() {
+            run_info.insert(
+                run.id.clone(),
+                (i + 1, run.model.clone(), run.started_at.clone()),
+            );
+        }
+        self.state.data.agent_run_info = run_info;
 
         self.state.data.agent_events = all_events;
 

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -286,6 +286,8 @@ pub struct DataCache {
     pub latest_agent_runs: HashMap<String, AgentRun>,
     /// Persisted agent events for the currently viewed worktree (from DB)
     pub agent_events: Vec<AgentRunEvent>,
+    /// run_id -> (run_number, model, started_at) for per-run boundary headers
+    pub agent_run_info: HashMap<String, (usize, Option<String>, String)>,
     /// Aggregate stats across all agent runs for the currently viewed worktree
     pub agent_totals: AgentTotals,
     /// Child runs of the latest root run (for run tree display)

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -217,26 +217,54 @@ fn render_agent_activity(frame: &mut Frame, area: Rect, state: &AppState) {
         .map(|wt| wt.path.as_str())
         .unwrap_or("");
 
-    let items: Vec<ListItem> = events
-        .iter()
-        .map(|ev| {
-            let style = event_style(&ev.kind);
-            let mut spans = vec![Span::styled(
-                shorten_paths(&ev.summary, worktree_path),
-                style,
-            )];
-            if let Some(dur) = ev.duration_ms() {
-                if dur >= 100 {
-                    let dur_s = dur as f64 / 1000.0;
-                    spans.push(Span::styled(
-                        format!("  ({dur_s:.1}s)"),
-                        Style::default().fg(Color::DarkGray),
-                    ));
+    let run_info = &state.data.agent_run_info;
+    let has_multiple_runs = run_info.len() > 1;
+
+    let mut items: Vec<ListItem> = Vec::new();
+    let mut prev_run_id: Option<&str> = None;
+
+    for ev in events {
+        // Insert a run boundary separator when run_id changes
+        if has_multiple_runs {
+            let is_new_run = prev_run_id.is_some_and(|prev| prev != ev.run_id);
+            let is_first = prev_run_id.is_none();
+            if is_first || is_new_run {
+                if let Some((run_num, model, started_at)) = run_info.get(&ev.run_id) {
+                    let ts = started_at
+                        .get(..16)
+                        .unwrap_or(started_at)
+                        .replacen('T', " ", 1);
+                    let model_str = model.as_deref().unwrap_or("default");
+                    let header = format!("── Run {run_num}  {ts}  {model_str} ");
+                    let pad = "─".repeat(60usize.saturating_sub(header.len()));
+                    items.push(ListItem::new(Line::from(Span::styled(
+                        format!("{header}{pad}"),
+                        Style::default()
+                            .fg(Color::DarkGray)
+                            .add_modifier(Modifier::DIM),
+                    ))));
                 }
             }
-            ListItem::new(Line::from(spans))
-        })
-        .collect();
+        }
+        prev_run_id = Some(&ev.run_id);
+
+        let style = event_style(&ev.kind);
+        let prefix = if ev.kind == "prompt" { "YOU: " } else { "" };
+        let mut spans = vec![Span::styled(
+            format!("{prefix}{}", shorten_paths(&ev.summary, worktree_path)),
+            style,
+        )];
+        if let Some(dur) = ev.duration_ms() {
+            if dur >= 100 {
+                let dur_s = dur as f64 / 1000.0;
+                spans.push(Span::styled(
+                    format!("  ({dur_s:.1}s)"),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+        }
+        items.push(ListItem::new(Line::from(spans)));
+    }
 
     let list = List::new(items)
         .block(activity_block)
@@ -265,6 +293,7 @@ fn event_style(kind: &str) -> Style {
         "result" => Style::default().fg(Color::Green),
         "system" => Style::default().fg(Color::DarkGray),
         "error" => Style::default().fg(Color::Red),
+        "prompt" => Style::default().fg(Color::Cyan),
         _ => Style::default(),
     }
 }

--- a/conductor-web/frontend/src/api/types.ts
+++ b/conductor-web/frontend/src/api/types.ts
@@ -83,6 +83,7 @@ export interface AgentRun {
   ended_at: string | null;
   tmux_window: string | null;
   log_file: string | null;
+  model: string | null;
   plan: PlanStep[] | null;
   parent_run_id: string | null;
 }
@@ -97,7 +98,7 @@ export interface RunTreeTotals {
 export interface AgentEvent {
   id: string;
   run_id: string;
-  kind: "text" | "tool" | "result" | "system" | "error";
+  kind: "text" | "tool" | "result" | "system" | "error" | "prompt";
   summary: string;
   started_at: string;
   ended_at: string | null;

--- a/conductor-web/frontend/src/components/agents/AgentActivityLog.tsx
+++ b/conductor-web/frontend/src/components/agents/AgentActivityLog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
-import type { AgentEvent } from "../../api/types";
+import { useEffect, useMemo, useRef } from "react";
+import type { AgentEvent, AgentRun } from "../../api/types";
 
 const kindConfig: Record<
   string,
@@ -35,6 +35,12 @@ const kindConfig: Record<
     text: "text-red-400",
     border: "border-l-red-500",
   },
+  prompt: {
+    label: "YOU",
+    badge: "bg-blue-900 text-blue-300",
+    text: "text-blue-300",
+    border: "border-l-blue-500",
+  },
 };
 
 const defaultConfig = {
@@ -46,10 +52,11 @@ const defaultConfig = {
 
 interface AgentActivityLogProps {
   events: AgentEvent[];
+  runs: AgentRun[];
   isRunning: boolean;
 }
 
-export function AgentActivityLog({ events, isRunning }: AgentActivityLogProps) {
+export function AgentActivityLog({ events, runs, isRunning }: AgentActivityLogProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -57,6 +64,20 @@ export function AgentActivityLog({ events, isRunning }: AgentActivityLogProps) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [events.length]);
+
+  // Build run_id -> { runNumber, model, startedAt } lookup
+  const runInfo = useMemo(() => {
+    const sorted = [...runs].sort(
+      (a, b) => a.started_at.localeCompare(b.started_at),
+    );
+    const map = new Map<string, { runNumber: number; model: string | null; startedAt: string }>();
+    sorted.forEach((r, i) => {
+      map.set(r.id, { runNumber: i + 1, model: r.model, startedAt: r.started_at });
+    });
+    return map;
+  }, [runs]);
+
+  const hasMultipleRuns = runs.length > 1;
 
   if (events.length === 0) {
     return (
@@ -68,39 +89,66 @@ export function AgentActivityLog({ events, isRunning }: AgentActivityLogProps) {
     );
   }
 
+  // Build elements with run boundary separators
+  const elements: React.ReactNode[] = [];
+  let prevRunId: string | null = null;
+
+  events.forEach((event, i) => {
+    // Insert run boundary separator when run_id changes
+    if (hasMultipleRuns && event.run_id !== prevRunId) {
+      const info = runInfo.get(event.run_id);
+      if (info) {
+        const ts = info.startedAt.slice(0, 16).replace("T", " ");
+        const model = info.model ?? "default";
+        elements.push(
+          <div
+            key={`sep-${event.run_id}`}
+            className={`flex items-center gap-2 px-2 py-1.5 ${prevRunId !== null ? "mt-3 border-t border-gray-800 pt-2" : ""}`}
+          >
+            <span className="text-[10px] text-gray-500 font-medium tracking-wider">
+              ── Run {info.runNumber} &nbsp; {ts} &nbsp; {model} ──
+            </span>
+          </div>,
+        );
+      }
+    }
+    prevRunId = event.run_id;
+
+    const cfg = kindConfig[event.kind] ?? defaultConfig;
+    const prevKind = i > 0 ? events[i - 1].kind : null;
+    const showGap =
+      prevKind !== null && prevKind !== event.kind && events[i - 1].run_id === event.run_id;
+
+    elements.push(
+      <div
+        key={i}
+        className={`flex items-start gap-2 px-2 py-1 border-l-2 ${cfg.border} ${showGap ? "mt-2" : ""}`}
+      >
+        <span
+          className={`shrink-0 inline-block w-12 text-center text-[10px] font-semibold rounded px-1 py-0.5 leading-tight ${cfg.badge}`}
+        >
+          {cfg.label}
+        </span>
+        <span className={`${cfg.text} leading-snug break-words min-w-0 flex-1`}>
+          {event.summary}
+        </span>
+        {event.duration_ms != null && event.duration_ms >= 100 && (
+          <span className="shrink-0 text-[10px] text-gray-500 tabular-nums">
+            {event.duration_ms >= 1000
+              ? `${(event.duration_ms / 1000).toFixed(1)}s`
+              : `${event.duration_ms}ms`}
+          </span>
+        )}
+      </div>,
+    );
+  });
+
   return (
     <div
       ref={scrollRef}
       className="rounded-lg border border-gray-200 bg-gray-950 p-2 max-h-[28rem] overflow-y-auto font-mono text-sm"
     >
-      {events.map((event, i) => {
-        const cfg = kindConfig[event.kind] ?? defaultConfig;
-        const prevKind = i > 0 ? events[i - 1].kind : null;
-        const showGap = prevKind !== null && prevKind !== event.kind;
-
-        return (
-          <div
-            key={i}
-            className={`flex items-start gap-2 px-2 py-1 border-l-2 ${cfg.border} ${showGap ? "mt-2" : ""}`}
-          >
-            <span
-              className={`shrink-0 inline-block w-12 text-center text-[10px] font-semibold rounded px-1 py-0.5 leading-tight ${cfg.badge}`}
-            >
-              {cfg.label}
-            </span>
-            <span className={`${cfg.text} leading-snug break-words min-w-0 flex-1`}>
-              {event.summary}
-            </span>
-            {event.duration_ms != null && event.duration_ms >= 100 && (
-              <span className="shrink-0 text-[10px] text-gray-500 tabular-nums">
-                {event.duration_ms >= 1000
-                  ? `${(event.duration_ms / 1000).toFixed(1)}s`
-                  : `${event.duration_ms}ms`}
-              </span>
-            )}
-          </div>
-        );
-      })}
+      {elements}
       {isRunning && (
         <div className="text-yellow-400 animate-pulse mt-2 px-2 py-1 text-xs">
           Agent is working...

--- a/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
+++ b/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
@@ -534,7 +534,7 @@ export function WorktreeDetailPage() {
           <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-3">
             Activity Log
           </h3>
-          <AgentActivityLog events={agentEvents} isRunning={isRunning} />
+          <AgentActivityLog events={agentEvents} runs={agentRuns} isRunning={isRunning} />
         </section>
       )}
 


### PR DESCRIPTION
Display the user's prompt as the first event in each agent run, with per-run
boundary separators in both TUI and web, showing run number, timestamp, and
model used. Prompts appear with distinctive cyan styling (TUI) or blue badge
(web) labeled "YOU".

Changes:
- Emit "prompt" event at run start before spawning claude (conductor-cli)
- Add "prompt" kind styling and per-run boundary headers in TUI with model
- Add "prompt" kind config and per-run separators in web frontend
- Update TypeScript AgentEvent and AgentRun types to include prompt kind/model
- Add test verifying prompt event appears first in activity list

Satisfies all core acceptance criteria:
✓ User prompts displayed as first event in each run
✓ Both TUI and web render the "prompt" kind distinctly
✓ Multi-run worktrees show visible boundary separators
✓ Model used displayed per run in activity view

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
