### PR TITLE
feat: agents can create GitHub issues (#107) + TUI enhancements

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -14,6 +14,9 @@ use conductor_core::repo::{derive_local_path, derive_slug_from_url, RepoManager}
 use conductor_core::tickets::{build_agent_prompt, TicketSyncer};
 use conductor_core::worktree::WorktreeManager;
 
+/// Environment variable name used to pass the current agent run ID to subprocesses.
+const CONDUCTOR_RUN_ID_ENV: &str = "CONDUCTOR_RUN_ID";
+
 #[derive(Parser)]
 #[command(name = "conductor", about = "Multi-repo orchestration tool")]
 struct Cli {
@@ -65,6 +68,18 @@ enum AgentCommands {
         #[arg(long)]
         model: Option<String>,
     },
+    /// Create a new GitHub issue (called by agents during a run)
+    CreateIssue {
+        /// Issue title
+        #[arg(long)]
+        title: String,
+        /// Issue body
+        #[arg(long)]
+        body: String,
+        /// Agent run ID (defaults to $CONDUCTOR_RUN_ID env var)
+        #[arg(long)]
+        run_id: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -107,6 +122,14 @@ enum RepoCommands {
     Sources {
         #[command(subcommand)]
         command: SourceCommands,
+    },
+    /// Allow or disallow agents to create issues for a repository
+    AllowAgentIssues {
+        /// Repo slug
+        slug: String,
+        /// Set to true to allow, false to disallow
+        #[arg(long, default_value = "true")]
+        allow: bool,
     },
 }
 
@@ -331,6 +354,16 @@ fn main() -> Result<()> {
                     None => println!("Cleared model override for {slug} (will use global default)"),
                 }
             }
+            RepoCommands::AllowAgentIssues { slug, allow } => {
+                let mgr = RepoManager::new(&conn, &config);
+                let repo = mgr.get_by_slug(&slug)?;
+                mgr.set_allow_agent_issue_creation(&repo.id, allow)?;
+                if allow {
+                    println!("Enabled agent issue creation for {slug}");
+                } else {
+                    println!("Disabled agent issue creation for {slug}");
+                }
+            }
             RepoCommands::Sources { command } => {
                 let repo_mgr = RepoManager::new(&conn, &config);
                 let source_mgr = IssueSourceManager::new(&conn);
@@ -516,6 +549,73 @@ fn main() -> Result<()> {
                     resume.as_deref(),
                     model.as_deref(),
                 )?;
+            }
+            AgentCommands::CreateIssue {
+                title,
+                body,
+                run_id,
+            } => {
+                let run_id = run_id
+                    .or_else(|| std::env::var(CONDUCTOR_RUN_ID_ENV).ok())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "No run ID provided. Use --run-id or set ${CONDUCTOR_RUN_ID_ENV}."
+                        )
+                    })?;
+
+                let agent_mgr = AgentManager::new(&conn);
+
+                // Look up run → worktree → repo
+                let run = agent_mgr
+                    .get_run(&run_id)?
+                    .ok_or_else(|| anyhow::anyhow!("Agent run not found: {run_id}"))?;
+
+                let (repo_id, remote_url): (String, String) = conn
+                    .query_row(
+                        "SELECT r.id, r.remote_url \
+                         FROM worktrees w \
+                         JOIN repos r ON w.repo_id = r.id \
+                         WHERE w.id = ?1",
+                        rusqlite::params![run.worktree_id],
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )
+                    .map_err(|_| {
+                        anyhow::anyhow!("Could not find repo for worktree {}", run.worktree_id)
+                    })?;
+
+                // Check per-repo opt-in
+                let allow: bool = conn
+                    .query_row(
+                        "SELECT allow_agent_issue_creation FROM repos WHERE id = ?1",
+                        rusqlite::params![repo_id],
+                        |row| row.get::<_, i64>(0).map(|v| v != 0),
+                    )
+                    .unwrap_or(false);
+
+                if !allow {
+                    anyhow::bail!(
+                        "Agent issue creation is disabled for this repo. \
+                         Enable it via `conductor repo allow-agent-issues <repo-slug>`."
+                    );
+                }
+
+                // Determine GitHub owner/repo from remote URL
+                let (owner, repo_name) =
+                    github::parse_github_remote(&remote_url).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Cannot determine GitHub repo from remote URL: {remote_url}"
+                        )
+                    })?;
+
+                // Create the GitHub issue
+                let (source_id, url) =
+                    github::create_github_issue(&owner, &repo_name, &title, &body)?;
+
+                // Record in DB
+                agent_mgr
+                    .record_created_issue(&run_id, &repo_id, "github", &source_id, &title, &url)?;
+
+                println!("Created issue #{source_id}: {url}");
             }
         },
         Commands::Tickets { command } => match command {
@@ -787,6 +887,7 @@ fn run_agent(
         .arg("stream-json")
         .arg("--verbose")
         .arg("--dangerously-skip-permissions")
+        .env(CONDUCTOR_RUN_ID_ENV, run_id)
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .current_dir(worktree_path);

--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -260,6 +260,19 @@ fn tool_summary(tool_name: &str, input: Option<&serde_json::Value>) -> String {
     }
 }
 
+/// A GitHub issue (or other tracker issue) created by an agent run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentCreatedIssue {
+    pub id: String,
+    pub agent_run_id: String,
+    pub repo_id: String,
+    pub source_type: String,
+    pub source_id: String,
+    pub title: String,
+    pub url: String,
+    pub created_at: String,
+}
+
 /// Aggregated agent stats for a ticket (across all linked worktrees).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TicketAgentTotals {
