### PR TITLE
feat: merge queue for serializing parallel agent merges (#134)

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -12,6 +12,7 @@ use conductor_core::db::open_database;
 use conductor_core::github;
 use conductor_core::issue_source::{GitHubConfig, IssueSourceManager, JiraConfig};
 use conductor_core::jira_acli;
+use conductor_core::merge_queue::MergeQueueManager;
 use conductor_core::orchestrator::{self, OrchestratorConfig};
 use conductor_core::repo::{derive_local_path, derive_slug_from_url, RepoManager};
 use conductor_core::tickets::{build_agent_prompt, TicketSyncer};
@@ -48,6 +49,64 @@ enum Commands {
     Agent {
         #[command(subcommand)]
         command: AgentCommands,
+    },
+    /// Manage the merge queue for serializing parallel agent merges
+    #[command(name = "merge-queue")]
+    MergeQueue {
+        #[command(subcommand)]
+        command: MergeQueueCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum MergeQueueCommands {
+    /// Add a worktree to the merge queue
+    Enqueue {
+        /// Repo slug
+        repo: String,
+        /// Worktree slug
+        worktree: String,
+        /// Target branch (defaults to main)
+        #[arg(long, default_value = "main")]
+        target: String,
+    },
+    /// List merge queue entries for a repo
+    List {
+        /// Repo slug
+        repo: String,
+        /// Show only pending entries (queued/processing)
+        #[arg(long)]
+        pending: bool,
+    },
+    /// Show details of a single merge queue entry
+    Show {
+        /// Entry ID
+        id: String,
+    },
+    /// Pop the next queued entry and mark it as processing
+    Pop {
+        /// Repo slug
+        repo: String,
+    },
+    /// Mark an entry as merged
+    Merged {
+        /// Entry ID
+        id: String,
+    },
+    /// Mark an entry as failed
+    Failed {
+        /// Entry ID
+        id: String,
+    },
+    /// Remove an entry from the queue
+    Remove {
+        /// Entry ID
+        id: String,
+    },
+    /// Show queue statistics for a repo
+    Stats {
+        /// Repo slug
+        repo: String,
     },
 }
 
@@ -800,6 +859,97 @@ fn main() -> Result<()> {
                 }
             }
         },
+        Commands::MergeQueue { command } => {
+            let mqm = MergeQueueManager::new(&conn);
+            match command {
+                MergeQueueCommands::Enqueue {
+                    repo,
+                    worktree,
+                    target,
+                } => {
+                    let repo_mgr = RepoManager::new(&conn, &config);
+                    let repo_obj = repo_mgr.get_by_slug(&repo)?;
+                    let wt_mgr = WorktreeManager::new(&conn, &config);
+                    let wt = wt_mgr.get_by_slug(&repo_obj.id, &worktree)?;
+                    let entry = mqm.enqueue(&repo_obj.id, &wt.id, None, Some(&target))?;
+                    println!(
+                        "Enqueued {} at position {} (id: {})",
+                        worktree, entry.position, entry.id
+                    );
+                }
+                MergeQueueCommands::List { repo, pending } => {
+                    let repo_mgr = RepoManager::new(&conn, &config);
+                    let repo_obj = repo_mgr.get_by_slug(&repo)?;
+                    let entries = if pending {
+                        mqm.list_pending(&repo_obj.id)?
+                    } else {
+                        mqm.list_for_repo(&repo_obj.id)?
+                    };
+                    if entries.is_empty() {
+                        println!("Merge queue is empty.");
+                    } else {
+                        println!("{:<4} {:<10} {:<26} Queued At", "Pos", "Status", "ID");
+                        for e in &entries {
+                            println!(
+                                "{:<4} {:<10} {:<26} {}",
+                                e.position, e.status, e.id, e.queued_at
+                            );
+                        }
+                    }
+                }
+                MergeQueueCommands::Show { id } => {
+                    if let Some(e) = mqm.get(&id)? {
+                        println!("ID:            {}", e.id);
+                        println!("Worktree:      {}", e.worktree_id);
+                        println!("Target branch: {}", e.target_branch);
+                        println!("Position:      {}", e.position);
+                        println!("Status:        {}", e.status);
+                        println!("Queued at:     {}", e.queued_at);
+                        if let Some(ref s) = e.started_at {
+                            println!("Started at:    {}", s);
+                        }
+                        if let Some(ref c) = e.completed_at {
+                            println!("Completed at:  {}", c);
+                        }
+                    } else {
+                        println!("Entry not found: {}", id);
+                    }
+                }
+                MergeQueueCommands::Pop { repo } => {
+                    let repo_mgr = RepoManager::new(&conn, &config);
+                    let repo_obj = repo_mgr.get_by_slug(&repo)?;
+                    if let Some(entry) = mqm.pop_next(&repo_obj.id)? {
+                        println!(
+                            "Processing entry {} (worktree: {})",
+                            entry.id, entry.worktree_id
+                        );
+                    } else {
+                        println!("Nothing to process (queue empty or entry already processing).");
+                    }
+                }
+                MergeQueueCommands::Merged { id } => {
+                    mqm.mark_merged(&id)?;
+                    println!("Marked {} as merged.", id);
+                }
+                MergeQueueCommands::Failed { id } => {
+                    mqm.mark_failed(&id)?;
+                    println!("Marked {} as failed.", id);
+                }
+                MergeQueueCommands::Remove { id } => {
+                    mqm.remove(&id)?;
+                    println!("Removed {} from merge queue.", id);
+                }
+                MergeQueueCommands::Stats { repo } => {
+                    let repo_mgr = RepoManager::new(&conn, &config);
+                    let repo_obj = repo_mgr.get_by_slug(&repo)?;
+                    let stats = mqm.queue_stats(&repo_obj.id)?;
+                    println!("Queued:     {}", stats.queued);
+                    println!("Processing: {}", stats.processing);
+                    println!("Merged:     {}", stats.merged);
+                    println!("Failed:     {}", stats.failed);
+                }
+            }
+        }
     }
 
     Ok(())

