### PR TITLE
feat: auto-resume runs with incomplete plan steps (#133)

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -892,6 +892,33 @@ fn run_agent(
             }
         }
         eprintln!("[conductor] Phase 2: Executing...");
+    } else {
+        // Resuming: carry forward the plan from the previous run
+        // Look up the previous run that owns this session_id
+        if let Ok(prev_runs) = mgr.list_for_worktree(&run.worktree_id) {
+            let prev_run = prev_runs
+                .iter()
+                .find(|r| r.claude_session_id.as_deref() == resume_session_id && r.id != run_id);
+            if let Some(prev) = prev_run {
+                if prev.has_incomplete_plan_steps() {
+                    let incomplete: Vec<&PlanStep> = prev.incomplete_plan_steps();
+                    eprintln!(
+                        "[conductor] Resuming with {} incomplete plan steps:",
+                        incomplete.len()
+                    );
+                    for (i, step) in incomplete.iter().enumerate() {
+                        eprintln!("  {}. {}", i + 1, step.description);
+                    }
+                    // Carry forward the full plan to the new run
+                    if let Some(ref plan) = prev.plan {
+                        if let Err(e) = mgr.update_run_plan(run_id, plan) {
+                            eprintln!("[conductor] Warning: could not carry forward plan: {e}");
+                        }
+                    }
+                }
+            }
+        }
+        eprintln!("[conductor] Resuming session...");
     }
 
     // Build the claude command in print mode with stream-json output.
@@ -982,9 +1009,12 @@ fn run_agent(
             // Display human-readable activity in the tmux terminal
             print_event_summary(&event);
 
-            // Capture session_id from init message
+            // Capture session_id from init message and save immediately for resume
             if let Some(sid) = event.get("session_id").and_then(|v| v.as_str()) {
                 session_id_parsed = Some(sid.to_string());
+                if let Err(e) = mgr.update_run_session_id(run_id, sid) {
+                    eprintln!("[conductor] Warning: could not save session_id: {e}");
+                }
             }
 
             // Capture result from final message
@@ -1056,17 +1086,17 @@ fn run_agent(
         }
         Ok(_) if is_error => {
             let error_msg = result_text.as_deref().unwrap_or("Claude reported an error");
-            mgr.update_run_failed(run_id, error_msg)?;
+            mgr.update_run_failed_with_session(run_id, error_msg, session_id_parsed.as_deref())?;
             eprintln!("[conductor] Agent failed: {}", error_msg);
         }
         Ok(s) => {
             let error_msg = format!("Claude exited with status: {}", s);
-            mgr.update_run_failed(run_id, &error_msg)?;
+            mgr.update_run_failed_with_session(run_id, &error_msg, session_id_parsed.as_deref())?;
             eprintln!("[conductor] Agent failed: {}", error_msg);
         }
         Err(e) => {
             let error_msg = format!("Error waiting for claude: {e}");
-            mgr.update_run_failed(run_id, &error_msg)?;
+            mgr.update_run_failed_with_session(run_id, &error_msg, session_id_parsed.as_deref())?;
             eprintln!("[conductor] {}", error_msg);
         }
     }

--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -73,6 +73,48 @@ pub struct AgentRun {
     pub parent_run_id: Option<String>,
 }
 