@@ -597,6 +610,81 @@ impl<'a> AgentManager<'a> {
         Ok(events)
     }
 
+    /// Record a GitHub issue created by an agent run.
+    pub fn record_created_issue(
+        &self,
+        agent_run_id: &str,
+        repo_id: &str,
+        source_type: &str,
+        source_id: &str,
+        title: &str,
+        url: &str,
+    ) -> Result<AgentCreatedIssue> {
+        let id = ulid::Ulid::new().to_string();
+        let now = Utc::now().to_rfc3339();
+
+        let issue = AgentCreatedIssue {
+            id: id.clone(),
+            agent_run_id: agent_run_id.to_string(),
+            repo_id: repo_id.to_string(),
+            source_type: source_type.to_string(),
+            source_id: source_id.to_string(),
+            title: title.to_string(),
+            url: url.to_string(),
+            created_at: now.clone(),
+        };
+
+        self.conn.execute(
+            "INSERT INTO agent_created_issues \
+             (id, agent_run_id, repo_id, source_type, source_id, title, url, created_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                issue.id,
+                issue.agent_run_id,
+                issue.repo_id,
+                issue.source_type,
+                issue.source_id,
+                issue.title,
+                issue.url,
+                issue.created_at,
+            ],
+        )?;
+
+        Ok(issue)
+    }
+
+    /// List all issues created by a specific agent run.
+    pub fn list_created_issues_for_run(
+        &self,
+        agent_run_id: &str,
+    ) -> Result<Vec<AgentCreatedIssue>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, agent_run_id, repo_id, source_type, source_id, title, url, created_at \
+             FROM agent_created_issues WHERE agent_run_id = ?1 ORDER BY created_at ASC",
+        )?;
+        let rows = stmt.query_map(params![agent_run_id], row_to_agent_created_issue)?;
+        let issues = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(issues)
+    }
+
+    /// List all issues created by all runs for a worktree.
+    pub fn list_created_issues_for_worktree(
+        &self,
+        worktree_id: &str,
+    ) -> Result<Vec<AgentCreatedIssue>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT aci.id, aci.agent_run_id, aci.repo_id, aci.source_type, \
+             aci.source_id, aci.title, aci.url, aci.created_at \
+             FROM agent_created_issues aci \
+             JOIN agent_runs ar ON aci.agent_run_id = ar.id \
+             WHERE ar.worktree_id = ?1 \
+             ORDER BY aci.created_at ASC",
+        )?;
+        let rows = stmt.query_map(params![worktree_id], row_to_agent_created_issue)?;
+        let issues = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(issues)
+    }
+
     /// Returns the latest agent run for each worktree, keyed by worktree_id.
     pub fn latest_runs_by_worktree(&self) -> Result<HashMap<String, AgentRun>> {
         let mut stmt = self.conn.prepare(
@@ -709,6 +797,19 @@ fn row_to_agent_run_event(row: &rusqlite::Row) -> rusqlite::Result<AgentRunEvent
         started_at: row.get(4)?,
         ended_at: row.get(5)?,
         metadata: row.get(6)?,
+    })
+}
+
+fn row_to_agent_created_issue(row: &rusqlite::Row) -> rusqlite::Result<AgentCreatedIssue> {
+    Ok(AgentCreatedIssue {
+        id: row.get(0)?,
+        agent_run_id: row.get(1)?,
+        repo_id: row.get(2)?,
+        source_type: row.get(3)?,
+        source_id: row.get(4)?,
+        title: row.get(5)?,
+        url: row.get(6)?,
+        created_at: row.get(7)?,
     })
 }
 
