### PR TITLE
feat: extract StatusPulseBadge component to reduce JSX duplication

### DIFF
--- a/conductor-web/frontend/src/components/agents/AgentStatusDisplay.tsx
+++ b/conductor-web/frontend/src/components/agents/AgentStatusDisplay.tsx
@@ -1,5 +1,6 @@
 import type { AgentRun } from "../../api/types";
 import { isActiveRun, statusColors, statusLabels } from "../../utils/agentStats";
+import { StatusPulseBadge } from "../shared/StatusPulseBadge";
 import { TimeAgo } from "../shared/TimeAgo";
 import { ChildRunsList } from "./ChildRunsList";
 
@@ -83,12 +84,7 @@ export function AgentStatusDisplay({
           >
             {statusLabels[run.status] ?? run.status}
           </span>
-          {run.status === "running" && (
-            <span className="inline-block w-2 h-2 rounded-full bg-yellow-400 animate-pulse" />
-          )}
-          {run.status === "waiting_for_feedback" && (
-            <span className="inline-block w-2 h-2 rounded-full bg-purple-400 animate-pulse" />
-          )}
+          <StatusPulseBadge status={run.status} />
           {hasChildren && (
             <span className="inline-block px-2 py-0.5 text-xs font-medium rounded-full bg-indigo-100 text-indigo-700">
               {childRuns.length} child{childRuns.length !== 1 ? "ren" : ""}

--- a/conductor-web/frontend/src/components/agents/ChildRunsList.tsx
+++ b/conductor-web/frontend/src/components/agents/ChildRunsList.tsx
@@ -1,5 +1,6 @@
 import type { AgentRun } from "../../api/types";
 import { statusColors, statusLabels } from "../../utils/agentStats";
+import { StatusPulseBadge } from "../shared/StatusPulseBadge";
 import { TimeAgo } from "../shared/TimeAgo";
 
 function formatDuration(ms: number): string {
@@ -72,12 +73,7 @@ export function ChildRunsList({ children }: ChildRunsListProps) {
               >
                 {statusLabels[child.status] ?? child.status}
               </span>
-              {child.status === "running" && (
-                <span className="inline-block w-2 h-2 rounded-full bg-yellow-400 animate-pulse" />
-              )}
-              {child.status === "waiting_for_feedback" && (
-                <span className="inline-block w-2 h-2 rounded-full bg-purple-400 animate-pulse" />
-              )}
+              <StatusPulseBadge status={child.status} />
               <span className="text-gray-700 truncate flex-1" title={child.prompt}>
                 {extractStepLabel(child.prompt) ??
                   (child.prompt.length > 80

--- a/conductor-web/frontend/src/components/shared/StatusPulseBadge.tsx
+++ b/conductor-web/frontend/src/components/shared/StatusPulseBadge.tsx
@@ -1,0 +1,12 @@
+const pulseColors: Partial<Record<string, string>> = {
+  running: "bg-yellow-400",
+  waiting_for_feedback: "bg-purple-400",
+};
+
+export function StatusPulseBadge({ status }: { status: string }) {
+  const color = pulseColors[status];
+  if (!color) return null;
+  return (
+    <span className={`inline-block w-2 h-2 rounded-full ${color} animate-pulse`} />
+  );
+}


### PR DESCRIPTION
Create a shared StatusPulseBadge component in conductor-web/frontend/src/components/shared/
that renders the animated pulse dot for 'running' (yellow) and 'waiting_for_feedback' (purple)
statuses. Replace the duplicated pulse badge JSX in AgentStatusDisplay and ChildRunsList.

Closes #208
