### PR TITLE
refactor: consolidate prepare_cached/query_map/collect into query_collect helper

### DIFF
--- a/conductor-core/src/merge_queue.rs
+++ b/conductor-core/src/merge_queue.rs
@@ -238,15 +238,14 @@ impl<'a> MergeQueueManager<'a> {
 
     /// Get the count of entries by status for a repo.
     pub fn queue_stats(&self, repo_id: &str) -> Result<QueueStats> {
-        let mut stmt = self.conn.prepare_cached(
+        let rows = query_collect(
+            self.conn,
             "SELECT status, COUNT(*) FROM merge_queue WHERE repo_id = ?1 GROUP BY status",
+            params![repo_id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
         )?;
         let mut stats = QueueStats::default();
-        let rows = stmt.query_map(params![repo_id], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-        })?;
-        for row in rows {
-            let (status, count) = row?;
+        for (status, count) in rows {
             match status.as_str() {
                 "queued" => stats.queued = count,
                 "processing" => stats.processing = count,

--- a/conductor-core/src/tickets.rs
+++ b/conductor-core/src/tickets.rs
@@ -2,6 +2,7 @@ use chrono::Utc;
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 
+use crate::db::query_collect;
 use crate::error::{ConductorError, Result};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -139,14 +140,11 @@ impl<'a> TicketSyncer<'a> {
             }
         };
 
-        let mut stmt = self.conn.prepare_cached(query)?;
-        let rows = if let Some(rid) = repo_id {
-            stmt.query_map(params![rid], map_ticket_row)?
+        let tickets = if let Some(rid) = repo_id {
+            query_collect(self.conn, query, params![rid], map_ticket_row)?
         } else {
-            stmt.query_map([], map_ticket_row)?
+            query_collect(self.conn, query, [], map_ticket_row)?
         };
-
-        let tickets = rows.collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(tickets)
     }
 

--- a/conductor-core/src/worktree.rs
+++ b/conductor-core/src/worktree.rs
@@ -238,14 +238,11 @@ impl<'a> WorktreeManager<'a> {
             }
         };
 
-        let mut stmt = self.conn.prepare_cached(&query)?;
-        let rows = if let Some(slug) = repo_slug {
-            stmt.query_map(params![slug], map_worktree_row)?
+        let worktrees = if let Some(slug) = repo_slug {
+            query_collect(self.conn, &query, params![slug], map_worktree_row)?
         } else {
-            stmt.query_map([], map_worktree_row)?
+            query_collect(self.conn, &query, [], map_worktree_row)?
         };
-
-        let worktrees = rows.collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(worktrees)
     }
 


### PR DESCRIPTION
Inline four call sites that repeat the prepare_cached → query_map → collect
pattern: merge_queue.rs queue_stats(), worktree.rs list(), tickets.rs list(),
and conductor-web tickets.rs get_ticket(). This reduces boilerplate and
centralizes the pattern for easier maintenance and future changes.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
