### PR TITLE
refactor: add total_nodes() method to WorkflowDef

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -19,9 +19,7 @@ use conductor_core::post_run::{self, PostRunInput};
 use conductor_core::pr_review::{self, ReviewSwarmConfig, ReviewSwarmInput};
 use conductor_core::repo::{derive_local_path, derive_slug_from_url, RepoManager};
 use conductor_core::tickets::{build_agent_prompt, TicketSyncer};
-use conductor_core::workflow::{
-    collect_agent_names, count_nodes, WorkflowExecConfig, WorkflowManager,
-};
+use conductor_core::workflow::{collect_agent_names, WorkflowExecConfig, WorkflowManager};
 use conductor_core::workflow_config;
 use conductor_core::worktree::WorktreeManager;
 
@@ -1245,7 +1243,7 @@ fn main() -> Result<()> {
                 let wf_defs = WorkflowManager::list_defs(&wt.path, &r.local_path)?;
                 if !wf_defs.is_empty() {
                     for def in &wf_defs {
-                        let node_count = count_nodes(&def.body) + count_nodes(&def.always);
+                        let node_count = def.total_nodes();
                         println!(
                             "  {:<20} {:<40} [{}, {} nodes]",
                             def.name, def.description, def.trigger, node_count
@@ -1327,7 +1325,7 @@ fn main() -> Result<()> {
                     ..Default::default()
                 };
 
-                let node_count = count_nodes(&workflow.body) + count_nodes(&workflow.always);
+                let node_count = workflow.total_nodes();
                 println!(
                     "Running workflow '{}' ({} nodes) on {}/{}...",
                     workflow.name, node_count, repo, worktree
@@ -1471,7 +1469,7 @@ fn main() -> Result<()> {
                 println!("Workflow: {}", workflow.name);
                 println!("  Description: {}", workflow.description);
                 println!("  Trigger: {}", workflow.trigger);
-                let node_count = count_nodes(&workflow.body) + count_nodes(&workflow.always);
+                let node_count = workflow.total_nodes();
                 println!("  Nodes: {node_count}");
                 println!("  Agents referenced: {}", all_names.len());
 

--- a/conductor-core/src/workflow.rs
+++ b/conductor-core/src/workflow.rs
@@ -25,7 +25,7 @@ use crate::workflow_dsl::{
 };
 
 // Re-export DSL types so consumers go through `workflow::` instead of `workflow_dsl::` directly.
-pub use crate::workflow_dsl::{collect_agent_names, count_nodes, InputDecl, WorkflowDef};
+pub use crate::workflow_dsl::{collect_agent_names, InputDecl, WorkflowDef};
 use crate::worktree::WorktreeManager;
 
 // ---------------------------------------------------------------------------

--- a/conductor-core/src/workflow_dsl.rs
+++ b/conductor-core/src/workflow_dsl.rs
@@ -44,6 +44,13 @@ pub struct WorkflowDef {
     pub source_path: String,
 }
 
+impl WorkflowDef {
+    /// Total number of nodes across body and always blocks.
+    pub fn total_nodes(&self) -> usize {
+        count_nodes(&self.body) + count_nodes(&self.always)
+    }
+}
+
 /// Trigger type for when a workflow should run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -881,8 +888,8 @@ pub fn load_workflow_by_name(
     })
 }
 
-/// Count the total number of nodes in a workflow (for display).
-pub fn count_nodes(nodes: &[WorkflowNode]) -> usize {
+/// Count the total number of nodes in a node list (for display).
+fn count_nodes(nodes: &[WorkflowNode]) -> usize {
     let mut count = 0;
     for node in nodes {
         count += 1;
@@ -1187,6 +1194,8 @@ workflow ticket-to-pr {
         let body_count = count_nodes(&def.body);
         // 9 top-level + 3 in while + 3 in parallel + 1 in if = 16
         assert_eq!(body_count, 16);
+        // total_nodes covers body + always
+        assert_eq!(def.total_nodes(), body_count + count_nodes(&def.always));
     }
 
     #[test]


### PR DESCRIPTION
Extract the pattern of counting nodes in both body and always blocks
into a dedicated WorkflowDef::total_nodes() method. This simplifies
call sites and provides a more intuitive public API.

Changes:
- Add total_nodes() method to WorkflowDef impl block
- Make count_nodes() private (internal helper)
- Remove count_nodes from public re-exports
- Replace all 3 call sites in CLI with def.total_nodes()
- Extend test_count_nodes to verify the new method

Closes #280
