### PR TITLE
refactor: deduplicate setup_db() test helper across 6 modules

### DIFF
--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -1737,24 +1737,10 @@ fn row_to_plan_step(row: &rusqlite::Row) -> rusqlite::Result<PlanStep> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db;
     use rusqlite::Connection;
 
     fn setup_db() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
-        db::migrations::run(&conn).unwrap();
-        // Insert a repo and worktree for FK constraints
-        conn.execute(
-            "INSERT INTO repos (id, slug, local_path, remote_url, default_branch, workspace_dir, created_at) \
-             VALUES ('r1', 'test-repo', '/tmp/repo', 'https://github.com/test/repo.git', 'main', '/tmp/ws', '2024-01-01T00:00:00Z')",
-            [],
-        ).unwrap();
-        conn.execute(
-            "INSERT INTO worktrees (id, repo_id, slug, branch, path, status, created_at) \
-             VALUES ('w1', 'r1', 'feat-test', 'feat/test', '/tmp/ws/feat-test', 'active', '2024-01-01T00:00:00Z')",
-            [],
-        ).unwrap();
+        let conn = crate::test_helpers::setup_db();
         conn.execute(
             "INSERT INTO worktrees (id, repo_id, slug, branch, path, status, created_at) \
              VALUES ('w2', 'r1', 'fix-bug', 'fix/bug', '/tmp/ws/fix-bug', 'active', '2024-01-01T00:00:00Z')",

--- a/conductor-core/src/issue_source.rs
+++ b/conductor-core/src/issue_source.rs
@@ -112,28 +112,7 @@ mod tests {
     use rusqlite::Connection;
 
     fn setup_db() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch(
-            "CREATE TABLE repos (
-                id TEXT PRIMARY KEY,
-                slug TEXT NOT NULL UNIQUE,
-                local_path TEXT NOT NULL,
-                remote_url TEXT NOT NULL,
-                default_branch TEXT NOT NULL DEFAULT 'main',
-                workspace_dir TEXT NOT NULL,
-                created_at TEXT NOT NULL
-            );
-            CREATE TABLE repo_issue_sources (
-                id TEXT PRIMARY KEY,
-                repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
-                source_type TEXT NOT NULL CHECK (source_type IN ('github', 'jira')),
-                config_json TEXT NOT NULL
-            );
-            INSERT INTO repos (id, slug, local_path, remote_url, workspace_dir, created_at)
-            VALUES ('repo1', 'test-repo', '/tmp/repo', 'https://github.com/test/repo', '/tmp/ws', '2024-01-01T00:00:00Z');",
-        )
-        .unwrap();
-        conn
+        crate::test_helpers::setup_db()
     }
 
     #[test]
@@ -143,17 +122,17 @@ mod tests {
 
         let source = mgr
             .add(
-                "repo1",
+                "r1",
                 "github",
                 r#"{"owner":"test","repo":"repo"}"#,
                 "test-repo",
             )
             .unwrap();
 
-        assert_eq!(source.repo_id, "repo1");
+        assert_eq!(source.repo_id, "r1");
         assert_eq!(source.source_type, "github");
 
-        let sources = mgr.list("repo1").unwrap();
+        let sources = mgr.list("r1").unwrap();
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].source_type, "github");
     }