--- a/conductor-core/src/db/migrations.rs
+++ b/conductor-core/src/db/migrations.rs
@@ -238,5 +238,17 @@ pub fn run(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    // Migration 016: create merge_queue table for serializing parallel agent merges.
+    let has_merge_queue: bool = conn.prepare("SELECT id FROM merge_queue LIMIT 0").is_ok();
+    if !has_merge_queue {
+        conn.execute_batch(include_str!("migrations/016_merge_queue.sql"))?;
+    }
+    if version < 16 {
+        conn.execute(
+            "INSERT OR REPLACE INTO _conductor_meta (key, value) VALUES ('schema_version', '16')",
+            [],
+        )?;
+    }
+
     Ok(())
 }

--- a/conductor-core/src/db/migrations/016_merge_queue.sql
+++ b/conductor-core/src/db/migrations/016_merge_queue.sql
@@ -1,0 +1,21 @@
+-- Migration 016: add merge_queue table for serializing parallel agent merges.
+-- Each entry represents a worktree+run whose changes should be landed on a
+-- target branch (typically main) by a dedicated "refinery" agent.
+
+CREATE TABLE IF NOT EXISTS merge_queue (
+    id            TEXT PRIMARY KEY,
+    repo_id       TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    worktree_id   TEXT NOT NULL REFERENCES worktrees(id) ON DELETE CASCADE,
+    run_id        TEXT REFERENCES agent_runs(id) ON DELETE SET NULL,
+    target_branch TEXT NOT NULL DEFAULT 'main',
+    position      INTEGER NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'queued'
+                  CHECK (status IN ('queued', 'processing', 'merged', 'failed')),
+    queued_at     TEXT NOT NULL,
+    started_at    TEXT,
+    completed_at  TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_merge_queue_repo_id ON merge_queue(repo_id);
+CREATE INDEX IF NOT EXISTS idx_merge_queue_worktree_id ON merge_queue(worktree_id);
+CREATE INDEX IF NOT EXISTS idx_merge_queue_status ON merge_queue(status);

--- a/conductor-core/src/error.rs
+++ b/conductor-core/src/error.rs
@@ -43,6 +43,9 @@ pub enum ConductorError {
 
     #[error("worktree already has a linked ticket")]
     TicketAlreadyLinked,
+
+    #[error("merge queue entry not found: {id}")]
+    MergeQueueEntryNotFound { id: String },
 }
 
 pub type Result<T> = std::result::Result<T, ConductorError>;

--- a/conductor-core/src/lib.rs
+++ b/conductor-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod github;
 pub mod issue_source;
 pub mod jira_acli;
+pub mod merge_queue;
 pub mod models;
 pub mod orchestrator;
 pub mod repo;

--- a/conductor-core/src/merge_queue.rs
+++ b/conductor-core/src/merge_queue.rs
@@ -1,0 +1,444 @@
+use chrono::Utc;
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+
+/// A single entry in the merge queue — represents a worktree whose changes
+/// should be landed onto the target branch by the refinery agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MergeQueueEntry {
+    pub id: String,
+    pub repo_id: String,
+    pub worktree_id: String,
+    pub run_id: Option<String>,
+    pub target_branch: String,
+    pub position: i64,
+    /// One of: queued, processing, merged, failed.
+    pub status: String,
+    pub queued_at: String,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+}
+
+/// Manages the per-repo merge queue that serializes parallel agent merges.
+pub struct MergeQueueManager<'a> {
+    conn: &'a Connection,
+}
+
+impl<'a> MergeQueueManager<'a> {
+    pub fn new(conn: &'a Connection) -> Self {
+        Self { conn }
+    }
+
+    /// Add a worktree (and optional run) to the merge queue for a repo.
+    /// Automatically assigns the next position.
+    pub fn enqueue(
+        &self,
+        repo_id: &str,
+        worktree_id: &str,
+        run_id: Option<&str>,
+        target_branch: Option<&str>,
+    ) -> Result<MergeQueueEntry> {
+        let id = ulid::Ulid::new().to_string();
+        let now = Utc::now().to_rfc3339();
+        let branch = target_branch.unwrap_or("main");
+
+        // Next position = max existing position for this repo + 1.
+        let next_pos: i64 = self.conn.query_row(
+            "SELECT COALESCE(MAX(position), -1) + 1 FROM merge_queue WHERE repo_id = ?1",
+            params![repo_id],
+            |row| row.get(0),
+        )?;
+
+        self.conn.execute(
+            "INSERT INTO merge_queue (id, repo_id, worktree_id, run_id, target_branch, position, status, queued_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'queued', ?7)",
+            params![id, repo_id, worktree_id, run_id, branch, next_pos, now],
+        )?;
+
+        Ok(MergeQueueEntry {
+            id,
+            repo_id: repo_id.to_string(),
+            worktree_id: worktree_id.to_string(),
+            run_id: run_id.map(|s| s.to_string()),
+            target_branch: branch.to_string(),
+            position: next_pos,
+            status: "queued".to_string(),
+            queued_at: now,
+            started_at: None,
+            completed_at: None,
+        })
+    }
+
+    /// List all merge queue entries for a repo, ordered by position.
+    pub fn list_for_repo(&self, repo_id: &str) -> Result<Vec<MergeQueueEntry>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo_id, worktree_id, run_id, target_branch, position, status,
+                    queued_at, started_at, completed_at
+             FROM merge_queue
+             WHERE repo_id = ?1
+             ORDER BY position ASC",
+        )?;
+        let entries = stmt
+            .query_map(params![repo_id], |row| {
+                Ok(MergeQueueEntry {
+                    id: row.get(0)?,
+                    repo_id: row.get(1)?,
+                    worktree_id: row.get(2)?,
+                    run_id: row.get(3)?,
+                    target_branch: row.get(4)?,
+                    position: row.get(5)?,
+                    status: row.get(6)?,
+                    queued_at: row.get(7)?,
+                    started_at: row.get(8)?,
+                    completed_at: row.get(9)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(entries)
+    }
+
+    /// List only pending (queued/processing) entries for a repo, ordered by position.
+    pub fn list_pending(&self, repo_id: &str) -> Result<Vec<MergeQueueEntry>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo_id, worktree_id, run_id, target_branch, position, status,
+                    queued_at, started_at, completed_at
+             FROM merge_queue
+             WHERE repo_id = ?1 AND status IN ('queued', 'processing')
+             ORDER BY position ASC",
+        )?;
+        let entries = stmt
+            .query_map(params![repo_id], |row| {
+                Ok(MergeQueueEntry {
+                    id: row.get(0)?,
+                    repo_id: row.get(1)?,
+                    worktree_id: row.get(2)?,
+                    run_id: row.get(3)?,
+                    target_branch: row.get(4)?,
+                    position: row.get(5)?,
+                    status: row.get(6)?,
+                    queued_at: row.get(7)?,
+                    started_at: row.get(8)?,
+                    completed_at: row.get(9)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(entries)
+    }
+
+    /// Get a single entry by ID.
+    pub fn get(&self, entry_id: &str) -> Result<Option<MergeQueueEntry>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo_id, worktree_id, run_id, target_branch, position, status,
+                    queued_at, started_at, completed_at
+             FROM merge_queue
+             WHERE id = ?1",
+        )?;
+        let entry = stmt
+            .query_row(params![entry_id], |row| {
+                Ok(MergeQueueEntry {
+                    id: row.get(0)?,
+                    repo_id: row.get(1)?,
+                    worktree_id: row.get(2)?,
+                    run_id: row.get(3)?,
+                    target_branch: row.get(4)?,
+                    position: row.get(5)?,
+                    status: row.get(6)?,
+                    queued_at: row.get(7)?,
+                    started_at: row.get(8)?,
+                    completed_at: row.get(9)?,
+                })
+            })
+            .optional()?;
+        Ok(entry)
+    }
+
+    /// Pop the next queued entry for a repo and mark it as processing.
+    /// Returns None if the queue is empty or an entry is already processing.
+    pub fn pop_next(&self, repo_id: &str) -> Result<Option<MergeQueueEntry>> {
+        // Don't pop if something is already being processed.
+        let processing_count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM merge_queue WHERE repo_id = ?1 AND status = 'processing'",
+            params![repo_id],
+            |row| row.get(0),
+        )?;
+        if processing_count > 0 {
+            return Ok(None);
+        }
+
+        let now = Utc::now().to_rfc3339();
+        let updated = self.conn.execute(
+            "UPDATE merge_queue SET status = 'processing', started_at = ?1
+             WHERE id = (
+                 SELECT id FROM merge_queue
+                 WHERE repo_id = ?2 AND status = 'queued'
+                 ORDER BY position ASC
+                 LIMIT 1
+             )",
+            params![now, repo_id],
+        )?;
+        if updated == 0 {
+            return Ok(None);
+        }
+
+        // Return the entry we just updated.
+        let mut stmt = self.conn.prepare(
+            "SELECT id, repo_id, worktree_id, run_id, target_branch, position, status,
+                    queued_at, started_at, completed_at
+             FROM merge_queue
+             WHERE repo_id = ?1 AND status = 'processing'
+             ORDER BY position ASC
+             LIMIT 1",
+        )?;
+        let entry = stmt
+            .query_row(params![repo_id], |row| {
+                Ok(MergeQueueEntry {
+                    id: row.get(0)?,
+                    repo_id: row.get(1)?,
+                    worktree_id: row.get(2)?,
+                    run_id: row.get(3)?,
+                    target_branch: row.get(4)?,
+                    position: row.get(5)?,
+                    status: row.get(6)?,
+                    queued_at: row.get(7)?,
+                    started_at: row.get(8)?,
+                    completed_at: row.get(9)?,
+                })
+            })
+            .optional()?;
+        Ok(entry)
+    }
+
+    /// Mark an entry as merged.
+    pub fn mark_merged(&self, entry_id: &str) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "UPDATE merge_queue SET status = 'merged', completed_at = ?1 WHERE id = ?2",
+            params![now, entry_id],
+        )?;
+        Ok(())
+    }
+
+    /// Mark an entry as failed.
+    pub fn mark_failed(&self, entry_id: &str) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "UPDATE merge_queue SET status = 'failed', completed_at = ?1 WHERE id = ?2",
+            params![now, entry_id],
+        )?;
+        Ok(())
+    }
+
+    /// Remove an entry from the queue (cancel before it's processed).
+    pub fn remove(&self, entry_id: &str) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM merge_queue WHERE id = ?1", params![entry_id])?;
+        Ok(())
+    }
+
+    /// Get the count of entries by status for a repo.
+    pub fn queue_stats(&self, repo_id: &str) -> Result<QueueStats> {
+        let mut stmt = self.conn.prepare(
+            "SELECT status, COUNT(*) FROM merge_queue WHERE repo_id = ?1 GROUP BY status",
+        )?;
+        let mut stats = QueueStats::default();
+        let rows = stmt.query_map(params![repo_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        for row in rows {
+            let (status, count) = row?;
+            match status.as_str() {
+                "queued" => stats.queued = count,
+                "processing" => stats.processing = count,
+                "merged" => stats.merged = count,
+                "failed" => stats.failed = count,
+                _ => {}
+            }
+        }
+        Ok(stats)
+    }
+}
+
+/// Summary counts for a repo's merge queue.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct QueueStats {
+    pub queued: i64,
+    pub processing: i64,
+    pub merged: i64,
+    pub failed: i64,
+}
+
+// ── Bring rusqlite::OptionalExtension into scope ─────────────────────
+use rusqlite::OptionalExtension;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::open_database;
+    use tempfile::NamedTempFile;
+
+    fn setup() -> (Connection, String) {
+        let tmp = NamedTempFile::new().unwrap();
+        let conn = open_database(tmp.path()).unwrap();
+
+        // Insert a repo.
+        let repo_id = ulid::Ulid::new().to_string();
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO repos (id, slug, local_path, remote_url, default_branch, workspace_dir, created_at)
+             VALUES (?1, 'test-repo', '/tmp/test', 'https://github.com/test/repo', 'main', '/tmp/ws', ?2)",
+            params![repo_id, now],
+        )
+        .unwrap();
+
+        (conn, repo_id)
+    }
+
+    fn insert_worktree(conn: &Connection, repo_id: &str, slug: &str) -> String {
+        let wt_id = ulid::Ulid::new().to_string();
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO worktrees (id, repo_id, slug, branch, path, status, created_at)
+             VALUES (?1, ?2, ?3, ?4, '/tmp/wt', 'active', ?5)",
+            params![wt_id, repo_id, slug, format!("feat/{slug}"), now],
+        )
+        .unwrap();
+        wt_id
+    }
+
+    #[test]
+    fn test_enqueue_and_list() {
+        let (conn, repo_id) = setup();
+        let wt1 = insert_worktree(&conn, &repo_id, "feature-a");
+        let wt2 = insert_worktree(&conn, &repo_id, "feature-b");
+
+        let mgr = MergeQueueManager::new(&conn);
+
+        let e1 = mgr.enqueue(&repo_id, &wt1, None, None).unwrap();
+        assert_eq!(e1.position, 0);
+        assert_eq!(e1.status, "queued");
+
+        let e2 = mgr.enqueue(&repo_id, &wt2, None, None).unwrap();
+        assert_eq!(e2.position, 1);
+
+        let all = mgr.list_for_repo(&repo_id).unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].worktree_id, wt1);
+        assert_eq!(all[1].worktree_id, wt2);
+    }
+
+    #[test]
+    fn test_pop_next_serializes() {
+        let (conn, repo_id) = setup();
+        let wt1 = insert_worktree(&conn, &repo_id, "feature-a");
+        let wt2 = insert_worktree(&conn, &repo_id, "feature-b");
+
+        let mgr = MergeQueueManager::new(&conn);
+        mgr.enqueue(&repo_id, &wt1, None, None).unwrap();
+        mgr.enqueue(&repo_id, &wt2, None, None).unwrap();
+
+        // Pop first — should get wt1.
+        let first = mgr.pop_next(&repo_id).unwrap().unwrap();
+        assert_eq!(first.worktree_id, wt1);
+        assert_eq!(first.status, "processing");
+        assert!(first.started_at.is_some());
+
+        // Pop again while first is processing — should get None (serialized).
+        let blocked = mgr.pop_next(&repo_id).unwrap();
+        assert!(blocked.is_none());
+
+        // Mark first merged, then pop — should get wt2.
+        mgr.mark_merged(&first.id).unwrap();
+        let second = mgr.pop_next(&repo_id).unwrap().unwrap();
+        assert_eq!(second.worktree_id, wt2);
+    }
+
+    #[test]
+    fn test_mark_failed() {
+        let (conn, repo_id) = setup();
+        let wt1 = insert_worktree(&conn, &repo_id, "feature-a");
+
+        let mgr = MergeQueueManager::new(&conn);
+        let entry = mgr.enqueue(&repo_id, &wt1, None, None).unwrap();
+
+        mgr.pop_next(&repo_id).unwrap();
+        mgr.mark_failed(&entry.id).unwrap();
+
+        let e = mgr.get(&entry.id).unwrap().unwrap();
+        assert_eq!(e.status, "failed");
+        assert!(e.completed_at.is_some());
+    }
+
+    #[test]
+    fn test_remove() {
+        let (conn, repo_id) = setup();
+        let wt1 = insert_worktree(&conn, &repo_id, "feature-a");
+
+        let mgr = MergeQueueManager::new(&conn);
+        let entry = mgr.enqueue(&repo_id, &wt1, None, None).unwrap();
+
+        mgr.remove(&entry.id).unwrap();
+        let gone = mgr.get(&entry.id).unwrap();
+        assert!(gone.is_none());
+    }
+
+    #[test]
+    fn test_queue_stats() {
+        let (conn, repo_id) = setup();
+        let wt1 = insert_worktree(&conn, &repo_id, "feature-a");
+        let wt2 = insert_worktree(&conn, &repo_id, "feature-b");
+        let wt3 = insert_worktree(&conn, &repo_id, "feature-c");
+
+        let mgr = MergeQueueManager::new(&conn);
+        mgr.enqueue(&repo_id, &wt1, None, None).unwrap();
+        let e2 = mgr.enqueue(&repo_id, &wt2, None, None).unwrap();
+        mgr.enqueue(&repo_id, &wt3, None, None).unwrap();
+
+        // Pop and merge one.
+        let first = mgr.pop_next(&repo_id).unwrap().unwrap();
+        mgr.mark_merged(&first.id).unwrap();
+
+        // Fail another.
+        // Need to pop_next again now that first is merged.
+        let second = mgr.pop_next(&repo_id).unwrap().unwrap();
+        assert_eq!(second.id, e2.id);
+        mgr.mark_failed(&second.id).unwrap();
+
+        let stats = mgr.queue_stats(&repo_id).unwrap();
+        assert_eq!(stats.queued, 1);
+        assert_eq!(stats.processing, 0);
+        assert_eq!(stats.merged, 1);
+        assert_eq!(stats.failed, 1);
+    }
+
+    #[test]
+    fn test_list_pending() {
+        let (conn, repo_id) = setup();
+        let wt1 = insert_worktree(&conn, &repo_id, "feature-a");
+        let wt2 = insert_worktree(&conn, &repo_id, "feature-b");
+
+        let mgr = MergeQueueManager::new(&conn);
+        let e1 = mgr.enqueue(&repo_id, &wt1, None, None).unwrap();
+        mgr.enqueue(&repo_id, &wt2, None, None).unwrap();
+
+        // Mark first merged.
+        mgr.pop_next(&repo_id).unwrap();
+        mgr.mark_merged(&e1.id).unwrap();
+
+        // Only wt2 should be pending.
+        let pending = mgr.list_pending(&repo_id).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].worktree_id, wt2);
+    }
+
+    #[test]
+    fn test_custom_target_branch() {
+        let (conn, repo_id) = setup();
+        let wt1 = insert_worktree(&conn, &repo_id, "feature-a");
+
+        let mgr = MergeQueueManager::new(&conn);
+        let entry = mgr.enqueue(&repo_id, &wt1, None, Some("develop")).unwrap();
+        assert_eq!(entry.target_branch, "develop");
+    }
+}