+impl AgentRun {
+    /// Returns true if this run ended (failed/cancelled) with incomplete plan steps
+    /// and has a session_id available for resume.
+    pub fn needs_resume(&self) -> bool {
+        matches!(self.status.as_str(), "failed" | "cancelled")
+            && self.claude_session_id.is_some()
+            && self.has_incomplete_plan_steps()
+    }
+
+    /// Returns true if the run has a plan with at least one incomplete step.
+    pub fn has_incomplete_plan_steps(&self) -> bool {
+        self.plan
+            .as_ref()
+            .is_some_and(|steps| steps.iter().any(|s| !s.done))
+    }
+
+    /// Returns the incomplete plan steps (not yet done).
+    pub fn incomplete_plan_steps(&self) -> Vec<&PlanStep> {
+        self.plan
+            .as_ref()
+            .map(|steps| steps.iter().filter(|s| !s.done).collect())
+            .unwrap_or_default()
+    }
+
+    /// Build a resume prompt from the remaining plan steps.
+    pub fn build_resume_prompt(&self) -> String {
+        let incomplete = self.incomplete_plan_steps();
+        if incomplete.is_empty() {
+            return "Continue where you left off.".to_string();
+        }
+
+        let mut prompt = String::from(
+            "Continue where you left off. The following plan steps remain incomplete:\n",
+        );
+        for (i, step) in incomplete.iter().enumerate() {
+            prompt.push_str(&format!("{}. {}\n", i + 1, step.description));
+        }
+        prompt.push_str("\nPlease complete these remaining steps.");
+        prompt
+    }
+}
+
 /// Parsed JSON result from `claude -p --output-format json`.
 #[derive(Debug, Deserialize)]
 pub struct ClaudeJsonResult {
@@ -453,11 +495,22 @@ impl<'a> AgentManager<'a> {
     }
 
     pub fn update_run_failed(&self, run_id: &str, error: &str) -> Result<()> {
+        self.update_run_failed_with_session(run_id, error, None)
+    }
+
+    /// Mark a run as failed, optionally preserving the session_id for resume.
+    pub fn update_run_failed_with_session(
+        &self,
+        run_id: &str,
+        error: &str,
+        session_id: Option<&str>,
+    ) -> Result<()> {
         let now = Utc::now().to_rfc3339();
         self.conn.execute(
-            "UPDATE agent_runs SET status = 'failed', result_text = ?1, ended_at = ?2 \
-             WHERE id = ?3",
-            params![error, now, run_id],
+            "UPDATE agent_runs SET status = 'failed', result_text = ?1, ended_at = ?2, \
+             claude_session_id = COALESCE(?3, claude_session_id) \
+             WHERE id = ?4",
+            params![error, now, session_id, run_id],
         )?;
         Ok(())
     }
@@ -467,6 +520,16 @@ impl<'a> AgentManager<'a> {
         self.conn.execute(
             "UPDATE agent_runs SET status = 'cancelled', ended_at = ?1 WHERE id = ?2",
             params![now, run_id],
+        )?;
+        Ok(())
+    }
+
+    /// Save the claude session_id as soon as it's known (before run completes).
+    /// This enables resume even if the run fails or is cancelled.
+    pub fn update_run_session_id(&self, run_id: &str, session_id: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE agent_runs SET claude_session_id = ?1 WHERE id = ?2",
+            params![session_id, run_id],
         )?;
         Ok(())
     }
