### PR TITLE
fix: use agent_activity_len for ListState clamping in reload_agent_events

### DIFF
--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -585,7 +585,9 @@ impl App {
 
         // Clamp ListState selection to valid range after events reload.
         // ratatui also clamps during render, but we keep it tidy here.
-        let len = self.state.data.agent_events.len();
+        // Use agent_activity_len() (which includes run-separator rows) so the
+        // cursor isn't clamped below the last visual row when multiple runs exist.
+        let len = self.state.data.agent_activity_len();
         let cur = self.state.agent_list_state.borrow().selected();
         if let Some(idx) = cur {
             if len == 0 {


### PR DESCRIPTION
When multiple runs exist, the visual list includes run-separator header rows.
The ListState clamping was using agent_events.len() (raw event count) instead
of agent_activity_len() (visual row count including separators), causing the
cursor to jump up by N rows (number of run separators) on each background poll.

Fixes #194.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
