### PR TITLE
refactor: deduplicate default_role() from workflow_config to agent_config

### DIFF
--- a/conductor-core/src/agent_config.rs
+++ b/conductor-core/src/agent_config.rs
@@ -26,7 +26,7 @@ struct AgentFrontmatter {
     model: Option<String>,
 }
 
-fn default_role() -> String {
+pub fn default_role() -> String {
     "reviewer".to_string()
 }
 

--- a/conductor-core/src/workflow_config.rs
+++ b/conductor-core/src/workflow_config.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use crate::agent_config::AgentRole;
+use crate::agent_config::{default_role, AgentRole};
 use crate::error::{ConductorError, Result};
 use crate::text_util::parse_frontmatter;
 use crate::workflow_dsl::WorkflowTrigger;
@@ -50,10 +50,6 @@ struct StepFrontmatter {
     /// Model override for this step.
     #[serde(default)]
     model: Option<String>,
-}
-
-fn default_role() -> String {
-    "reviewer".to_string()
 }
 
 /// Re-export `AgentRole` as `WorkflowRole` for backward compatibility.


### PR DESCRIPTION
Move the default_role() function from workflow_config.rs to agent_config.rs
and make it public. workflow_config.rs now imports and reuses it, eliminating
the duplicate function definition. This fixes issue #255.

All 28 tests pass.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
