### PR TITLE
refactor: deduplicate sync_github/sync_jira and sync_github_repo/sync_jira_repo into generic sync_repo helpers

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -9,6 +9,7 @@ use conductor_core::agent::{
 };
 use conductor_core::config::{ensure_dirs, load_config};
 use conductor_core::db::open_database;
+use conductor_core::error::ConductorError;
 use conductor_core::github;
 use conductor_core::github_app;
 use conductor_core::issue_source::{GitHubConfig, IssueSourceManager, JiraConfig};
@@ -18,7 +19,7 @@ use conductor_core::orchestrator::{self, OrchestratorConfig};
 use conductor_core::post_run::{self, PostRunInput};
 use conductor_core::pr_review::{self, ReviewSwarmConfig, ReviewSwarmInput};
 use conductor_core::repo::{derive_local_path, derive_slug_from_url, RepoManager};
-use conductor_core::tickets::{build_agent_prompt, TicketSyncer};
+use conductor_core::tickets::{build_agent_prompt, TicketInput, TicketSyncer};
 use conductor_core::workflow::{collect_agent_names, WorkflowExecConfig, WorkflowManager};
 use conductor_core::workflow_config;
 use conductor_core::worktree::WorktreeManager;
@@ -964,7 +965,9 @@ fn main() -> Result<()> {
                     if sources.is_empty() {
                         // Backward compat: auto-detect GitHub from remote_url
                         if let Some((owner, name)) = github::parse_github_remote(&r.remote_url) {
-                            sync_github(&syncer, &r.id, &r.slug, &owner, &name);
+                            sync_repo(&syncer, &r.id, &r.slug, "github", "GitHub issues", || {
+                                github::sync_github_issues(&owner, &name)
+                            });
                         }
                     } else {
                         for source in sources {
@@ -973,8 +976,17 @@ fn main() -> Result<()> {
                                     match serde_json::from_str::<GitHubConfig>(&source.config_json)
                                     {
                                         Ok(cfg) => {
-                                            sync_github(
-                                                &syncer, &r.id, &r.slug, &cfg.owner, &cfg.repo,
+                                            sync_repo(
+                                                &syncer,
+                                                &r.id,
+                                                &r.slug,
+                                                "github",
+                                                "GitHub issues",
+                                                || {
+                                                    github::sync_github_issues(
+                                                        &cfg.owner, &cfg.repo,
+                                                    )
+                                                },
                                             );
                                         }
                                         Err(e) => {
@@ -985,7 +997,18 @@ fn main() -> Result<()> {
                                 "jira" => {
                                     match serde_json::from_str::<JiraConfig>(&source.config_json) {
                                         Ok(cfg) => {
-                                            sync_jira(&syncer, &r.id, &r.slug, &cfg.jql, &cfg.url);
+                                            sync_repo(
+                                                &syncer,
+                                                &r.id,
+                                                &r.slug,
+                                                "jira",
+                                                "Jira issues",
+                                                || {
+                                                    jira_acli::sync_jira_issues_acli(
+                                                        &cfg.jql, &cfg.url,
+                                                    )
+                                                },
+                                            );
                                         }
                                         Err(e) => {
                                             eprintln!("  {} — invalid jira config: {e}", r.slug);
@@ -2133,53 +2156,27 @@ fn print_event_summary(event: &serde_json::Value) {
     }
 }
 
-/// Sync Jira issues for a single repo, printing results.
-fn sync_jira(syncer: &TicketSyncer, repo_id: &str, repo_slug: &str, jql: &str, base_url: &str) {
-    match jira_acli::sync_jira_issues_acli(jql, base_url) {
+/// Sync issues for a single repo using the given fetch closure, printing results.
+fn sync_repo(
+    syncer: &TicketSyncer,
+    repo_id: &str,
+    repo_slug: &str,
+    source_type: &str,
+    label: &str,
+    fetch: impl FnOnce() -> Result<Vec<TicketInput>, ConductorError>,
+) {
+    match fetch() {
         Ok(tickets) => {
             let synced_ids: Vec<&str> = tickets.iter().map(|t| t.source_id.as_str()).collect();
             match syncer.upsert_tickets(repo_id, &tickets) {
                 Ok(count) => {
                     let closed = syncer
-                        .close_missing_tickets(repo_id, "jira", &synced_ids)
+                        .close_missing_tickets(repo_id, source_type, &synced_ids)
                         .unwrap_or(0);
                     let merged = syncer
                         .mark_worktrees_for_closed_tickets(repo_id)
                         .unwrap_or(0);
-                    print!("  {} — synced {count} Jira issues", repo_slug);
-                    if closed > 0 {
-                        print!(", {closed} marked closed");
-                    }
-                    if merged > 0 {
-                        print!(", {merged} worktrees merged");
-                    }
-                    println!();
-                }
-                Err(e) => {
-                    eprintln!("  {} — sync failed: {e}", repo_slug);
-                }
-            }
-        }
-        Err(e) => {
-            eprintln!("  {} — sync failed: {e}", repo_slug);
-        }
-    }
-}
-
-/// Sync GitHub issues for a single repo, printing results.
-fn sync_github(syncer: &TicketSyncer, repo_id: &str, repo_slug: &str, owner: &str, name: &str) {
-    match github::sync_github_issues(owner, name) {
-        Ok(tickets) => {
-            let synced_ids: Vec<&str> = tickets.iter().map(|t| t.source_id.as_str()).collect();
-            match syncer.upsert_tickets(repo_id, &tickets) {
-                Ok(count) => {
-                    let closed = syncer
-                        .close_missing_tickets(repo_id, "github", &synced_ids)
-                        .unwrap_or(0);
-                    let merged = syncer
-                        .mark_worktrees_for_closed_tickets(repo_id)
-                        .unwrap_or(0);
-                    print!("  {} — synced {count} GitHub issues", repo_slug);
+                    print!("  {} — synced {count} {label}", repo_slug);
                     if closed > 0 {
                         print!(", {closed} marked closed");
                     }

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -5,11 +5,12 @@ use std::time::Duration;
 use conductor_core::agent::AgentManager;
 use conductor_core::config::{db_path, load_config};
 use conductor_core::db::open_database;
+use conductor_core::error::ConductorError;
 use conductor_core::github;
 use conductor_core::issue_source::{GitHubConfig, IssueSourceManager, JiraConfig};
 use conductor_core::jira_acli;
 use conductor_core::repo::RepoManager;
-use conductor_core::tickets::TicketSyncer;
+use conductor_core::tickets::{TicketInput, TicketSyncer};
 use conductor_core::worktree::WorktreeManager;
 
 use crate::action::{Action, DataRefreshedPayload, WorkflowDataPayload};
@@ -93,7 +94,9 @@ fn sync_all_tickets(tx: &BackgroundSender) {
         if sources.is_empty() {
             // Backward compat: auto-detect GitHub from remote_url
             if let Some((owner, name)) = github::parse_github_remote(&repo.remote_url) {
-                let action = sync_github_repo(&syncer, &repo.id, &repo.slug, &owner, &name);
+                let action = sync_repo(&syncer, &repo.id, &repo.slug, "github", || {
+                    github::sync_github_issues(&owner, &name)
+                });
                 if !tx.send(action) {
                     return;
                 }
@@ -104,9 +107,9 @@ fn sync_all_tickets(tx: &BackgroundSender) {
                     "github" => {
                         let action = match serde_json::from_str::<GitHubConfig>(&source.config_json)
                         {
-                            Ok(cfg) => sync_github_repo(
-                                &syncer, &repo.id, &repo.slug, &cfg.owner, &cfg.repo,
-                            ),
+                            Ok(cfg) => sync_repo(&syncer, &repo.id, &repo.slug, "github", || {
+                                github::sync_github_issues(&cfg.owner, &cfg.repo)
+                            }),
                             Err(e) => Action::TicketSyncFailed {
                                 repo_slug: repo.slug.clone(),
                                 error: format!("invalid github config: {e}"),
@@ -118,9 +121,9 @@ fn sync_all_tickets(tx: &BackgroundSender) {
                     }
                     "jira" => {
                         let action = match serde_json::from_str::<JiraConfig>(&source.config_json) {
-                            Ok(cfg) => {
-                                sync_jira_repo(&syncer, &repo.id, &repo.slug, &cfg.jql, &cfg.url)
-                            }
+                            Ok(cfg) => sync_repo(&syncer, &repo.id, &repo.slug, "jira", || {
+                                jira_acli::sync_jira_issues_acli(&cfg.jql, &cfg.url)
+                            }),
                             Err(e) => Action::TicketSyncFailed {
                                 repo_slug: repo.slug.clone(),
                                 error: format!("invalid jira config: {e}"),
@@ -137,53 +140,20 @@ fn sync_all_tickets(tx: &BackgroundSender) {
     }
 }
 
-/// Sync Jira issues for a single repo, returning the appropriate Action.
-fn sync_jira_repo(
+/// Sync issues for a single repo using the given fetch closure, returning the appropriate Action.
+fn sync_repo(
     syncer: &TicketSyncer,
     repo_id: &str,
     repo_slug: &str,
-    jql: &str,
-    base_url: &str,
+    source_type: &str,
+    fetch: impl FnOnce() -> Result<Vec<TicketInput>, ConductorError>,
 ) -> Action {
-    match jira_acli::sync_jira_issues_acli(jql, base_url) {
+    match fetch() {
         Ok(tickets) => {
             let synced_ids: Vec<&str> = tickets.iter().map(|t| t.source_id.as_str()).collect();
             match syncer.upsert_tickets(repo_id, &tickets) {
                 Ok(count) => {
-                    let _ = syncer.close_missing_tickets(repo_id, "jira", &synced_ids);
-                    let _ = syncer.mark_worktrees_for_closed_tickets(repo_id);
-                    Action::TicketSyncComplete {
-                        repo_slug: repo_slug.to_string(),
-                        count,
-                    }
-                }
-                Err(e) => Action::TicketSyncFailed {
-                    repo_slug: repo_slug.to_string(),
-                    error: e.to_string(),
-                },
-            }
-        }
-        Err(e) => Action::TicketSyncFailed {
-            repo_slug: repo_slug.to_string(),
-            error: e.to_string(),
-        },
-    }
-}
-
-/// Sync GitHub issues for a single repo, returning the appropriate Action.
-fn sync_github_repo(
-    syncer: &TicketSyncer,
-    repo_id: &str,
-    repo_slug: &str,
-    owner: &str,
-    name: &str,
-) -> Action {
-    match github::sync_github_issues(owner, name) {
-        Ok(tickets) => {
-            let synced_ids: Vec<&str> = tickets.iter().map(|t| t.source_id.as_str()).collect();
-            match syncer.upsert_tickets(repo_id, &tickets) {
-                Ok(count) => {
-                    let _ = syncer.close_missing_tickets(repo_id, "github", &synced_ids);
+                    let _ = syncer.close_missing_tickets(repo_id, source_type, &synced_ids);
                     let _ = syncer.mark_worktrees_for_closed_tickets(repo_id);
                     Action::TicketSyncComplete {
                         repo_slug: repo_slug.to_string(),


### PR DESCRIPTION
Both sync_github and sync_jira in conductor-cli follow identical structure:
fetch → upsert_tickets → close_missing_tickets → mark_worktrees_for_closed_tickets → print results.
Only differences are the source type string and the upstream fetch call.

Similarly, sync_github_repo and sync_jira_repo in conductor-tui both follow
the same pattern but return Actions instead of printing.

Consolidate into single generic sync_repo helpers parameterized on:
- source_type: "github" or "jira" string for DB operations
- fetch closure: FnOnce() -> Result<Vec<TicketInput>, ConductorError>
- (CLI only) label: display string like "GitHub issues" or "Jira issues"

Eliminates ~60 lines of duplication in each crate.

Fixes #246.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
