### PR TITLE
refactor: remove duplicate load_workflow_by_name from workflow_config

### DIFF
--- a/conductor-core/src/workflow_config.rs
+++ b/conductor-core/src/workflow_config.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 use crate::agent_config::{default_role, AgentRole};
 use crate::error::{ConductorError, Result};
 use crate::text_util::parse_frontmatter;
-use crate::workflow_dsl::{validate_workflow_name, WorkflowTrigger};
+use crate::workflow_dsl::WorkflowTrigger;
 
 /// YAML frontmatter for a workflow `.md` file.
 #[derive(Debug, Clone, Deserialize)]
@@ -249,21 +249,6 @@ pub fn load_workflow_defs(worktree_path: &str, repo_path: &str) -> Result<Vec<Wo
     Ok(defs)
 }
 
-/// Load a single workflow definition by name.
-pub fn load_workflow_by_name(
-    worktree_path: &str,
-    repo_path: &str,
-    name: &str,
-) -> Result<WorkflowDef> {
-    validate_workflow_name(name)?;
-    let defs = load_workflow_defs(worktree_path, repo_path)?;
-    defs.into_iter().find(|d| d.name == name).ok_or_else(|| {
-        ConductorError::Workflow(format!(
-            "Workflow '{name}' not found in .conductor/workflows/"
-        ))
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -453,51 +438,6 @@ and commit them to the branch.
         )
         .unwrap();
         assert!(defs.is_empty());
-    }
-
-    #[test]
-    fn test_load_workflow_by_name() {
-        let tmp = TempDir::new().unwrap();
-        let repo = TempDir::new().unwrap();
-        write_workflow_file(tmp.path(), "test-coverage.md", TEST_WORKFLOW);
-
-        let def = load_workflow_by_name(
-            tmp.path().to_str().unwrap(),
-            repo.path().to_str().unwrap(),
-            "test-coverage",
-        )
-        .unwrap();
-        assert_eq!(def.name, "test-coverage");
-    }
-
-    #[test]
-    fn test_load_workflow_by_name_not_found() {
-        let tmp = TempDir::new().unwrap();
-        let repo = TempDir::new().unwrap();
-
-        let result = load_workflow_by_name(
-            tmp.path().to_str().unwrap(),
-            repo.path().to_str().unwrap(),
-            "nonexistent",
-        );
-        assert!(result.is_err());
-        let err = format!("{}", result.unwrap_err());
-        assert!(err.contains("not found"));
-    }
-
-    #[test]
-    fn test_load_workflow_by_name_rejects_path_traversal() {
-        let tmp = TempDir::new().unwrap();
-        let repo = TempDir::new().unwrap();
-
-        let result = load_workflow_by_name(
-            tmp.path().to_str().unwrap(),
-            repo.path().to_str().unwrap(),
-            "../etc/passwd",
-        );
-        assert!(result.is_err());
-        let err = format!("{}", result.unwrap_err());
-        assert!(err.contains("Invalid workflow name"));
     }
 
     #[test]

--- a/conductor-core/src/workflow_dsl.rs
+++ b/conductor-core/src/workflow_dsl.rs
@@ -1383,6 +1383,32 @@ workflow lint-fix {
     }
 
     #[test]
+    fn test_load_workflow_by_name() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let wf_dir = tmp.path().join(".conductor").join("workflows");
+        fs::create_dir_all(&wf_dir).unwrap();
+        fs::write(wf_dir.join("deploy.wf"), "workflow deploy { call build }").unwrap();
+
+        let def =
+            load_workflow_by_name(tmp.path().to_str().unwrap(), "/nonexistent", "deploy").unwrap();
+        assert_eq!(def.name, "deploy");
+    }
+
+    #[test]
+    fn test_load_workflow_by_name_not_found() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let wf_dir = tmp.path().join(".conductor").join("workflows");
+        fs::create_dir_all(&wf_dir).unwrap();
+        fs::write(wf_dir.join("deploy.wf"), "workflow deploy { call build }").unwrap();
+
+        let result =
+            load_workflow_by_name(tmp.path().to_str().unwrap(), "/nonexistent", "nonexistent");
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("not found"));
+    }
+
+    #[test]
     fn test_load_workflow_by_name_rejects_invalid() {
         let tmp = tempfile::TempDir::new().unwrap();
         let result = load_workflow_by_name(


### PR DESCRIPTION
The workflow_config::load_workflow_by_name duplicated the exact same
validate → load-all → find-by-name pattern as workflow_dsl::load_workflow_by_name.
Since workflow_config operates on the legacy .md format and workflow_dsl on the
current .wf format, both functions serve their respective domains, but the
workflow_config version was dead code (only used in its own tests).

Remove the duplicate from workflow_config and consolidate its test coverage in
workflow_dsl, adding happy-path and not-found tests to ensure the sole
load_workflow_by_name function has complete coverage.

Fixes #297

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
