### PR TITLE
refactor: extract SQL enum serialization to macro to reduce duplication

### DIFF
--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -167,23 +167,7 @@ impl std::str::FromStr for AgentRunStatus {
     }
 }
 
-impl rusqlite::types::ToSql for AgentRunStatus {
-    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-        Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
-    }
-}
-
-impl rusqlite::types::FromSql for AgentRunStatus {
-    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        let s = String::column_result(value)?;
-        s.parse().map_err(|e: String| {
-            rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e,
-            )))
-        })
-    }
-}
+crate::impl_sql_enum!(AgentRunStatus);
 
 /// Status of a human-in-the-loop feedback request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -217,23 +201,7 @@ impl std::str::FromStr for FeedbackStatus {
     }
 }
 
-impl rusqlite::types::ToSql for FeedbackStatus {
-    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-        Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
-    }
-}
-
-impl rusqlite::types::FromSql for FeedbackStatus {
-    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        let s = String::column_result(value)?;
-        s.parse().map_err(|e: String| {
-            rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e,
-            )))
-        })
-    }
-}
+crate::impl_sql_enum!(FeedbackStatus);
 
 /// Status of a single plan step.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -271,23 +239,7 @@ impl std::str::FromStr for StepStatus {
     }
 }
 
-impl rusqlite::types::ToSql for StepStatus {
-    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-        Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
-    }
-}
-
-impl rusqlite::types::FromSql for StepStatus {
-    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        let s = String::column_result(value)?;
-        s.parse().map_err(|e: String| {
-            rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e,
-            )))
-        })
-    }
-}
+crate::impl_sql_enum!(StepStatus);
 
 /// A single step in an agent's two-phase execution plan.
 /// Stored as individual records in the `agent_run_steps` table.

--- a/conductor-core/src/lib.rs
+++ b/conductor-core/src/lib.rs
@@ -1,3 +1,31 @@
+/// Implements `rusqlite::types::ToSql` and `rusqlite::types::FromSql` for an
+/// enum that already implements `std::fmt::Display` and `std::str::FromStr<Err = String>`.
+macro_rules! impl_sql_enum {
+    ($Type:ty) => {
+        impl rusqlite::types::ToSql for $Type {
+            fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+                Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
+            }
+        }
+
+        impl rusqlite::types::FromSql for $Type {
+            fn column_result(
+                value: rusqlite::types::ValueRef<'_>,
+            ) -> rusqlite::types::FromSqlResult<Self> {
+                let s = String::column_result(value)?;
+                s.parse().map_err(|e: String| {
+                    rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        e,
+                    )))
+                })
+            }
+        }
+    };
+}
+
+pub(crate) use impl_sql_enum;
+
 pub mod agent;
 pub mod agent_config;
 pub mod agent_runtime;

--- a/conductor-core/src/workflow.rs
+++ b/conductor-core/src/workflow.rs
@@ -145,23 +145,7 @@ impl std::str::FromStr for WorkflowRunStatus {
     }
 }
 
-impl rusqlite::types::ToSql for WorkflowRunStatus {
-    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-        Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
-    }
-}
-
-impl rusqlite::types::FromSql for WorkflowRunStatus {
-    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        let s = String::column_result(value)?;
-        s.parse().map_err(|e: String| {
-            rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e,
-            )))
-        })
-    }
-}
+crate::impl_sql_enum!(WorkflowRunStatus);
 
 /// Status of a single workflow step execution.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -204,23 +188,7 @@ impl std::str::FromStr for WorkflowStepStatus {
     }
 }
 
-impl rusqlite::types::ToSql for WorkflowStepStatus {
-    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-        Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
-    }
-}
-
-impl rusqlite::types::FromSql for WorkflowStepStatus {
-    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        let s = String::column_result(value)?;
-        s.parse().map_err(|e: String| {
-            rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e,
-            )))
-        })
-    }
-}
+crate::impl_sql_enum!(WorkflowStepStatus);
 
 // ---------------------------------------------------------------------------
 // Data structs


### PR DESCRIPTION
Eliminate byte-for-byte identical FromSql/ToSql implementations across
5 enum types (AgentRunStatus, FeedbackStatus, StepStatus, WorkflowRunStatus,
WorkflowStepStatus) by introducing impl_sql_enum! macro.

All 5 types already implement Display + FromStr<Err = String>, so the
macro generates both ToSql and FromSql implementations that parse from
string via the FromStr trait, reducing ~85 lines of boilerplate to 5
macro invocations.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
