### PR TITLE
refactor: make workflow_dsl module crate-internal, re-export types through workflow

### DIFF
--- a/conductor-core/src/lib.rs
+++ b/conductor-core/src/lib.rs
@@ -19,7 +19,7 @@ pub mod text_util;
 pub mod tickets;
 pub mod workflow;
 pub mod workflow_config;
-pub mod workflow_dsl;
+pub(crate) mod workflow_dsl;
 pub mod worktree;
 
 #[cfg(test)]

--- a/conductor-core/src/workflow.rs
+++ b/conductor-core/src/workflow.rs
@@ -25,7 +25,7 @@ use crate::workflow_dsl::{
 };
 
 // Re-export DSL types so consumers go through `workflow::` instead of `workflow_dsl::` directly.
-pub use crate::workflow_dsl::{collect_agent_names, InputDecl, WorkflowDef};
+pub use crate::workflow_dsl::{collect_agent_names, InputDecl, WorkflowDef, WorkflowTrigger};
 use crate::worktree::WorktreeManager;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Make workflow_dsl pub(crate) to prevent direct imports of internal module structure.
Re-export WorkflowDef, WorkflowTrigger, InputDecl, and collect_agent_names from the
workflow module, allowing the internal DSL module to evolve without breaking downstream
consumers (CLI, TUI, web).

Fixes #278

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
