### PR TITLE
feat: add composite index on feedback_requests(status, run_id)

### DIFF
--- a/conductor-core/src/db/migrations/018_feedback_requests.sql
+++ b/conductor-core/src/db/migrations/018_feedback_requests.sql
@@ -14,3 +14,4 @@ CREATE TABLE IF NOT EXISTS feedback_requests (
     responded_at TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_feedback_requests_run_id ON feedback_requests(run_id);
+CREATE INDEX IF NOT EXISTS idx_feedback_requests_status_run_id ON feedback_requests(status, run_id);


### PR DESCRIPTION
Adds index to support future bulk queries across all pending feedback
requests without full table scan (e.g. "show all waiting runs" dashboard).
Maintains existing run_id index for single-run lookups.

Resolves #207

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
