### PR TITLE
refactor: migrate rebase-and-fix-review skill to directory format

### DIFF
--- a/.claude/skills/rebase-and-fix-review/SKILL.md
+++ b/.claude/skills/rebase-and-fix-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: rebase-and-fix-review
+description: Rebase the current branch onto main and address all on-diff PR review comments.
+---
+
 # rebase-and-fix-review
 
 Rebase the current branch onto main, then address all on-diff PR review comments.


### PR DESCRIPTION
## Summary

- Converts `.claude/skills/rebase-and-fix-review.md` to `.claude/skills/rebase-and-fix-review/SKILL.md`
- Adds YAML frontmatter (`name` + `description`) to match the new Claude Code skill directory format
- Content is otherwise identical (94% rename per git)

## Test plan

- [x] Verify `/rebase-and-fix-review` skill still loads correctly in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)