### PR TITLE
perf: use prepare_cached for repeated queries

### DIFF
--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -1025,7 +1025,7 @@ impl<'a> AgentManager<'a> {
     /// Returns aggregated agent stats per ticket (across all linked worktrees).
     /// Only includes completed runs with recorded metrics.
     pub fn totals_by_ticket_all(&self) -> Result<HashMap<String, TicketAgentTotals>> {
-        let mut stmt = self.conn.prepare(
+        let mut stmt = self.conn.prepare_cached(
             "SELECT w.ticket_id, \
                     COUNT(*) AS total_runs, \
                     COALESCE(SUM(a.cost_usd), 0.0) AS total_cost, \
@@ -1287,7 +1287,7 @@ impl<'a> AgentManager<'a> {
     pub fn worktree_cost_phases(&self, worktree_id: &str) -> Result<Vec<CostPhase>> {
         // Single recursive-CTE query: find all root runs and aggregate each
         // tree's cost/duration in one round-trip instead of 1+N queries.
-        let mut stmt = self.conn.prepare(
+        let mut stmt = self.conn.prepare_cached(
             "WITH RECURSIVE tree(root_id, node_id) AS ( \
                  SELECT id, id \
                  FROM agent_runs \

--- a/conductor-core/src/db/mod.rs
+++ b/conductor-core/src/db/mod.rs
@@ -21,7 +21,7 @@ where
     P: rusqlite::Params,
     F: FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
 {
-    let mut stmt = conn.prepare(sql)?;
+    let mut stmt = conn.prepare_cached(sql)?;
     let rows = stmt.query_map(params, f)?;
     Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
 }

--- a/conductor-core/src/merge_queue.rs
+++ b/conductor-core/src/merge_queue.rs
@@ -128,7 +128,7 @@ impl<'a> MergeQueueManager<'a> {
 
     /// Get a single entry by ID.
     pub fn get(&self, entry_id: &str) -> Result<Option<MergeQueueEntry>> {
-        let mut stmt = self.conn.prepare(
+        let mut stmt = self.conn.prepare_cached(
             "SELECT id, repo_id, worktree_id, run_id, target_branch, position, status,
                     queued_at, started_at, completed_at
              FROM merge_queue
@@ -182,7 +182,7 @@ impl<'a> MergeQueueManager<'a> {
         }
 
         // Return the entry we just updated.
-        let mut stmt = self.conn.prepare(
+        let mut stmt = self.conn.prepare_cached(
             "SELECT id, repo_id, worktree_id, run_id, target_branch, position, status,
                     queued_at, started_at, completed_at
              FROM merge_queue
@@ -238,7 +238,7 @@ impl<'a> MergeQueueManager<'a> {
 
     /// Get the count of entries by status for a repo.
     pub fn queue_stats(&self, repo_id: &str) -> Result<QueueStats> {
-        let mut stmt = self.conn.prepare(
+        let mut stmt = self.conn.prepare_cached(
             "SELECT status, COUNT(*) FROM merge_queue WHERE repo_id = ?1 GROUP BY status",
         )?;
         let mut stats = QueueStats::default();

--- a/conductor-core/src/tickets.rs
+++ b/conductor-core/src/tickets.rs
@@ -139,7 +139,7 @@ impl<'a> TicketSyncer<'a> {
             }
         };
 
-        let mut stmt = self.conn.prepare(query)?;
+        let mut stmt = self.conn.prepare_cached(query)?;
         let rows = if let Some(rid) = repo_id {
             stmt.query_map(params![rid], map_ticket_row)?
         } else {

--- a/conductor-core/src/workflow.rs
+++ b/conductor-core/src/workflow.rs
@@ -640,7 +640,7 @@ impl<'a> WorkflowManager<'a> {
     }
 
     pub fn get_step_by_id(&self, step_id: &str) -> Result<Option<WorkflowRunStep>> {
-        let mut stmt = self.conn.prepare(&format!(
+        let mut stmt = self.conn.prepare_cached(&format!(
             "SELECT {STEP_COLUMNS} FROM workflow_run_steps WHERE id = ?1"
         ))?;
         let mut rows = stmt.query_map(params![step_id], row_to_workflow_step)?;

--- a/conductor-core/src/worktree.rs
+++ b/conductor-core/src/worktree.rs
@@ -228,7 +228,7 @@ impl<'a> WorktreeManager<'a> {
             }
         };
 
-        let mut stmt = self.conn.prepare(&query)?;
+        let mut stmt = self.conn.prepare_cached(&query)?;
         let rows = if let Some(slug) = repo_slug {
             stmt.query_map(params![slug], map_worktree_row)?
         } else {

--- a/conductor-web/src/routes/tickets.rs
+++ b/conductor-web/src/routes/tickets.rs
@@ -125,7 +125,7 @@ pub async fn ticket_detail(
     let all_totals = agent_mgr.totals_by_ticket_all()?;
     let agent_totals = all_totals.get(&ticket_id).cloned();
 
-    let mut stmt = db.prepare(
+    let mut stmt = db.prepare_cached(
         "SELECT id, repo_id, slug, branch, path, ticket_id, status, created_at, completed_at, model \
          FROM worktrees WHERE ticket_id = ?1 ORDER BY created_at DESC",
     )?;


### PR DESCRIPTION
Replace conn.prepare() with conn.prepare_cached() for queries that are
executed frequently with the same SQL string. This avoids re-parsing the
SQL statement on each invocation by reusing the compiled query from
rusqlite's internal LRU cache.

Changed in these locations:
- db/mod.rs query_collect helper (covers all call sites using this helper)
- agent.rs: totals_by_ticket_all(), worktree_cost_phases()
- worktree.rs: list() (finite query variants based on repo_slug/active_only)
- merge_queue.rs: get(), pop_next(), queue_stats()
- tickets.rs: list()
- workflow.rs: get_step_by_id()
- routes/tickets.rs: ticket detail worktree query

Left prepare() unchanged for:
- Dynamic IN clauses where placeholder count varies per call
- One-time migration checks where caching provides no benefit

Fixes #271

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
