### PR TITLE
fix: handle UTF-8 char boundaries in string truncation (#172)

### DIFF
--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -1046,7 +1046,7 @@ pub fn build_startup_context(
         {
             if let Some(ref result) = last_run.result_text {
                 let truncated = if result.len() > 500 {
-                    format!("{}…", &result[..500])
+                    format!("{}…", crate::pr_review::truncate_str(result, 500))
                 } else {
                     result.clone()
                 };
@@ -2154,6 +2154,35 @@ mod tests {
         assert!(ctx.contains(&"x".repeat(500)));
         assert!(ctx.contains('…'));
         assert!(!ctx.contains(&"x".repeat(501)));
+    }
+
+    #[test]
+    fn test_startup_context_truncates_multibyte_result() {
+        let conn = setup_db();
+        let mgr = AgentManager::new(&conn);
+
+        // 'é' is 2 bytes; 300 copies = 600 bytes > 500 byte limit
+        let prior = mgr.create_run("w1", "Prior task", None, None).unwrap();
+        let long_result = "é".repeat(300);
+        mgr.update_run_completed(&prior.id, None, Some(&long_result), None, None, None)
+            .unwrap();
+
+        let current = mgr.create_run("w1", "Next", None, None).unwrap();
+
+        let ctx = build_startup_context(&conn, "w1", &current.id, "/tmp").unwrap();
+        assert!(ctx.contains('…'));
+        // Extract the truncated 'é' portion before the ellipsis
+        let ellipsis_pos = ctx.find('…').unwrap();
+        // Walk backwards from the ellipsis to find the start of the 'é' run
+        let before_ellipsis = &ctx[..ellipsis_pos];
+        let e_start = before_ellipsis.rfind(|c: char| c != 'é').map_or(0, |i| {
+            i + before_ellipsis[i..].chars().next().unwrap().len_utf8()
+        });
+        let truncated_part = &before_ellipsis[e_start..];
+        assert!(!truncated_part.is_empty());
+        for c in truncated_part.chars() {
+            assert_eq!(c, 'é');
+        }
     }
 
     // ── Auto-resume tests ────────────────────────────────────────────

--- a/conductor-core/src/pr_review.rs
+++ b/conductor-core/src/pr_review.rs
@@ -369,7 +369,7 @@ pub fn build_remediation_prompt(swarm_result: &ReviewSwarmResult) -> String {
 }
 
 /// Truncate a string at a char boundary no greater than `max_bytes`.
-fn truncate_str(s: &str, max_bytes: usize) -> &str {
+pub(crate) fn truncate_str(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {
         return s;
     }


### PR DESCRIPTION
Replace unsafe byte-index slicing in agent.rs with truncate_str utility
that respects UTF-8 char boundaries, preventing panics when truncating
at multi-byte character boundaries.

- Expose truncate_str as pub(crate) for reuse
- Replace &result[..500] with truncate_str call in build_startup_context
- Add test for multi-byte char truncation in startup context

All 203 tests pass.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
