### PR TITLE
feat: scope reviewer critique to + lines; route off-diff findings to GH issues (#157)

### DIFF
--- a/conductor-core/src/github.rs
+++ b/conductor-core/src/github.rs
@@ -22,6 +22,13 @@ fn run_gh(args: &[&str]) -> Result<Output> {
     Ok(output)
 }
 
+/// A lightweight reference to a GitHub issue (title + URL).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueRef {
+    pub title: String,
+    pub url: String,
+}
+
 /// A GitHub repository discovered via the `gh` CLI.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DiscoveredRepo {
@@ -181,14 +188,13 @@ pub fn create_github_issue(
 }
 
 /// Search for existing GitHub issues matching a query, filtered by label.
-/// Returns parsed JSON objects with `number`, `title`, and `url` fields.
 pub fn list_issues_by_search(
     owner: &str,
     repo: &str,
     query: &str,
     label: &str,
     limit: u32,
-) -> Result<Vec<serde_json::Value>> {
+) -> Result<Vec<IssueRef>> {
     let repo_slug = format!("{owner}/{repo}");
     let limit_str = limit.to_string();
     let output = run_gh(&[
@@ -201,13 +207,13 @@ pub fn list_issues_by_search(
         "--label",
         label,
         "--json",
-        "number,title,url",
+        "title,url",
         "--limit",
         &limit_str,
     ])?;
 
     let json_str = String::from_utf8_lossy(&output.stdout);
-    let issues: Vec<serde_json::Value> = serde_json::from_str(json_str.trim())
+    let issues: Vec<IssueRef> = serde_json::from_str(json_str.trim())
         .map_err(|e| ConductorError::TicketSync(format!("failed to parse gh output: {e}")))?;
 
     Ok(issues)

--- a/conductor-core/src/pr_review.rs
+++ b/conductor-core/src/pr_review.rs
@@ -583,12 +583,9 @@ fn find_existing_issue(owner: &str, repo: &str, title: &str) -> Option<String> {
     // Look for a title that matches closely (case-insensitive substring)
     let title_lower = title.to_lowercase();
     for issue in &issues {
-        if let Some(existing_title) = issue["title"].as_str() {
-            if existing_title.to_lowercase().contains(&title_lower)
-                || title_lower.contains(&existing_title.to_lowercase())
-            {
-                return issue["url"].as_str().map(String::from);
-            }
+        let existing_lower = issue.title.to_lowercase();
+        if existing_lower.contains(&title_lower) || title_lower.contains(&existing_lower) {
+            return Some(issue.url.clone());
         }
     }
 


### PR DESCRIPTION
- Update build_reviewer_prompt with diff scope rules: + lines are in scope,
  - and context lines are read-only; off-diff findings use a structured block format
- Add OffDiffFinding struct and parse_off_diff_findings() to extract findings
  against unchanged/removed code from reviewer output
- Add deduplicate_off_diff_findings() to aggregate by file:line across reviewers,
  keeping the highest severity when multiple reviewers flag the same location
- Add find_existing_issue() and file_off_diff_issues() to check for duplicate GH
  issues before creating new ones with the conductor-review label
- Update is_review_approved(): suggestion-only REQUEST_CHANGES verdicts no longer
  block merge; only critical/warning findings produce blocking verdicts
- Add focus scope instructions to each reviewer prompt so out-of-focus findings
  are downgraded to suggestion rather than blocking
- Integrate off-diff filing into run_review_swarm and include issue refs in the
  aggregated PR comment
- Add 15 new tests covering parsing, dedup, severity logic, and comment rendering

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
