### PR TITLE
refactor: consolidate tmux window liveness check into single function

### DIFF
--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -1563,7 +1563,7 @@ impl<'a> AgentManager<'a> {
 ///
 /// Calls `tmux list-windows -a` once and returns the set of window names.
 /// Returns an empty set if tmux is not running or the command fails.
-fn list_live_tmux_windows() -> std::collections::HashSet<String> {
+pub(crate) fn list_live_tmux_windows() -> std::collections::HashSet<String> {
     let Ok(output) = Command::new("tmux")
         .args(["list-windows", "-a", "-F", "#{window_name}"])
         .output()

--- a/conductor-core/src/agent_runtime.rs
+++ b/conductor-core/src/agent_runtime.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use rusqlite::Connection;
 
-use crate::agent::{AgentManager, AgentRun, AgentRunStatus};
+use crate::agent::{list_live_tmux_windows, AgentManager, AgentRun, AgentRunStatus};
 
 /// Resolve the path to the `conductor` binary.
 ///
@@ -65,17 +65,8 @@ fn verify_tmux_window(window_name: &str) -> std::result::Result<(), String> {
     // Give tmux a moment to register the window.
     thread::sleep(Duration::from_millis(100));
 
-    let output = Command::new("tmux")
-        .args(["list-windows", "-a", "-F", "#{window_name}"])
-        .output()
-        .map_err(|e| format!("Failed to list tmux windows: {e}"))?;
-
-    if !output.status.success() {
-        return Err("tmux list-windows failed — tmux may not be running".to_string());
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    if stdout.lines().any(|line| line.trim() == window_name) {
+    let live = list_live_tmux_windows();
+    if live.contains(window_name) {
         Ok(())
     } else {
         Err(format!(


### PR DESCRIPTION
Move the tmux list-windows logic from verify_tmux_window() into
list_live_tmux_windows() to create a single source of truth for the
tmux window existence check. Both the orphan reaper and post-spawn
verification now use the shared function, eliminating code duplication.

Resolves #301.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
