### PR TITLE
perf: pass --label to gh issue create instead of separate gh issue edit (#164)

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -733,7 +733,7 @@ fn main() -> Result<()> {
 
                 // Create the GitHub issue
                 let (source_id, url) =
-                    github::create_github_issue(&owner, &repo_name, &title, &body)?;
+                    github::create_github_issue(&owner, &repo_name, &title, &body, &[])?;
 
                 // Record in DB
                 agent_mgr

--- a/conductor-core/src/github.rs
+++ b/conductor-core/src/github.rs
@@ -170,11 +170,17 @@ pub fn create_github_issue(
     repo: &str,
     title: &str,
     body: &str,
+    labels: &[&str],
 ) -> Result<(String, String)> {
     let repo_slug = repo_slug(owner, repo);
-    let output = run_gh(&[
+    let mut args = vec![
         "issue", "create", "--repo", &repo_slug, "--title", title, "--body", body,
-    ])?;
+    ];
+    for label in labels {
+        args.push("--label");
+        args.push(label);
+    }
+    let output = run_gh(&args)?;
 
     // `gh issue create` prints the issue URL on stdout, e.g.
     // https://github.com/owner/repo/issues/42
@@ -222,22 +228,6 @@ pub fn list_issues_by_search(
         .map_err(|e| ConductorError::TicketSync(format!("failed to parse gh output: {e}")))?;
 
     Ok(issues)
-}
-
-/// Add a label to an existing GitHub issue (best-effort via `gh issue edit`).
-pub fn add_label_to_issue(owner: &str, repo: &str, issue_url: &str, label: &str) -> Result<()> {
-    let repo_slug = repo_slug(owner, repo);
-    run_gh(&[
-        "issue",
-        "edit",
-        issue_url,
-        "--repo",
-        &repo_slug,
-        "--add-label",
-        label,
-    ])?;
-
-    Ok(())
 }
 
 /// Parse a GitHub remote URL to extract owner and repo name.

--- a/conductor-core/src/pr_review.rs
+++ b/conductor-core/src/pr_review.rs
@@ -723,10 +723,14 @@ fn file_off_diff_issues(
             body = finding.body,
         );
 
-        match github::create_github_issue(owner, repo, &finding.title, &issue_body) {
+        match github::create_github_issue(
+            owner,
+            repo,
+            &finding.title,
+            &issue_body,
+            &["conductor-review"],
+        ) {
             Ok((_number, url)) => {
-                // Try to add the conductor-review label (best-effort)
-                let _ = github::add_label_to_issue(owner, repo, &url, "conductor-review");
                 eprintln!(
                     "[review-swarm] Filed off-diff issue '{}': {}",
                     finding.title, url


### PR DESCRIPTION
Pass the "conductor-review" label directly to `gh issue create` via the
--label flag instead of making a separate `gh issue edit --add-label`
subprocess call. This reduces the number of subprocesses per filed issue
by half and simplifies error handling (the label is now atomic with
creation rather than a best-effort separate call).

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