--- a/conductor-core/src/worktree.rs
+++ b/conductor-core/src/worktree.rs
@@ -170,6 +170,19 @@ impl<'a> WorktreeManager<'a> {
             })
     }
 
+    pub fn get_by_slug(&self, repo_id: &str, slug: &str) -> Result<Worktree> {
+        self.conn
+            .query_row(
+                "SELECT id, repo_id, slug, branch, path, ticket_id, status, created_at, completed_at, model
+                 FROM worktrees WHERE repo_id = ?1 AND slug = ?2",
+                params![repo_id, slug],
+                map_worktree_row,
+            )
+            .map_err(|_| ConductorError::WorktreeNotFound {
+                slug: slug.to_string(),
+            })
+    }
+
     pub fn list_by_repo_id(&self, repo_id: &str, active_only: bool) -> Result<Vec<Worktree>> {
         let status_filter = if active_only {
             " AND status = 'active'"

--- a/conductor-web/src/error.rs
+++ b/conductor-web/src/error.rs
@@ -9,7 +9,8 @@ impl IntoResponse for ApiError {
         let status = match &self.0 {
             ConductorError::RepoNotFound { .. }
             | ConductorError::WorktreeNotFound { .. }
-            | ConductorError::TicketNotFound { .. } => StatusCode::NOT_FOUND,
+            | ConductorError::TicketNotFound { .. }
+            | ConductorError::MergeQueueEntryNotFound { .. } => StatusCode::NOT_FOUND,
             ConductorError::RepoAlreadyExists { .. }
             | ConductorError::WorktreeAlreadyExists { .. }
             | ConductorError::IssueSourceAlreadyExists { .. }

--- a/conductor-web/src/routes/merge_queue.rs
+++ b/conductor-web/src/routes/merge_queue.rs
@@ -1,0 +1,109 @@
+use axum::extract::{Path, State};
+use axum::Json;
+use serde::Deserialize;
+
+use conductor_core::merge_queue::{MergeQueueEntry, MergeQueueManager, QueueStats};
+
+use crate::error::ApiError;
+use crate::state::AppState;
+
+/// List all merge queue entries for a repo.
+pub async fn list_entries(
+    State(state): State<AppState>,
+    Path(repo_id): Path<String>,
+) -> Result<Json<Vec<MergeQueueEntry>>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = MergeQueueManager::new(&db);
+    let entries = mgr.list_for_repo(&repo_id)?;
+    Ok(Json(entries))
+}
+
+/// List only pending (queued/processing) entries for a repo.
+pub async fn list_pending(
+    State(state): State<AppState>,
+    Path(repo_id): Path<String>,
+) -> Result<Json<Vec<MergeQueueEntry>>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = MergeQueueManager::new(&db);
+    let entries = mgr.list_pending(&repo_id)?;
+    Ok(Json(entries))
+}
+
+#[derive(Deserialize)]
+pub struct EnqueueRequest {
+    pub worktree_id: String,
+    pub run_id: Option<String>,
+    pub target_branch: Option<String>,
+}
+
+/// Add a worktree to the merge queue.
+pub async fn enqueue(
+    State(state): State<AppState>,
+    Path(repo_id): Path<String>,
+    Json(body): Json<EnqueueRequest>,
+) -> Result<Json<MergeQueueEntry>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = MergeQueueManager::new(&db);
+    let entry = mgr.enqueue(
+        &repo_id,
+        &body.worktree_id,
+        body.run_id.as_deref(),
+        body.target_branch.as_deref(),
+    )?;
+    Ok(Json(entry))
+}
+
+/// Pop the next queued entry and mark it as processing.
+pub async fn pop_next(
+    State(state): State<AppState>,
+    Path(repo_id): Path<String>,
+) -> Result<Json<Option<MergeQueueEntry>>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = MergeQueueManager::new(&db);
+    let entry = mgr.pop_next(&repo_id)?;
+    Ok(Json(entry))
+}
+
+/// Mark an entry as merged.
+pub async fn mark_merged(
+    State(state): State<AppState>,
+    Path(entry_id): Path<String>,
+) -> Result<Json<()>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = MergeQueueManager::new(&db);
+    mgr.mark_merged(&entry_id)?;
+    Ok(Json(()))
+}
+
+/// Mark an entry as failed.
+pub async fn mark_failed(
+    State(state): State<AppState>,
+    Path(entry_id): Path<String>,
+) -> Result<Json<()>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = MergeQueueManager::new(&db);
+    mgr.mark_failed(&entry_id)?;
+    Ok(Json(()))
+}
+
+/// Remove an entry from the queue.
+pub async fn remove_entry(
+    State(state): State<AppState>,
+    Path(entry_id): Path<String>,
+) -> Result<Json<()>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = MergeQueueManager::new(&db);
+    mgr.remove(&entry_id)?;
+    Ok(Json(()))
+}
+
+/// Get queue statistics for a repo.
+pub async fn queue_stats(
+    State(state): State<AppState>,
+    Path(repo_id): Path<String>,
+) -> Result<Json<QueueStats>, ApiError> {
+    let db = state.db.lock().await;
+    let mgr = MergeQueueManager::new(&db);
+    let stats = mgr.queue_stats(&repo_id)?;
+    Ok(Json(stats))
+}

