### PR TITLE
refactor: remove duplicate parse_frontmatter tests

### DIFF
--- a/conductor-core/src/review_config.rs
+++ b/conductor-core/src/review_config.rs
@@ -206,24 +206,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_frontmatter_basic() {
-        let content = "---\nname: security\nrequired: true\n---\nYou are a security reviewer.";
-        let (yaml, body) = parse_frontmatter(content).unwrap();
-        assert!(yaml.contains("name: security"));
-        assert_eq!(body, "You are a security reviewer.");
-    }
-
-    #[test]
-    fn test_parse_frontmatter_no_opening() {
-        assert!(parse_frontmatter("no frontmatter here").is_none());
-    }
-
-    #[test]
-    fn test_parse_frontmatter_no_closing() {
-        assert!(parse_frontmatter("---\nname: test\nno closing").is_none());
-    }
-
-    #[test]
     fn test_parse_reviewer_file() {
         let tmp = TempDir::new().unwrap();
         let file_path = tmp.path().join("security.md");

--- a/conductor-core/src/workflow_config.rs
+++ b/conductor-core/src/workflow_config.rs
@@ -289,19 +289,6 @@ and commit them to the branch.
 ";
 
     #[test]
-    fn test_parse_frontmatter_basic() {
-        let content = "---\nname: test\nsteps: []\n---\n## section\nbody";
-        let (yaml, body) = parse_frontmatter(content).unwrap();
-        assert!(yaml.contains("name: test"));
-        assert!(body.contains("## section"));
-    }
-
-    #[test]
-    fn test_parse_frontmatter_no_opening() {
-        assert!(parse_frontmatter("no frontmatter here").is_none());
-    }
-
-    #[test]
     fn test_parse_sections() {
         let body = "## analyze\nYou are a reviewer.\n\n## write\nYou are a writer.";
         let sections = parse_sections(body);


### PR DESCRIPTION
The parse_frontmatter function was consolidated into text_util.rs
and all callers now import from there. Removed duplicate test cases
from review_config.rs (3 tests) and workflow_config.rs (2 tests) to
keep canonical tests in one place.

Fixes #250

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