@@ -164,7 +143,7 @@ mod tests {
         let mgr = IssueSourceManager::new(&conn);
 
         mgr.add(
-            "repo1",
+            "r1",
             "github",
             r#"{"owner":"test","repo":"repo"}"#,
             "test-repo",
@@ -172,7 +151,7 @@ mod tests {
         .unwrap();
 
         let result = mgr.add(
-            "repo1",
+            "r1",
             "github",
             r#"{"owner":"other","repo":"other"}"#,
             "test-repo",
@@ -187,7 +166,7 @@ mod tests {
 
         let source = mgr
             .add(
-                "repo1",
+                "r1",
                 "github",
                 r#"{"owner":"test","repo":"repo"}"#,
                 "test-repo",
@@ -196,7 +175,7 @@ mod tests {
 
         mgr.remove(&source.id).unwrap();
 
-        let sources = mgr.list("repo1").unwrap();
+        let sources = mgr.list("r1").unwrap();
         assert!(sources.is_empty());
     }
 
@@ -206,21 +185,21 @@ mod tests {
         let mgr = IssueSourceManager::new(&conn);
 
         mgr.add(
-            "repo1",
+            "r1",
             "github",
             r#"{"owner":"test","repo":"repo"}"#,
             "test-repo",
         )
         .unwrap();
 
-        let removed = mgr.remove_by_type("repo1", "github").unwrap();
+        let removed = mgr.remove_by_type("r1", "github").unwrap();
         assert!(removed);
 
-        let sources = mgr.list("repo1").unwrap();
+        let sources = mgr.list("r1").unwrap();
         assert!(sources.is_empty());
 
         // Removing again returns false
-        let removed = mgr.remove_by_type("repo1", "github").unwrap();
+        let removed = mgr.remove_by_type("r1", "github").unwrap();
         assert!(!removed);
     }
 
@@ -229,7 +208,7 @@ mod tests {
         let conn = setup_db();
         let mgr = IssueSourceManager::new(&conn);
 
-        let sources = mgr.list("repo1").unwrap();
+        let sources = mgr.list("r1").unwrap();
         assert!(sources.is_empty());
     }
 
@@ -239,7 +218,7 @@ mod tests {
         let mgr = IssueSourceManager::new(&conn);
 
         mgr.add(
-            "repo1",
+            "r1",
             "github",
             r#"{"owner":"test","repo":"repo"}"#,
             "test-repo",
@@ -247,14 +226,14 @@ mod tests {
         .unwrap();
 
         mgr.add(
-            "repo1",
+            "r1",
             "jira",
             r#"{"jql":"project = TEST","url":"https://jira.example.com"}"#,
             "test-repo",
         )
         .unwrap();
 
-        let sources = mgr.list("repo1").unwrap();
+        let sources = mgr.list("r1").unwrap();
         assert_eq!(sources.len(), 2);
     }
 }

--- a/conductor-core/src/lib.rs
+++ b/conductor-core/src/lib.rs
@@ -21,3 +21,6 @@ pub mod workflow;
 pub mod workflow_config;
 pub mod workflow_dsl;
 pub mod worktree;
+
+#[cfg(test)]
+pub mod test_helpers;

--- a/conductor-core/src/orchestrator.rs
+++ b/conductor-core/src/orchestrator.rs
@@ -376,23 +376,9 @@ fn build_orchestration_summary(result: &OrchestrationResult) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db;
 
     fn setup_db() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
-        db::migrations::run(&conn).unwrap();
-        conn.execute(
-            "INSERT INTO repos (id, slug, local_path, remote_url, default_branch, workspace_dir, created_at) \
-             VALUES ('r1', 'test-repo', '/tmp/repo', 'https://github.com/test/repo.git', 'main', '/tmp/ws', '2024-01-01T00:00:00Z')",
-            [],
-        ).unwrap();
-        conn.execute(
-            "INSERT INTO worktrees (id, repo_id, slug, branch, path, status, created_at) \
-             VALUES ('w1', 'r1', 'feat-test', 'feat/test', '/tmp/ws/feat-test', 'active', '2024-01-01T00:00:00Z')",
-            [],
-        ).unwrap();
-        conn
+        crate::test_helpers::setup_db()
     }
 
     fn make_parent_run(prompt: &str) -> AgentRun {

--- a/conductor-core/src/pr_review.rs
+++ b/conductor-core/src/pr_review.rs
@@ -1249,26 +1249,9 @@ fn poll_reviewer_completion(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db;
-    use chrono::Utc;
-    use tempfile::NamedTempFile;
 
     fn setup_db() -> Connection {
-        let tmp = NamedTempFile::new().unwrap();
-        let conn = db::open_database(tmp.path()).unwrap();
-        let now = Utc::now().to_rfc3339();
-        conn.execute(
-            "INSERT INTO repos (id, slug, local_path, remote_url, default_branch, workspace_dir, created_at) \
-             VALUES ('r1', 'test-repo', '/tmp/repo', 'https://github.com/test/repo.git', 'main', '/tmp/ws', ?1)",
-            rusqlite::params![now],
-        ).unwrap();
-        conn.execute(
-            "INSERT INTO worktrees (id, repo_id, slug, branch, path, status, created_at) \
-             VALUES ('w1', 'r1', 'feat-test', 'feat/test', '/tmp/ws/feat-test', 'active', ?1)",
-            rusqlite::params![now],
-        )
-        .unwrap();
-        conn
+        crate::test_helpers::setup_db()
     }
 
     fn make_run(status: AgentRunStatus, result_text: Option<&str>) -> AgentRun {

--- a/conductor-core/src/test_helpers.rs
+++ b/conductor-core/src/test_helpers.rs
@@ -1,0 +1,25 @@
+use rusqlite::Connection;
+
+use crate::db;
+
+/// Opens an in-memory SQLite database with migrations applied and a test repo + worktree inserted.
+///
+/// Provides:
+/// - repo `r1` (slug `test-repo`)
+/// - worktree `w1` (slug `feat-test`, branch `feat/test`, status `active`)
+pub fn setup_db() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    db::migrations::run(&conn).unwrap();
+    conn.execute(
+        "INSERT INTO repos (id, slug, local_path, remote_url, default_branch, workspace_dir, created_at) \
+         VALUES ('r1', 'test-repo', '/tmp/repo', 'https://github.com/test/repo.git', 'main', '/tmp/ws', '2024-01-01T00:00:00Z')",
+        [],
+    ).unwrap();
+    conn.execute(
+        "INSERT INTO worktrees (id, repo_id, slug, branch, path, status, created_at) \
+         VALUES ('w1', 'r1', 'feat-test', 'feat/test', '/tmp/ws/feat-test', 'active', '2024-01-01T00:00:00Z')",
+        [],
+    ).unwrap();
+    conn
+}

--- a/conductor-core/src/tickets.rs
+++ b/conductor-core/src/tickets.rs
@@ -255,50 +255,7 @@ mod tests {
     use rusqlite::Connection;
 
     fn setup_db() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch(
-            "CREATE TABLE repos (
-                id TEXT PRIMARY KEY,
-                slug TEXT NOT NULL UNIQUE,
-                local_path TEXT NOT NULL,
-                remote_url TEXT NOT NULL,
-                default_branch TEXT NOT NULL DEFAULT 'main',
-                workspace_dir TEXT NOT NULL,
-                created_at TEXT NOT NULL
-            );
-            CREATE TABLE tickets (
-                id TEXT PRIMARY KEY,
-                repo_id TEXT NOT NULL REFERENCES repos(id),
-                source_type TEXT NOT NULL,
-                source_id TEXT NOT NULL,
-                title TEXT NOT NULL,
-                body TEXT NOT NULL DEFAULT '',
-                state TEXT NOT NULL DEFAULT 'open',
-                labels TEXT NOT NULL DEFAULT '[]',
-                assignee TEXT,
-                priority TEXT,
-                url TEXT NOT NULL DEFAULT '',
-                synced_at TEXT NOT NULL,
-                raw_json TEXT NOT NULL DEFAULT '{}',
-                UNIQUE(repo_id, source_type, source_id)
-            );
-            CREATE TABLE worktrees (
-                id TEXT PRIMARY KEY,
-                repo_id TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
-                slug TEXT NOT NULL,
-                branch TEXT NOT NULL,
-                path TEXT NOT NULL,
-                ticket_id TEXT REFERENCES tickets(id) ON DELETE SET NULL,
-                status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'merged', 'abandoned')),
-                created_at TEXT NOT NULL,
-                completed_at TEXT,
-                UNIQUE(repo_id, slug)
-            );
-            INSERT INTO repos (id, slug, local_path, remote_url, workspace_dir, created_at)
-            VALUES ('repo1', 'test-repo', '/tmp/repo', 'https://github.com/test/repo', '/tmp/ws', '2024-01-01T00:00:00Z');",
-        )
-        .unwrap();
-        conn
+        crate::test_helpers::setup_db()
     }
 
     fn make_ticket(source_id: &str, title: &str) -> TicketInput {
@@ -336,14 +293,14 @@ mod tests {
             make_ticket("2", "Issue 2"),
             make_ticket("3", "Issue 3"),
         ];
-        syncer.upsert_tickets("repo1", &tickets).unwrap();
+        syncer.upsert_tickets("r1", &tickets).unwrap();
 
         // Sync #2: only issues 1, 3 are open (issue 2 was closed on GitHub)
         let tickets2 = vec![make_ticket("1", "Issue 1"), make_ticket("3", "Issue 3")];
         let synced_ids: Vec<&str> = tickets2.iter().map(|t| t.source_id.as_str()).collect();
-        syncer.upsert_tickets("repo1", &tickets2).unwrap();
+        syncer.upsert_tickets("r1", &tickets2).unwrap();
         let closed = syncer
-            .close_missing_tickets("repo1", "github", &synced_ids)
+            .close_missing_tickets("r1", "github", &synced_ids)
             .unwrap();
 
         assert_eq!(closed, 1);
@@ -359,18 +316,18 @@ mod tests {
 
         // Sync #1: issues 1, 2 are open
         let tickets = vec![make_ticket("1", "Issue 1"), make_ticket("2", "Issue 2")];
-        syncer.upsert_tickets("repo1", &tickets).unwrap();
+        syncer.upsert_tickets("r1", &tickets).unwrap();
 
         // Sync #2: only issue 1 open → issue 2 closed
         let synced_ids = vec!["1"];
         syncer
-            .close_missing_tickets("repo1", "github", &synced_ids)
+            .close_missing_tickets("r1", "github", &synced_ids)
             .unwrap();
         assert_eq!(get_ticket_state(&conn, "2"), "closed");
 
         // Sync #3: still only issue 1 open → issue 2 already closed, count should be 0
         let closed = syncer
-            .close_missing_tickets("repo1", "github", &synced_ids)
+            .close_missing_tickets("r1", "github", &synced_ids)
             .unwrap();
         assert_eq!(closed, 0);
     }
@@ -382,12 +339,10 @@ mod tests {
 
         // Sync existing tickets
         let tickets = vec![make_ticket("1", "Issue 1")];
-        syncer.upsert_tickets("repo1", &tickets).unwrap();
+        syncer.upsert_tickets("r1", &tickets).unwrap();
 
         // Empty sync should not close anything (protects against API failures)
-        let closed = syncer
-            .close_missing_tickets("repo1", "github", &[])
-            .unwrap();
+        let closed = syncer.close_missing_tickets("r1", "github", &[]).unwrap();
         assert_eq!(closed, 0);
         assert_eq!(get_ticket_state(&conn, "1"), "open");
     }
@@ -408,19 +363,19 @@ mod tests {
         // Both repos have issue #1
         let tickets1 = vec![make_ticket("1", "Repo1 Issue")];
         let tickets2 = vec![make_ticket("1", "Repo2 Issue")];
-        syncer.upsert_tickets("repo1", &tickets1).unwrap();
+        syncer.upsert_tickets("r1", &tickets1).unwrap();
         syncer.upsert_tickets("repo2", &tickets2).unwrap();
 
         // Sync repo1 with no open issues → only repo1's ticket should close
         let closed = syncer
-            .close_missing_tickets("repo1", "github", &["999"])
+            .close_missing_tickets("r1", "github", &["999"])
             .unwrap();
         assert_eq!(closed, 1);
 
         // repo1's ticket should be closed
         let repo1_state: String = conn
             .query_row(
-                "SELECT state FROM tickets WHERE repo_id = 'repo1' AND source_id = '1'",
+                "SELECT state FROM tickets WHERE repo_id = 'r1' AND source_id = '1'",
                 [],
                 |row| row.get(0),
             )
@@ -477,19 +432,19 @@ mod tests {
         let syncer = TicketSyncer::new(&conn);
 
         let tickets = vec![make_ticket("1", "Issue 1")];
-        syncer.upsert_tickets("repo1", &tickets).unwrap();
+        syncer.upsert_tickets("r1", &tickets).unwrap();
         let ticket_id: String = conn
             .query_row("SELECT id FROM tickets WHERE source_id = '1'", [], |row| {
                 row.get(0)
             })
             .unwrap();
-        insert_worktree(&conn, "wt1", "repo1", Some(&ticket_id), "active");
+        insert_worktree(&conn, "wt1", "r1", Some(&ticket_id), "active");
 
         syncer
-            .close_missing_tickets("repo1", "github", &["999"])
+            .close_missing_tickets("r1", "github", &["999"])
             .unwrap();
 
-        let count = syncer.mark_worktrees_for_closed_tickets("repo1").unwrap();
+        let count = syncer.mark_worktrees_for_closed_tickets("r1").unwrap();
         assert_eq!(count, 1);
         assert_eq!(get_worktree_status(&conn, "wt1"), "merged");
     }
@@ -500,18 +455,18 @@ mod tests {
         let syncer = TicketSyncer::new(&conn);
 
         let tickets = vec![make_ticket("1", "Issue 1")];
-        syncer.upsert_tickets("repo1", &tickets).unwrap();
+        syncer.upsert_tickets("r1", &tickets).unwrap();
         let ticket_id: String = conn
             .query_row("SELECT id FROM tickets WHERE source_id = '1'", [], |row| {
                 row.get(0)
             })
             .unwrap();
-        insert_worktree(&conn, "wt1", "repo1", Some(&ticket_id), "abandoned");
+        insert_worktree(&conn, "wt1", "r1", Some(&ticket_id), "abandoned");
         syncer
-            .close_missing_tickets("repo1", "github", &["999"])
+            .close_missing_tickets("r1", "github", &["999"])
             .unwrap();
 
-        let count = syncer.mark_worktrees_for_closed_tickets("repo1").unwrap();
+        let count = syncer.mark_worktrees_for_closed_tickets("r1").unwrap();
         assert_eq!(count, 1);
         assert_eq!(get_worktree_status(&conn, "wt1"), "merged");
     }
@@ -521,9 +476,9 @@ mod tests {
         let conn = setup_db();
         let syncer = TicketSyncer::new(&conn);
 
-        insert_worktree(&conn, "wt1", "repo1", None, "active");
+        insert_worktree(&conn, "wt1", "r1", None, "active");
 
-        let count = syncer.mark_worktrees_for_closed_tickets("repo1").unwrap();
+        let count = syncer.mark_worktrees_for_closed_tickets("r1").unwrap();
         assert_eq!(count, 0);
         assert_eq!(get_worktree_status(&conn, "wt1"), "active");
     }
@@ -534,18 +489,18 @@ mod tests {
         let syncer = TicketSyncer::new(&conn);
 
         let tickets = vec![make_ticket("1", "Issue 1")];
-        syncer.upsert_tickets("repo1", &tickets).unwrap();
+        syncer.upsert_tickets("r1", &tickets).unwrap();
         let ticket_id: String = conn
             .query_row("SELECT id FROM tickets WHERE source_id = '1'", [], |row| {
                 row.get(0)
             })
             .unwrap();
-        insert_worktree(&conn, "wt1", "repo1", Some(&ticket_id), "merged");
+        insert_worktree(&conn, "wt1", "r1", Some(&ticket_id), "merged");
         syncer
-            .close_missing_tickets("repo1", "github", &["999"])
+            .close_missing_tickets("r1", "github", &["999"])
             .unwrap();
 
-        let count = syncer.mark_worktrees_for_closed_tickets("repo1").unwrap();
+        let count = syncer.mark_worktrees_for_closed_tickets("r1").unwrap();
         assert_eq!(count, 0);
     }
 
@@ -563,15 +518,13 @@ mod tests {
 
         let t1 = vec![make_ticket("1", "Repo1 Issue")];
         let t2 = vec![make_ticket("1", "Repo2 Issue")];
-        syncer.upsert_tickets("repo1", &t1).unwrap();
+        syncer.upsert_tickets("r1", &t1).unwrap();
         syncer.upsert_tickets("repo2", &t2).unwrap();
 
         let tid1: String = conn
-            .query_row(
-                "SELECT id FROM tickets WHERE repo_id = 'repo1'",
-                [],
-                |row| row.get(0),
-            )
+            .query_row("SELECT id FROM tickets WHERE repo_id = 'r1'", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         let tid2: String = conn
             .query_row(
@@ -580,17 +533,17 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        insert_worktree(&conn, "wt1", "repo1", Some(&tid1), "active");
+        insert_worktree(&conn, "wt1", "r1", Some(&tid1), "active");
         insert_worktree(&conn, "wt2", "repo2", Some(&tid2), "active");
 
         syncer
-            .close_missing_tickets("repo1", "github", &["999"])
+            .close_missing_tickets("r1", "github", &["999"])
             .unwrap();
         syncer
             .close_missing_tickets("repo2", "github", &["999"])
             .unwrap();
 
-        let count = syncer.mark_worktrees_for_closed_tickets("repo1").unwrap();
+        let count = syncer.mark_worktrees_for_closed_tickets("r1").unwrap();
         assert_eq!(count, 1);
         assert_eq!(get_worktree_status(&conn, "wt1"), "merged");
         assert_eq!(get_worktree_status(&conn, "wt2"), "active");
@@ -601,13 +554,13 @@ mod tests {
         let conn = setup_db();
         let syncer = TicketSyncer::new(&conn);
         let tickets = vec![make_ticket("1", "Issue 1")];
-        syncer.upsert_tickets("repo1", &tickets).unwrap();
+        syncer.upsert_tickets("r1", &tickets).unwrap();
         let ticket_id: String = conn
             .query_row("SELECT id FROM tickets WHERE source_id = '1'", [], |row| {
                 row.get(0)
             })
             .unwrap();
-        insert_worktree(&conn, "wt1", "repo1", None, "active");
+        insert_worktree(&conn, "wt1", "r1", None, "active");
 
         syncer.link_to_worktree(&ticket_id, "wt1").unwrap();
 
@@ -626,7 +579,7 @@ mod tests {
         let conn = setup_db();
         let syncer = TicketSyncer::new(&conn);
         let tickets = vec![make_ticket("1", "Issue 1"), make_ticket("2", "Issue 2")];
-        syncer.upsert_tickets("repo1", &tickets).unwrap();
+        syncer.upsert_tickets("r1", &tickets).unwrap();
         let tid1: String = conn
             .query_row("SELECT id FROM tickets WHERE source_id = '1'", [], |row| {
                 row.get(0)
@@ -637,7 +590,7 @@ mod tests {
                 row.get(0)
             })
             .unwrap();
-        insert_worktree(&conn, "wt1", "repo1", Some(&tid1), "active");
+        insert_worktree(&conn, "wt1", "r1", Some(&tid1), "active");
 
         let result = syncer.link_to_worktree(&tid2, "wt1");
         assert!(result.is_err());
@@ -652,7 +605,7 @@ mod tests {
         let conn = setup_db();
         let syncer = TicketSyncer::new(&conn);
         let tickets = vec![make_ticket("1", "Issue 1")];
-        syncer.upsert_tickets("repo1", &tickets).unwrap();
+        syncer.upsert_tickets("r1", &tickets).unwrap();
 
         let ticket_id: String = conn
             .query_row("SELECT id FROM tickets WHERE source_id = '1'", [], |row| {
@@ -677,7 +630,7 @@ mod tests {
     fn test_build_agent_prompt_full_ticket() {
         let ticket = Ticket {
             id: "01ABCDEF".to_string(),
-            repo_id: "repo1".to_string(),
+            repo_id: "r1".to_string(),
             source_type: "github".to_string(),
             source_id: "42".to_string(),
             title: "Add dark mode support".to_string(),
@@ -703,7 +656,7 @@ mod tests {
     fn test_build_agent_prompt_empty_body_and_labels() {
         let ticket = Ticket {
             id: "01ABCDEF".to_string(),
-            repo_id: "repo1".to_string(),
+            repo_id: "r1".to_string(),
             source_type: "github".to_string(),
             source_id: "7".to_string(),
             title: "Fix typo".to_string(),

--- a/conductor-core/src/workflow.rs
+++ b/conductor-core/src/workflow.rs
@@ -1941,23 +1941,9 @@ fn sanitize_tmux_name(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db;
 
     fn setup_db() -> Connection {
-        let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
-        db::migrations::run(&conn).unwrap();
-        conn.execute(
-            "INSERT INTO repos (id, slug, local_path, remote_url, default_branch, workspace_dir, created_at) \
-             VALUES ('r1', 'test-repo', '/tmp/repo', 'https://github.com/test/repo.git', 'main', '/tmp/ws', '2024-01-01T00:00:00Z')",
-            [],
-        ).unwrap();
-        conn.execute(
-            "INSERT INTO worktrees (id, repo_id, slug, branch, path, status, created_at) \
-             VALUES ('w1', 'r1', 'feat-test', 'feat/test', '/tmp/ws/feat-test', 'active', '2024-01-01T00:00:00Z')",
-            [],
-        ).unwrap();
-        conn
+        crate::test_helpers::setup_db()
     }
 
     #[test]


### PR DESCRIPTION
Extract the duplicated ~15-line setup_db() function (open in-memory DB, run migrations,
insert test repo+worktree) into a shared test_helpers module. Replaces copy-pasted code
in orchestrator, agent, workflow, issue_source, pr_review, and tickets modules.

Updates tickets.rs and issue_source.rs to use the shared helper schema instead of
manually creating tables, and normalizes repo ID from 'repo1' to 'r1' for consistency.

Closes #258.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
