### PR TITLE
refactor: deduplicate field accessors in build_aggregated_comment

### DIFF
--- a/conductor-core/src/pr_review.rs
+++ b/conductor-core/src/pr_review.rs
@@ -825,26 +825,16 @@ fn build_aggregated_comment(
             "The following issues were found in unchanged code and filed as separate GitHub issues:\n\n",
         );
         for issue in off_diff_issues {
-            if issue.url.starts_with("https://") {
-                comment.push_str(&format!(
-                    "- **{}** (`{}`:{}): [{}]({}) *({})*\n",
-                    issue.finding.title,
-                    issue.finding.file,
-                    issue.finding.line,
-                    issue.url,
-                    issue.url,
-                    issue.finding.severity
-                ));
+            let f = &issue.finding;
+            let url_part = if issue.url.starts_with("https://") {
+                format!("[{}]({})", issue.url, issue.url)
             } else {
-                comment.push_str(&format!(
-                    "- **{}** (`{}`:{}): {} *({})*\n",
-                    issue.finding.title,
-                    issue.finding.file,
-                    issue.finding.line,
-                    issue.url,
-                    issue.finding.severity
-                ));
-            }
+                issue.url.clone()
+            };
+            comment.push_str(&format!(
+                "- **{}** (`{}`:{}): {} *({})*\n",
+                f.title, f.file, f.line, url_part, f.severity
+            ));
         }
         comment.push_str("\n---\n\n");
     }


### PR DESCRIPTION
Extract `f = &issue.finding` and `url_part` to eliminate duplicated
field references across the two URL-formatting branches.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