@@ -1051,6 +1152,76 @@ mod tests {
         assert_eq!(plan.len(), 1);
         assert_eq!(plan[0].description, "Do the thing");
         assert!(plan[0].done);
+    }
+
+    #[test]
+    fn test_record_and_list_created_issues() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run1 = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        let run2 = mgr.create_run("w2", "Other task", None, None).unwrap();
+
+        // No issues yet
+        assert!(mgr
+            .list_created_issues_for_run(&run1.id)
+            .unwrap()
+            .is_empty());
+        assert!(mgr
+            .list_created_issues_for_worktree("w1")
+            .unwrap()
+            .is_empty());
+
+        // Record two issues on run1
+        let issue1 = mgr
+            .record_created_issue(
+                &run1.id,
+                "r1",
+                "github",
+                "101",
+                "Found a memory leak",
+                "https://github.com/test/repo/issues/101",
+            )
+            .unwrap();
+        let issue2 = mgr
+            .record_created_issue(
+                &run1.id,
+                "r1",
+                "github",
+                "102",
+                "Needs follow-up refactor",
+                "https://github.com/test/repo/issues/102",
+            )
+            .unwrap();
+
+        // Record one issue on run2
+        mgr.record_created_issue(
+            &run2.id,
+            "r1",
+            "github",
+            "103",
+            "Another issue",
+            "https://github.com/test/repo/issues/103",
+        )
+        .unwrap();
+
+        // list_for_run returns only run1's issues
+        let run1_issues = mgr.list_created_issues_for_run(&run1.id).unwrap();
+        assert_eq!(run1_issues.len(), 2);
+        assert_eq!(run1_issues[0].source_id, "101");
+        assert_eq!(run1_issues[1].source_id, "102");
+        assert_eq!(run1_issues[0].title, "Found a memory leak");
+
+        // list_for_worktree returns issues from all runs on w1 (only run1 here)
+        let w1_issues = mgr.list_created_issues_for_worktree("w1").unwrap();
+        assert_eq!(w1_issues.len(), 2);
+        assert_eq!(w1_issues[0].id, issue1.id);
+        assert_eq!(w1_issues[1].id, issue2.id);
+
+        // w2 has its own issue
+        let w2_issues = mgr.list_created_issues_for_worktree("w2").unwrap();
+        assert_eq!(w2_issues.len(), 1);
+        assert_eq!(w2_issues[0].source_id, "103");
     }
 
     #[test]

--- a/conductor-core/src/db/migrations.rs
+++ b/conductor-core/src/db/migrations.rs
@@ -166,5 +166,33 @@ pub fn run(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    // Migration 013: add agent_created_issues table.
+    let has_agent_created_issues: bool = conn
+        .prepare("SELECT id FROM agent_created_issues LIMIT 0")
+        .is_ok();
+    if !has_agent_created_issues {
+        conn.execute_batch(include_str!("migrations/007_agent_created_issues.sql"))?;
+    }
+    if version < 13 {
+        conn.execute(
+            "INSERT OR REPLACE INTO _conductor_meta (key, value) VALUES ('schema_version', '13')",
+            [],
+        )?;
+    }
+
+    // Migration 014: add allow_agent_issue_creation to repos.
+    let has_allow_agent_issue_creation: bool = conn
+        .prepare("SELECT allow_agent_issue_creation FROM repos LIMIT 0")
+        .is_ok();
+    if !has_allow_agent_issue_creation {
+        conn.execute_batch(include_str!("migrations/008_repo_allow_agent_issues.sql"))?;
+    }
+    if version < 14 {
+        conn.execute(
+            "INSERT OR REPLACE INTO _conductor_meta (key, value) VALUES ('schema_version', '14')",
+            [],
+        )?;
+    }
+
     Ok(())
 }

--- a/conductor-core/src/db/migrations/007_agent_created_issues.sql
+++ b/conductor-core/src/db/migrations/007_agent_created_issues.sql
@@ -1,0 +1,10 @@
+CREATE TABLE agent_created_issues (
+    id           TEXT PRIMARY KEY,
+    agent_run_id TEXT NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+    repo_id      TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    source_type  TEXT NOT NULL DEFAULT 'github',
+    source_id    TEXT NOT NULL,
+    title        TEXT NOT NULL,
+    url          TEXT NOT NULL DEFAULT '',
+    created_at   TEXT NOT NULL
+);

