### PR TITLE
chore: add restart.sh for quick pull-build-launch workflow

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Pull latest main, rebuild, and launch the TUI.
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+echo "==> Pulling latest main..."
+cd "$REPO_ROOT"
+git pull
+
+echo "==> Building..."
+"$REPO_ROOT/build.sh"
+
+echo "==> Starting TUI..."
+cargo run --bin conductor-tui


### PR DESCRIPTION
## Summary
- Adds `restart.sh` script that runs `git pull`, `./build.sh`, and `cargo run --bin conductor-tui` in sequence
- Saves the manual close-pull-build-launch cycle when updating the TUI

## Test plan
- [ ] Run `./restart.sh` and verify it pulls, builds, and launches the TUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)