### PR TITLE
fix: add '--' separator before branch name in git commands (#245)

### DIFF
--- a/conductor-core/src/worktree.rs
+++ b/conductor-core/src/worktree.rs
@@ -101,7 +101,7 @@ impl<'a> WorktreeManager<'a> {
 
         // Create git branch
         let output = Command::new("git")
-            .args(["branch", &branch, &base])
+            .args(["branch", "--", &branch, &base])
             .current_dir(&repo.local_path)
             .output()?;
         if !output.status.success() {
@@ -302,7 +302,7 @@ impl<'a> WorktreeManager<'a> {
 
         // Delete git branch
         let _ = Command::new("git")
-            .args(["branch", "-D", &worktree.branch])
+            .args(["branch", "-D", "--", &worktree.branch])
             .current_dir(&repo.local_path)
             .output();
 


### PR DESCRIPTION
Prevent argument injection in git branch commands where branch names
are derived from user-controlled issue titles. Using '--' forces git
to treat the following argument as a branch name, not an option flag,
even if the branch starts with '-'.

Fixes:
- git branch -D: add '--' before branch name when deleting
- git branch: add '--' before branch name when creating

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