@@ -2091,5 +2154,207 @@ mod tests {
         assert!(ctx.contains(&"x".repeat(500)));
         assert!(ctx.contains('…'));
         assert!(!ctx.contains(&"x".repeat(501)));
+    }
+
+    // ── Auto-resume tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_needs_resume_failed_with_incomplete_plan() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        let steps = vec![
+            PlanStep {
+                description: "Investigate".to_string(),
+                done: true,
+                ..Default::default()
+            },
+            PlanStep {
+                description: "Write fix".to_string(),
+                ..Default::default()
+            },
+            PlanStep {
+                description: "Write tests".to_string(),
+                ..Default::default()
+            },
+        ];
+        mgr.update_run_plan(&run.id, &steps).unwrap();
+        mgr.update_run_session_id(&run.id, "sess-abc").unwrap();
+        mgr.update_run_failed(&run.id, "Context exhausted").unwrap();
+
+        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
+        assert!(fetched.needs_resume());
+        assert!(fetched.has_incomplete_plan_steps());
+        assert_eq!(fetched.incomplete_plan_steps().len(), 2);
+        assert_eq!(fetched.claude_session_id.as_deref(), Some("sess-abc"));
+    }
+
+    #[test]
+    fn test_needs_resume_cancelled_with_incomplete_plan() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        let steps = vec![
+            PlanStep {
+                description: "Step 1".to_string(),
+                done: true,
+                ..Default::default()
+            },
+            PlanStep {
+                description: "Step 2".to_string(),
+                ..Default::default()
+            },
+        ];
+        mgr.update_run_plan(&run.id, &steps).unwrap();
+        mgr.update_run_session_id(&run.id, "sess-xyz").unwrap();
+        mgr.update_run_cancelled(&run.id).unwrap();
+
+        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
+        assert!(fetched.needs_resume());
+        assert_eq!(fetched.incomplete_plan_steps().len(), 1);
+    }
+
+    #[test]
+    fn test_no_needs_resume_completed_run() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        let steps = vec![PlanStep {
+            description: "Step 1".to_string(),
+            ..Default::default()
+        }];
+        mgr.update_run_plan(&run.id, &steps).unwrap();
+        mgr.update_run_completed(&run.id, Some("sess-123"), None, None, None, None)
+            .unwrap();
+        mgr.mark_plan_done(&run.id).unwrap();
+
+        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
+        assert!(!fetched.needs_resume());
+    }
+
+    #[test]
+    fn test_no_needs_resume_no_session_id() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        let steps = vec![PlanStep {
+            description: "Step 1".to_string(),
+            ..Default::default()
+        }];
+        mgr.update_run_plan(&run.id, &steps).unwrap();
+        // Fail without ever getting a session_id (e.g. spawn failure)
+        mgr.update_run_failed(&run.id, "Failed to spawn").unwrap();
+
+        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
+        assert!(!fetched.needs_resume()); // No session_id means can't resume
+    }
+
+    #[test]
+    fn test_no_needs_resume_all_steps_done() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        let steps = vec![PlanStep {
+            description: "Step 1".to_string(),
+            done: true,
+            ..Default::default()
+        }];
+        mgr.update_run_plan(&run.id, &steps).unwrap();
+        mgr.update_run_session_id(&run.id, "sess-123").unwrap();
+        mgr.update_run_failed(&run.id, "Some error").unwrap();
+
+        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
+        assert!(!fetched.needs_resume()); // All steps done, nothing to resume
+    }
+
+    #[test]
+    fn test_build_resume_prompt() {
+        let run = AgentRun {
+            id: "test".to_string(),
+            worktree_id: "w1".to_string(),
+            claude_session_id: Some("sess-abc".to_string()),
+            prompt: "Fix the bug".to_string(),
+            status: "failed".to_string(),
+            result_text: None,
+            cost_usd: None,
+            num_turns: None,
+            duration_ms: None,
+            started_at: "2024-01-01T00:00:00Z".to_string(),
+            ended_at: None,
+            tmux_window: None,
+            log_file: None,
+            model: None,
+            plan: Some(vec![
+                PlanStep {
+                    description: "Investigate".to_string(),
+                    done: true,
+                    ..Default::default()
+                },
+                PlanStep {
+                    description: "Write fix".to_string(),
+                    ..Default::default()
+                },
+                PlanStep {
+                    description: "Write tests".to_string(),
+                    ..Default::default()
+                },
+            ]),
+            parent_run_id: None,
+        };
+
+        let prompt = run.build_resume_prompt();
+        assert!(prompt.contains("Continue where you left off"));
+        assert!(prompt.contains("1. Write fix"));
+        assert!(prompt.contains("2. Write tests"));
+        assert!(!prompt.contains("Investigate")); // Done step should not appear
+    }
+
+    #[test]
+    fn test_update_run_failed_with_session() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        mgr.update_run_failed_with_session(&run.id, "Context exhausted", Some("sess-456"))
+            .unwrap();
+
+        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
+        assert_eq!(fetched.status, "failed");
+        assert_eq!(fetched.result_text.as_deref(), Some("Context exhausted"));
+        assert_eq!(fetched.claude_session_id.as_deref(), Some("sess-456"));
+    }
+
+    #[test]
+    fn test_update_run_session_id() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        assert!(run.claude_session_id.is_none());
+
+        mgr.update_run_session_id(&run.id, "sess-early").unwrap();
+
+        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
+        assert_eq!(fetched.claude_session_id.as_deref(), Some("sess-early"));
+    }
+
+    #[test]
+    fn test_failed_with_session_preserves_eager_session_id() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        let run = mgr.create_run("w1", "Fix the bug", None, None).unwrap();
+        // Session ID was saved eagerly during stream
+        mgr.update_run_session_id(&run.id, "sess-eager").unwrap();
+        // Fail without passing session_id (uses COALESCE to keep existing)
+        mgr.update_run_failed(&run.id, "Crashed").unwrap();
+
+        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
+        assert_eq!(fetched.claude_session_id.as_deref(), Some("sess-eager"));
     }
 }

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -2630,18 +2630,33 @@ impl App {
         }
 
         // Check for existing session to resume (from DB)