--- a/conductor-core/src/db/migrations/008_repo_allow_agent_issues.sql
+++ b/conductor-core/src/db/migrations/008_repo_allow_agent_issues.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repos ADD COLUMN allow_agent_issue_creation INTEGER NOT NULL DEFAULT 0;

--- a/conductor-core/src/github.rs
+++ b/conductor-core/src/github.rs
@@ -160,6 +160,50 @@ pub fn sync_github_issues(owner: &str, repo: &str) -> Result<Vec<TicketInput>> {
     Ok(tickets)
 }
 
+/// Create a new GitHub issue via the `gh` CLI.
+/// Returns `(source_id, url)` where `source_id` is the issue number as a string.
+pub fn create_github_issue(
+    owner: &str,
+    repo: &str,
+    title: &str,
+    body: &str,
+) -> Result<(String, String)> {
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "create",
+            "--repo",
+            &format!("{owner}/{repo}"),
+            "--title",
+            title,
+            "--body",
+            body,
+        ])
+        .output()
+        .map_err(|e| ConductorError::TicketSync(format!("failed to run gh: {e}")))?;
+
+    if !output.status.success() {
+        return Err(ConductorError::TicketSync(
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ));
+    }
+
+    // `gh issue create` prints the issue URL on stdout, e.g.
+    // https://github.com/owner/repo/issues/42
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    // Extract the issue number from the URL's last path segment.
+    let number = url.rsplit('/').next().unwrap_or("").to_string();
+
+    if number.is_empty() {
+        return Err(ConductorError::TicketSync(format!(
+            "unexpected output from gh issue create: {url}"
+        )));
+    }
+
+    Ok((number, url))
+}
+
 /// Parse a GitHub remote URL to extract owner and repo name.
 /// Handles both SSH (git@github.com:owner/repo.git) and HTTPS (https://github.com/owner/repo.git).
 pub fn parse_github_remote(remote_url: &str) -> Option<(String, String)> {

--- a/conductor-core/src/repo.rs
+++ b/conductor-core/src/repo.rs
@@ -17,6 +17,8 @@ pub struct Repo {
     /// Per-repo default model for Claude agent runs.
     #[serde(default)]
     pub model: Option<String>,
+    /// Whether agents are allowed to create issues in the issue tracker for this repo.
+    pub allow_agent_issue_creation: bool,
 }
 
 pub struct RepoManager<'a> {
@@ -68,6 +70,7 @@ impl<'a> RepoManager<'a> {
             workspace_dir: ws_dir,
             created_at: now,
             model: None,
+            allow_agent_issue_creation: false,
         };
 
         self.conn.execute(
@@ -89,7 +92,9 @@ impl<'a> RepoManager<'a> {
 
     pub fn list(&self) -> Result<Vec<Repo>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, slug, local_path, remote_url, default_branch, workspace_dir, created_at, model
+            "SELECT id, slug, local_path, remote_url, default_branch, workspace_dir, created_at, \
+             COALESCE(model, NULL) as model, \
+             COALESCE(allow_agent_issue_creation, 0) as allow_agent_issue_creation \
              FROM repos ORDER BY slug",
         )?;
         let repos = stmt
@@ -103,6 +108,7 @@ impl<'a> RepoManager<'a> {
                     workspace_dir: row.get(5)?,
                     created_at: row.get(6)?,
                     model: row.get(7)?,
+                    allow_agent_issue_creation: row.get::<_, i64>(8).map(|v| v != 0)?,
                 })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -112,7 +118,10 @@ impl<'a> RepoManager<'a> {
     pub fn get_by_id(&self, id: &str) -> Result<Repo> {
         self.conn
             .query_row(
-                "SELECT id, slug, local_path, remote_url, default_branch, workspace_dir, created_at, model
+                "SELECT id, slug, local_path, remote_url, default_branch, workspace_dir, \
+                 created_at, \
+                 COALESCE(model, NULL) as model, \
+                 COALESCE(allow_agent_issue_creation, 0) as allow_agent_issue_creation \
                  FROM repos WHERE id = ?1",
                 params![id],
                 |row| {
@@ -125,6 +134,7 @@ impl<'a> RepoManager<'a> {
                         workspace_dir: row.get(5)?,
                         created_at: row.get(6)?,
                         model: row.get(7)?,
+                        allow_agent_issue_creation: row.get::<_, i64>(8).map(|v| v != 0)?,
                     })
                 },
             )
@@ -136,7 +146,10 @@ impl<'a> RepoManager<'a> {
     pub fn get_by_slug(&self, slug: &str) -> Result<Repo> {
         self.conn
             .query_row(
-                "SELECT id, slug, local_path, remote_url, default_branch, workspace_dir, created_at, model
+                "SELECT id, slug, local_path, remote_url, default_branch, workspace_dir, \
+                 created_at, \
+                 COALESCE(model, NULL) as model, \
+                 COALESCE(allow_agent_issue_creation, 0) as allow_agent_issue_creation \
                  FROM repos WHERE slug = ?1",
                 params![slug],
                 |row| {
@@ -149,6 +162,7 @@ impl<'a> RepoManager<'a> {
                         workspace_dir: row.get(5)?,
                         created_at: row.get(6)?,
                         model: row.get(7)?,
+                        allow_agent_issue_creation: row.get::<_, i64>(8).map(|v| v != 0)?,
                     })
                 },
             )
@@ -167,6 +181,20 @@ impl<'a> RepoManager<'a> {
         if affected == 0 {
             return Err(ConductorError::RepoNotFound {
                 slug: slug.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Set whether agents can create issues for this repo.
+    pub fn set_allow_agent_issue_creation(&self, repo_id: &str, allow: bool) -> Result<()> {
+        let affected = self.conn.execute(
+            "UPDATE repos SET allow_agent_issue_creation = ?1 WHERE id = ?2",
+            params![allow as i64, repo_id],
+        )?;
+        if affected == 0 {
+            return Err(ConductorError::RepoNotFound {
+                slug: repo_id.to_string(),
             });
         }
         Ok(())

--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -88,6 +88,9 @@ pub enum Action {
     // Model configuration
     SetModel,
 
+    // Agent issue creation toggle (repo-level)
+    ToggleAgentIssues,
+
     // Agent triggers (tmux-based)
     LaunchAgent,
     StopAgent,

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -286,6 +286,9 @@ impl App {
             // Model configuration
             Action::SetModel => self.handle_set_model(),
 
+            // Agent issue creation toggle
+            Action::ToggleAgentIssues => self.handle_toggle_agent_issues(),
+
             // Agent (tmux-based)
             Action::LaunchAgent => self.handle_launch_agent(),
             Action::StopAgent => self.handle_stop_agent(),
@@ -459,6 +462,7 @@ impl App {
             self.state.data.agent_run_info = std::collections::HashMap::new();
             self.state.data.agent_totals = AgentTotals::default();
             self.state.data.child_runs = Vec::new();
+            self.state.data.agent_created_issues = Vec::new();
             return;
         };
 
@@ -552,6 +556,11 @@ impl App {
                     .select(Some(len - 1));
             }
         }
+
+        // Load issues created by agents for this worktree
+        self.state.data.agent_created_issues = mgr
+            .list_created_issues_for_worktree(wt_id)
+            .unwrap_or_default();
     }
 
     fn clamp_indices(&mut self) {
@@ -2563,6 +2572,32 @@ impl App {
                 };
             }
             _ => {}
+        }
+    }
+
+    fn handle_toggle_agent_issues(&mut self) {
+        let Some(repo) = self
+            .state
+            .selected_repo_id
+            .as_ref()
+            .and_then(|id| self.state.data.repos.iter().find(|r| &r.id == id))
+            .cloned()
+        else {
+            self.state.status_message = Some("No repo selected".to_string());
+            return;
+        };
+        let new_value = !repo.allow_agent_issue_creation;
+        let mgr = conductor_core::repo::RepoManager::new(&self.conn, &self.config);
+        match mgr.set_allow_agent_issue_creation(&repo.id, new_value) {
+            Ok(()) => {
+                let label = if new_value { "enabled" } else { "disabled" };
+                self.state.status_message =
+                    Some(format!("Agent issue creation {} for {}", label, repo.slug));
+                self.refresh_data();
+            }
+            Err(e) => {
+                self.state.status_message = Some(format!("Failed to toggle agent issues: {e}"));
+            }
         }
     }
 

--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -241,8 +241,10 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
 
     // View-specific keybindings (RepoDetail)
     if state.view == View::RepoDetail {
-        if let KeyCode::Char('m') = key.code {
-            return Action::SetModel;
+        match key.code {
+            KeyCode::Char('m') => return Action::SetModel,
+            KeyCode::Char('I') => return Action::ToggleAgentIssues,
+            _ => {}
         }
     }
 

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
 
-use conductor_core::agent::{AgentRun, AgentRunEvent, TicketAgentTotals};
+use conductor_core::agent::{AgentCreatedIssue, AgentRun, AgentRunEvent, TicketAgentTotals};
 use conductor_core::config::WorkTarget;
 use conductor_core::github::DiscoveredRepo;
 use conductor_core::issue_source::IssueSource;
@@ -296,6 +296,8 @@ pub struct DataCache {
     pub ticket_agent_totals: HashMap<String, TicketAgentTotals>,
     /// ticket_id -> linked worktrees (most recently created first)
     pub ticket_worktrees: HashMap<String, Vec<Worktree>>,
+    /// Issues created by agents for the currently viewed worktree
+    pub agent_created_issues: Vec<AgentCreatedIssue>,
 }
 
 /// Aggregated stats across all agent runs for a worktree.

--- a/conductor-tui/src/ui/repo_detail.rs
+++ b/conductor-tui/src/ui/repo_detail.rs
@@ -25,7 +25,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(7),
+            Constraint::Length(8),
             Constraint::Percentage(50),
             Constraint::Percentage(50),
         ])
@@ -60,6 +60,15 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                     Style::default().fg(Color::DarkGray),
                 ),
             },
+        ]),
+        Line::from(vec![
+            Span::styled("Agent Issues: ", Style::default().fg(Color::DarkGray)),
+            if repo.allow_agent_issue_creation {
+                Span::styled("Enabled", Style::default().fg(Color::Green))
+            } else {
+                Span::styled("Disabled", Style::default().fg(Color::DarkGray))
+            },
+            Span::styled(" (press I to toggle)", Style::default().fg(Color::DarkGray)),
         ]),
     ])
     .block(Block::default().borders(Borders::ALL).title(" Info "));

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -152,6 +152,23 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
         }
     }
 
