### PR TITLE
fix: validate workflow names to prevent path traversal (#279)

### DIFF
--- a/conductor-core/src/workflow_config.rs
+++ b/conductor-core/src/workflow_config.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 use crate::agent_config::{default_role, AgentRole};
 use crate::error::{ConductorError, Result};
 use crate::text_util::parse_frontmatter;
-use crate::workflow_dsl::WorkflowTrigger;
+use crate::workflow_dsl::{validate_workflow_name, WorkflowTrigger};
 
 /// YAML frontmatter for a workflow `.md` file.
 #[derive(Debug, Clone, Deserialize)]
@@ -255,6 +255,7 @@ pub fn load_workflow_by_name(
     repo_path: &str,
     name: &str,
 ) -> Result<WorkflowDef> {
+    validate_workflow_name(name)?;
     let defs = load_workflow_defs(worktree_path, repo_path)?;
     defs.into_iter().find(|d| d.name == name).ok_or_else(|| {
         ConductorError::Workflow(format!(
@@ -482,6 +483,21 @@ and commit them to the branch.
         assert!(result.is_err());
         let err = format!("{}", result.unwrap_err());
         assert!(err.contains("not found"));
+    }
+
+    #[test]
+    fn test_load_workflow_by_name_rejects_path_traversal() {
+        let tmp = TempDir::new().unwrap();
+        let repo = TempDir::new().unwrap();
+
+        let result = load_workflow_by_name(
+            tmp.path().to_str().unwrap(),
+            repo.path().to_str().unwrap(),
+            "../etc/passwd",
+        );
+        assert!(result.is_err());
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("Invalid workflow name"));
     }
 
     #[test]

--- a/conductor-core/src/workflow_dsl.rs
+++ b/conductor-core/src/workflow_dsl.rs
@@ -867,18 +867,35 @@ pub fn load_workflow_defs(worktree_path: &str, repo_path: &str) -> Result<Vec<Wo
     Ok(defs)
 }
 
+/// Validate that a workflow name is safe for use in filesystem paths.
+///
+/// Only alphanumeric characters, hyphens, underscores, and dots (but not `..`)
+/// are allowed. This prevents path traversal when names are used to construct
+/// file paths.
+pub fn validate_workflow_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(ConductorError::Workflow(
+            "Workflow name must not be empty".to_string(),
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(ConductorError::Workflow(format!(
+            "Invalid workflow name '{name}': only alphanumeric characters, hyphens, and underscores are allowed"
+        )));
+    }
+    Ok(())
+}
+
 /// Load a single workflow definition by name.
 pub fn load_workflow_by_name(
     worktree_path: &str,
     repo_path: &str,
     name: &str,
 ) -> Result<WorkflowDef> {
-    // Reject names with path separators or traversal sequences as defense-in-depth.
-    if name.contains('/') || name.contains('\\') || name.contains("..") || name.is_empty() {
-        return Err(ConductorError::Workflow(format!(
-            "Invalid workflow name: '{name}'"
-        )));
-    }
+    validate_workflow_name(name)?;
 
     let defs = load_workflow_defs(worktree_path, repo_path)?;
     defs.into_iter().find(|d| d.name == name).ok_or_else(|| {
@@ -1334,5 +1351,47 @@ workflow lint-fix {
             WorkflowNode::Call(c) => assert_eq!(c.agent, "analyze-lint"),
             _ => panic!("Expected Call node"),
         }
+    }
+
+    #[test]
+    fn test_validate_workflow_name_valid() {
+        assert!(validate_workflow_name("ticket-to-pr").is_ok());
+        assert!(validate_workflow_name("test_coverage").is_ok());
+        assert!(validate_workflow_name("simple").is_ok());
+        assert!(validate_workflow_name("A-Z_0-9").is_ok());
+    }
+
+    #[test]
+    fn test_validate_workflow_name_empty() {
+        assert!(validate_workflow_name("").is_err());
+    }
+
+    #[test]
+    fn test_validate_workflow_name_path_traversal() {
+        assert!(validate_workflow_name("..").is_err());
+        assert!(validate_workflow_name("../etc/passwd").is_err());
+        assert!(validate_workflow_name("foo/bar").is_err());
+        assert!(validate_workflow_name("foo\\bar").is_err());
+    }
+
+    #[test]
+    fn test_validate_workflow_name_special_chars() {
+        assert!(validate_workflow_name("name with spaces").is_err());
+        assert!(validate_workflow_name("name.wf").is_err());
+        assert!(validate_workflow_name("name;rm -rf").is_err());
+        assert!(validate_workflow_name("name\0null").is_err());
+    }
+
+    #[test]
+    fn test_load_workflow_by_name_rejects_invalid() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let result = load_workflow_by_name(
+            tmp.path().to_str().unwrap(),
+            "/nonexistent",
+            "../etc/passwd",
+        );
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Invalid workflow name"));
     }
 }


### PR DESCRIPTION
Add validate_workflow_name() function to enforce that workflow names
contain only alphanumeric characters, hyphens, and underscores. This
prevents path traversal attacks when names are used in filesystem paths.

Apply validation in both workflow_dsl.rs and workflow_config.rs entry
points. Add comprehensive tests covering valid names, empty names,
path traversal sequences, and special characters.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