-        let resume_session_id = self
-            .state
-            .data
-            .latest_agent_runs
-            .get(&wt.id)
-            .and_then(|run| run.claude_session_id.clone());
+        let latest_run = self.state.data.latest_agent_runs.get(&wt.id);
+
+        // Determine resume state: either a normal resume (completed run with session_id)
+        // or a needs_resume (failed/cancelled run with incomplete plan steps)
+        let (resume_session_id, needs_resume) = match latest_run {
+            Some(run) if run.needs_resume() => (run.claude_session_id.clone(), true),
+            Some(run) => (run.claude_session_id.clone(), false),
+            None => (None, false),
+        };
 
         let has_prior_runs = AgentManager::new(&self.conn)
             .has_runs_for_worktree(&wt.id)
             .unwrap_or(false);
 
-        let (title, prefill) = if resume_session_id.is_some() {
+        let (title, prefill) = if needs_resume {
+            // Auto-build resume prompt from incomplete plan steps
+            let incomplete_count = latest_run
+                .map(|r| r.incomplete_plan_steps().len())
+                .unwrap_or(0);
+            let resume_prompt = latest_run
+                .map(|r| r.build_resume_prompt())
+                .unwrap_or_default();
+            (
+                format!("Claude Agent (Resume — {incomplete_count} steps remaining)"),
+                resume_prompt,
+            )
+        } else if resume_session_id.is_some() {
             ("Claude Agent (Resume)".to_string(), String::new())
         } else if has_prior_runs {
             // Skip pre-fill when worktree has prior agent activity

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -376,7 +376,13 @@ fn render_agent_status_line(
                 Span::styled("Agent: ", Style::default().fg(Color::DarkGray)),
                 Span::styled("[failed]", Style::default().fg(Color::Red)),
             ];
-            if let Some(ref err) = run.result_text {
+            if run.needs_resume() {
+                let remaining = run.incomplete_plan_steps().len();
+                spans.push(Span::styled(
+                    format!(" [{remaining} steps remaining — press r to resume]"),
+                    Style::default().fg(Color::Yellow),
+                ));
+            } else if let Some(ref err) = run.result_text {
                 let truncated = if err.len() > 60 { &err[..60] } else { err };
                 spans.push(Span::styled(
                     format!(" {truncated}"),
@@ -385,10 +391,20 @@ fn render_agent_status_line(
             }
             Line::from(spans)
         }
-        "cancelled" => Line::from(vec![
-            Span::styled("Agent: ", Style::default().fg(Color::DarkGray)),
-            Span::styled("[cancelled]", Style::default().fg(Color::DarkGray)),
-        ]),
+        "cancelled" => {
+            let mut spans = vec![
+                Span::styled("Agent: ", Style::default().fg(Color::DarkGray)),
+                Span::styled("[cancelled]", Style::default().fg(Color::DarkGray)),
+            ];
+            if run.needs_resume() {
+                let remaining = run.incomplete_plan_steps().len();
+                spans.push(Span::styled(
+                    format!(" [{remaining} steps remaining — press r to resume]"),
+                    Style::default().fg(Color::Yellow),
+                ));
+            }
+            Line::from(spans)
+        }
         other => Line::from(vec![
             Span::styled("Agent: ", Style::default().fg(Color::DarkGray)),
             Span::raw(format!("[{other}]")),

--- a/conductor-web/src/routes/agents.rs
+++ b/conductor-web/src/routes/agents.rs
@@ -389,6 +389,10 @@ pub async fn get_run_events(
 pub struct AgentPromptResponse {
     pub prompt: String,
     pub resume_session_id: Option<String>,
+    /// True if the latest run ended with incomplete plan steps and can be auto-resumed.
+    pub needs_resume: bool,
+    /// Number of incomplete plan steps remaining (0 if no resume needed).
+    pub incomplete_steps: usize,
 }
 
 /// Get a pre-filled agent prompt for a worktree (from its linked ticket).
@@ -403,8 +407,26 @@ pub async fn get_prompt(
     let wt_mgr = WorktreeManager::new(&db, &config);
     let wt = wt_mgr.get_by_id(&worktree_id)?;
 
-    // Build prompt from ticket if linked
-    let prompt = if let Some(ref ticket_id) = wt.ticket_id {
+    // Check for resumable session
+    let agent_mgr = AgentManager::new(&db);
+    let latest_run = agent_mgr.latest_for_worktree(&wt.id)?;
+
+    let (resume_session_id, needs_resume, incomplete_steps) = match &latest_run {
+        Some(run) if run.needs_resume() => {
+            let incomplete = run.incomplete_plan_steps().len();
+            (run.claude_session_id.clone(), true, incomplete)
+        }
+        Some(run) => (run.claude_session_id.clone(), false, 0),
+        None => (None, false, 0),
+    };
+
+    // Build prompt: if needs_resume, use the resume prompt; otherwise use ticket context
+    let prompt = if needs_resume {
+        latest_run
+            .as_ref()
+            .map(|r| r.build_resume_prompt())
+            .unwrap_or_default()
+    } else if let Some(ref ticket_id) = wt.ticket_id {
         let syncer = TicketSyncer::new(&db);
         match syncer.get_by_id(ticket_id) {
             Ok(ticket) => build_agent_prompt(&ticket),
@@ -414,15 +436,11 @@ pub async fn get_prompt(
         String::new()
     };
 
-    // Check for resumable session
-    let agent_mgr = AgentManager::new(&db);
-    let resume_session_id = agent_mgr
-        .latest_for_worktree(&wt.id)?
-        .and_then(|run| run.claude_session_id);
-
     Ok(Json(AgentPromptResponse {
         prompt,
         resume_session_id,
+        needs_resume,
+        incomplete_steps,
     }))
 }
 


### PR DESCRIPTION
Detect and surface runs that ended (failed/cancelled) with incomplete plan steps.
When a Claude Code session ends, the previous session_id and incomplete steps are now
preserved and resumable, enabling continuation of long or complex agent tasks.

Key changes:
- Add AgentRun::needs_resume() to detect resumable runs (failed/cancelled + session_id + incomplete steps)
- Add AgentRun::build_resume_prompt() to construct prompt from remaining steps
- Add AgentManager::update_run_session_id() to eagerly save session_id during run
- Add AgentManager::update_run_failed_with_session() to preserve session_id on failure via COALESCE
- CLI: save session_id eagerly when parsed from stream; carry forward plan on resume
- TUI: detect needs_resume and show "[N steps remaining — press r to resume]" badge on failed/cancelled runs
- Web API: expose needs_resume and incomplete_steps fields in agent prompt response
- Add 6 unit tests covering: all steps done, some incomplete, failed/cancelled, no session_id

The detection uses a computed property rather than a DB status change, allowing the feature
to work without migrations while maintaining self-clearing behavior (latest run after successful
resume will have all steps complete, so badge disappears automatically).

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