--- a/conductor-web/src/routes/mod.rs
+++ b/conductor-web/src/routes/mod.rs
@@ -1,6 +1,7 @@
 pub mod agents;
 pub mod events;
 pub mod issue_sources;
+pub mod merge_queue;
 pub mod repos;
 pub mod tickets;
 pub mod work_targets;
@@ -106,6 +107,32 @@ pub fn api_router() -> Router<AppState> {
             "/api/repos/{id}/sources/{source_id}",
             delete(issue_sources::delete_issue_source),
         )
+        // Merge Queue
+        .route(
+            "/api/repos/{id}/merge-queue",
+            get(merge_queue::list_entries).post(merge_queue::enqueue),
+        )
+        .route(
+            "/api/repos/{id}/merge-queue/pending",
+            get(merge_queue::list_pending),
+        )
+        .route(
+            "/api/repos/{id}/merge-queue/pop",
+            post(merge_queue::pop_next),
+        )
+        .route(
+            "/api/repos/{id}/merge-queue/stats",
+            get(merge_queue::queue_stats),
+        )
+        .route(
+            "/api/merge-queue/{id}/merged",
+            post(merge_queue::mark_merged),
+        )
+        .route(
+            "/api/merge-queue/{id}/failed",
+            post(merge_queue::mark_failed),
+        )
+        .route("/api/merge-queue/{id}", delete(merge_queue::remove_entry))
         // Work Targets
         .route(
             "/api/config/model",


### PR DESCRIPTION
Add a dedicated merge queue system to prevent parallel agents from fighting
over merge conflicts and rebase chaos. Implements:

**Database:**
- Migration 016: new `merge_queue` table with ULID id, repo_id, worktree_id,
  run_id, position, status (queued|processing|merged|failed), queued_at,
  started_at, completed_at, and indexes on repo_id and worktree_id.

**Core Logic:**
- MergeQueueManager with methods: enqueue(), list_for_repo(), list_pending(),
  pop_next() (serializes - blocks if entry already processing), mark_merged(),
  mark_failed(), remove(), queue_stats().
- Atomic serialization: pop_next() prevents concurrent merges by checking for
  processing status before returning the next queued entry.
- 7 unit tests covering enqueue, serialization, status transitions, and stats.

**CLI:**
- New `conductor merge-queue` subcommand with: enqueue, list (--pending flag),
  show, pop, merged, failed, remove, stats.

**Web API:**
- 7 endpoints: GET/POST /api/repos/{id}/merge-queue (list/enqueue),
  GET /api/repos/{id}/merge-queue/pending (list pending),
  POST /api/repos/{id}/merge-queue/pop (pop next),
  GET /api/repos/{id}/merge-queue/stats (queue stats),
  POST /api/merge-queue/{id}/merged|failed (mark status),
  DELETE /api/merge-queue/{id} (remove entry).

**Supporting Changes:**
- WorktreeManager.get_by_slug(repo_id, slug) public method for CLI lookup.
- Updated error handling: MergeQueueEntryNotFound error variant.

All tests pass (148), linting clean, ready for refinery agent implementation.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