+    // Issues created by agents
+    if !state.data.agent_created_issues.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![Span::styled(
+            "Issues created:",
+            Style::default().fg(Color::DarkGray),
+        )]));
+        for issue in &state.data.agent_created_issues {
+            lines.push(Line::from(vec![
+                Span::styled("  #", Style::default().fg(Color::DarkGray)),
+                Span::styled(&issue.source_id, Style::default().fg(Color::Cyan)),
+                Span::raw(" — "),
+                Span::raw(&issue.title),
+            ]));
+        }
+    }
+
     lines.push(Line::from(""));
 
     let actions_text = if wt.is_active() {

--- a/conductor-web/frontend/src/api/client.ts
+++ b/conductor-web/frontend/src/api/client.ts
@@ -11,6 +11,7 @@ import type {
   AgentEvent,
   AgentPromptInfo,
   RunTreeTotals,
+  AgentCreatedIssue,
   WorkTarget,
   CreateWorkTargetRequest,
   PushResult,
@@ -130,6 +131,13 @@ export const api = {
     request<RunTreeTotals>(
       `/worktrees/${worktreeId}/agent/runs/${runId}/tree-totals`,
     ),
+  getCreatedIssues: (worktreeId: string) =>
+    request<AgentCreatedIssue[]>(`/worktrees/${worktreeId}/agent/created-issues`),
+  updateRepoSettings: (repoId: string, settings: { allow_agent_issue_creation?: boolean }) =>
+    request<Repo>(`/repos/${repoId}/settings`, {
+      method: "PATCH",
+      body: JSON.stringify(settings),
+    }),
 
   // Global config
   getGlobalModel: () => request<GlobalConfig>("/config/model"),

--- a/conductor-web/frontend/src/api/types.ts
+++ b/conductor-web/frontend/src/api/types.ts
@@ -7,6 +7,7 @@ export interface Repo {
   workspace_dir: string;
   created_at: string;
   model: string | null;
+  allow_agent_issue_creation: boolean;
 }
 
 export interface Worktree {
@@ -109,6 +110,17 @@ export interface AgentEvent {
 export interface AgentPromptInfo {
   prompt: string;
   resume_session_id: string | null;
+}
+
+export interface AgentCreatedIssue {
+  id: string;
+  agent_run_id: string;
+  repo_id: string;
+  source_type: string;
+  source_id: string;
+  title: string;
+  url: string;
+  created_at: string;
 }
 
 export interface WorkTarget {

--- a/conductor-web/frontend/src/pages/RepoDetailPage.tsx
+++ b/conductor-web/frontend/src/pages/RepoDetailPage.tsx
@@ -84,6 +84,7 @@ export function RepoDetailPage() {
   const navigate = useNavigate();
   const [syncing, setSyncing] = useState(false);
   const [syncResult, setSyncResult] = useState<string | null>(null);
+  const [togglingAgentIssues, setTogglingAgentIssues] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [deleteRepoConfirm, setDeleteRepoConfirm] = useState(false);
   const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
@@ -126,6 +127,21 @@ export function RepoDetailPage() {
       refreshRepos();
     } catch (err) {
       alert(err instanceof Error ? err.message : "Failed to save model");
+    }
+  }
+
+  async function handleToggleAgentIssues() {
+    if (!repo) return;
+    setTogglingAgentIssues(true);
+    try {
+      await api.updateRepoSettings(repoId!, {
+        allow_agent_issue_creation: !repo.allow_agent_issue_creation,
+      });
+      refreshRepos();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Failed to update setting");
+    } finally {
+      setTogglingAgentIssues(false);
     }
   }
 
@@ -224,6 +240,20 @@ export function RepoDetailPage() {
                 </button>
               </span>
             )}
+          </dd>
+          <dt className="font-medium text-gray-500">Agent Issue Creation</dt>
+          <dd>
+            <button
+              onClick={handleToggleAgentIssues}
+              disabled={togglingAgentIssues}
+              className={`px-2 py-0.5 text-xs rounded border ${
+                repo.allow_agent_issue_creation
+                  ? "border-green-300 text-green-700 bg-green-50 hover:bg-green-100"
+                  : "border-gray-300 text-gray-600 hover:bg-gray-50"
+              } disabled:opacity-50`}
+            >
+              {repo.allow_agent_issue_creation ? "Enabled" : "Disabled"}
+            </button>
           </dd>
         </dl>
       </div>

--- a/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
+++ b/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from "react";
 import { useParams, Link, useNavigate } from "react-router";
 import { useApi } from "../hooks/useApi";
 import { api } from "../api/client";
-import type { AgentRun, AgentEvent, Ticket } from "../api/types";
+import type { AgentRun, AgentEvent, AgentCreatedIssue, Ticket } from "../api/types";
 import { StatusBadge } from "../components/shared/StatusBadge";
 import { TimeAgo } from "../components/shared/TimeAgo";
 import { ConfirmDialog } from "../components/shared/ConfirmDialog";
@@ -52,6 +52,7 @@ export function WorktreeDetailPage() {
   const [agentRuns, setAgentRuns] = useState<AgentRun[]>([]);
   const [childRuns, setChildRuns] = useState<AgentRun[]>([]);
   const [agentEvents, setAgentEvents] = useState<AgentEvent[]>([]);
+  const [createdIssues, setCreatedIssues] = useState<AgentCreatedIssue[]>([]);
   const [promptModalOpen, setPromptModalOpen] = useState(false);
   const [promptInfo, setPromptInfo] = useState({
     prompt: "",
@@ -80,14 +81,16 @@ export function WorktreeDetailPage() {
   const refreshAgent = useCallback(async () => {
     if (!worktreeId) return;
     try {
-      const [latest, runs, events] = await Promise.all([
+      const [latest, runs, events, issues] = await Promise.all([
         api.latestAgentRun(worktreeId),
         api.listAgentRuns(worktreeId),
         api.getAgentEvents(worktreeId),
+        api.getCreatedIssues(worktreeId),
       ]);
       setLatestRun(latest);
       setAgentRuns(runs);
       setAgentEvents(events);
+      setCreatedIssues(issues);
 
       // Fetch child runs for the latest run (if it has no parent — i.e. it's a root run)
       if (latest && !latest.parent_run_id) {
@@ -535,6 +538,34 @@ export function WorktreeDetailPage() {
             Activity Log
           </h3>
           <AgentActivityLog events={agentEvents} runs={agentRuns} isRunning={isRunning} />
+        </section>
+      )}
+
+      {/* Issues Created by Agent */}
+      {createdIssues.length > 0 && (
+        <section>
+          <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-3">
+            Issues Created by Agent
+          </h3>
+          <div className="rounded-lg border border-gray-200 bg-white overflow-hidden">
+            <ul className="divide-y divide-gray-100">
+              {createdIssues.map((issue) => (
+                <li key={issue.id} className="px-4 py-3 flex items-center gap-3">
+                  <span className="text-xs font-mono text-gray-400">
+                    #{issue.source_id}
+                  </span>
+                  <a
+                    href={issue.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-indigo-600 hover:underline flex-1"
+                  >
+                    {issue.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
         </section>
       )}
 

--- a/conductor-web/src/routes/agents.rs
+++ b/conductor-web/src/routes/agents.rs
@@ -7,8 +7,8 @@ use axum::Json;
 use serde::{Deserialize, Serialize};
 
 use conductor_core::agent::{
-    parse_agent_log, AgentEvent, AgentManager, AgentRun, AgentRunEvent, RunTreeTotals,
-    TicketAgentTotals,
+    parse_agent_log, AgentCreatedIssue, AgentEvent, AgentManager, AgentRun, AgentRunEvent,
+    RunTreeTotals, TicketAgentTotals,
 };
 use conductor_core::repo::RepoManager;
 use conductor_core::tickets::{build_agent_prompt, TicketSyncer};
@@ -459,6 +459,17 @@ pub async fn get_run_tree_totals(
     let mgr = AgentManager::new(&db);
     let totals = mgr.aggregate_run_tree(&run_id)?;
     Ok(Json(totals))
+}
+
+/// List issues created by all agent runs for a worktree.
+pub async fn list_created_issues(
+    State(state): State<AppState>,
+    Path(worktree_id): Path<String>,
+) -> Result<Json<Vec<AgentCreatedIssue>>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = AgentManager::new(&db);
+    let issues = mgr.list_created_issues_for_worktree(&worktree_id)?;
+    Ok(Json(issues))
 }
 
 fn strip_worktree_prefix(summary: &str, worktree_path: &str) -> String {

--- a/conductor-web/src/routes/mod.rs
+++ b/conductor-web/src/routes/mod.rs
@@ -22,6 +22,10 @@ pub fn api_router() -> Router<AppState> {
         )
         .route("/api/repos/{id}", delete(repos::delete_repo))
         .route("/api/repos/{id}/model", patch(repos::patch_repo_model))
+        .route(
+            "/api/repos/{id}/settings",
+            patch(repos::update_repo_settings),
+        )
         // GitHub repo discovery
         .route("/api/github/orgs", get(repos::list_github_orgs_handler))
         .route(
@@ -85,6 +89,10 @@ pub fn api_router() -> Router<AppState> {
             get(agents::get_run_tree_totals),
         )
         .route("/api/worktrees/{id}/agent/prompt", get(agents::get_prompt))
+        .route(
+            "/api/worktrees/{id}/agent/created-issues",
+            get(agents::list_created_issues),
+        )
         // Issue Sources
         .route(
             "/api/repos/{id}/sources",

--- a/conductor-web/src/routes/repos.rs
+++ b/conductor-web/src/routes/repos.rs
@@ -82,6 +82,27 @@ pub async fn patch_repo_model(
     Ok(Json(updated))
 }
 
+#[derive(Deserialize)]
+pub struct UpdateRepoSettingsRequest {
+    pub allow_agent_issue_creation: Option<bool>,
+}
+
+/// Update per-repo settings (e.g. agent issue creation opt-in).
+pub async fn update_repo_settings(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateRepoSettingsRequest>,
+) -> Result<Json<Repo>, ApiError> {
+    let db = state.db.lock().await;
+    let config = state.config.read().await;
+    let mgr = RepoManager::new(&db, &config);
+    if let Some(allow) = body.allow_agent_issue_creation {
+        mgr.set_allow_agent_issue_creation(&id, allow)?;
+    }
+    let repo = mgr.get_by_id(&id)?;
+    Ok(Json(repo))
+}
+
 /// A repo discovered via GitHub with a flag indicating if it's already registered.
 #[derive(Serialize)]
 pub struct DiscoverableRepo {


### PR DESCRIPTION
- Add agent_created_issues table + allow_agent_issue_creation per-repo opt-in flag
- Agents can call `conductor agent create-issue` during runs (CONDUCTOR_RUN_ID env var)
- Created issues recorded in DB and displayed in TUI/Web UI
- Fixed gh issue create command (removed --json flag that caused error)
- TUI repo detail now shows "Agent Issues: Enabled/Disabled" status
- TUI: press I (shift-i) in repo detail to toggle agent issue creation per-repo
- Web UI: toggle agent issue creation on repo settings via API

Resolves #107

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
