### PR TITLE
refactor: extract resolve_conductor_subdir helper to deduplicate dir resolution (#253)

### DIFF
--- a/conductor-core/src/agent_config.rs
+++ b/conductor-core/src/agent_config.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::error::{ConductorError, Result};
-use crate::text_util::parse_frontmatter;
+use crate::text_util::{parse_frontmatter, resolve_conductor_subdir};
 
 /// YAML frontmatter for an agent `.md` file.
 #[derive(Debug, Clone, Deserialize)]
@@ -194,17 +194,8 @@ pub fn load_agent(
 
 /// Load all agent definitions from `.conductor/agents/*.md`.
 pub fn load_all_agents(worktree_path: &str, repo_path: &str) -> Result<Vec<AgentDef>> {
-    let worktree_dir = PathBuf::from(worktree_path)
-        .join(".conductor")
-        .join("agents");
-    let agents_dir = if worktree_dir.is_dir() {
-        worktree_dir
-    } else {
-        let repo_dir = PathBuf::from(repo_path).join(".conductor").join("agents");
-        if !repo_dir.is_dir() {
-            return Ok(Vec::new());
-        }
-        repo_dir
+    let Some(agents_dir) = resolve_conductor_subdir(worktree_path, repo_path, "agents") else {
+        return Ok(Vec::new());
     };
 
     let mut entries: Vec<_> = fs::read_dir(&agents_dir)

--- a/conductor-core/src/review_config.rs
+++ b/conductor-core/src/review_config.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::error::{ConductorError, Result};
-use crate::text_util::parse_frontmatter;
+use crate::text_util::{parse_frontmatter, resolve_conductor_subdir};
 
 const REVIEWER_HINT: &str = "See .conductor/reviewers/ in conductor-ai for reference roles.";
 
@@ -148,24 +148,14 @@ pub fn load_review_settings(repo_path: &str) -> Result<ReviewSettings> {
 pub fn load_reviewer_roles(worktree_path: &str, repo_path: &str) -> Result<Vec<ReviewerRole>> {
     // Prefer the worktree so new/modified reviewer files can be tested in-branch.
     // Fall back to the main repo checkout when the worktree doesn't have them.
-    let worktree_dir = PathBuf::from(worktree_path)
-        .join(".conductor")
-        .join("reviewers");
-    let reviewers_dir = if worktree_dir.is_dir() {
-        worktree_dir
-    } else {
-        let repo_dir = PathBuf::from(repo_path)
-            .join(".conductor")
-            .join("reviewers");
-        if !repo_dir.is_dir() {
-            return Err(ConductorError::Config(format!(
+    let reviewers_dir = resolve_conductor_subdir(worktree_path, repo_path, "reviewers")
+        .ok_or_else(|| {
+            ConductorError::Config(format!(
                 "No .conductor/reviewers/ directory found in {} or {}. \
                  Create it and add reviewer role .md files. {REVIEWER_HINT}",
                 worktree_path, repo_path
-            )));
-        }
-        repo_dir
-    };
+            ))
+        })?;
 
     let mut roles: Vec<ReviewerRole> = Vec::new();
     let mut entries: Vec<_> = fs::read_dir(&reviewers_dir)

--- a/conductor-core/src/text_util.rs
+++ b/conductor-core/src/text_util.rs
@@ -1,3 +1,24 @@
+use std::path::PathBuf;
+
+/// Resolve a `.conductor/<subdir>` directory, preferring `worktree_path` over `repo_path`.
+///
+/// Returns `Some(path)` for the first existing directory found, or `None` if neither exists.
+pub fn resolve_conductor_subdir(
+    worktree_path: &str,
+    repo_path: &str,
+    subdir: &str,
+) -> Option<PathBuf> {
+    let worktree_dir = PathBuf::from(worktree_path).join(".conductor").join(subdir);
+    if worktree_dir.is_dir() {
+        return Some(worktree_dir);
+    }
+    let repo_dir = PathBuf::from(repo_path).join(".conductor").join(subdir);
+    if repo_dir.is_dir() {
+        return Some(repo_dir);
+    }
+    None
+}
+
 /// Truncate a string at a char boundary no greater than `max_bytes`.
 pub fn truncate_str(s: &str, max_bytes: usize) -> &str {
     if s.len() <= max_bytes {

--- a/conductor-core/src/workflow_config.rs
+++ b/conductor-core/src/workflow_config.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 
 use crate::agent_config::{default_role, AgentRole};
 use crate::error::{ConductorError, Result};
-use crate::text_util::parse_frontmatter;
+use crate::text_util::{parse_frontmatter, resolve_conductor_subdir};
 use crate::workflow_dsl::WorkflowTrigger;
 
 /// YAML frontmatter for a workflow `.md` file.
@@ -212,19 +212,7 @@ fn parse_sections(body: &str) -> HashMap<String, String> {
 
 /// Resolve the `.conductor/workflows/` directory, preferring worktree over repo.
 fn resolve_workflows_dir(worktree_path: &str, repo_path: &str) -> Option<PathBuf> {
-    let worktree_dir = PathBuf::from(worktree_path)
-        .join(".conductor")
-        .join("workflows");
-    if worktree_dir.is_dir() {
-        return Some(worktree_dir);
-    }
-    let repo_dir = PathBuf::from(repo_path)
-        .join(".conductor")
-        .join("workflows");
-    if repo_dir.is_dir() {
-        return Some(repo_dir);
-    }
-    None
+    resolve_conductor_subdir(worktree_path, repo_path, "workflows")
 }
 
 /// Load all workflow definitions from `.conductor/workflows/*.md`.

--- a/conductor-core/src/workflow_dsl.rs
+++ b/conductor-core/src/workflow_dsl.rs
@@ -27,6 +27,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{ConductorError, Result};
+use crate::text_util::resolve_conductor_subdir;
 
 // ---------------------------------------------------------------------------
 // AST types
@@ -881,19 +882,7 @@ pub fn validate_workflow_name(name: &str) -> Result<()> {
 
 /// Resolve the `.conductor/workflows/` directory, preferring worktree over repo.
 fn resolve_workflows_dir(worktree_path: &str, repo_path: &str) -> Option<PathBuf> {
-    let worktree_dir = PathBuf::from(worktree_path)
-        .join(".conductor")
-        .join("workflows");
-    if worktree_dir.is_dir() {
-        return Some(worktree_dir);
-    }
-    let repo_dir = PathBuf::from(repo_path)
-        .join(".conductor")
-        .join("workflows");
-    if repo_dir.is_dir() {
-        return Some(repo_dir);
-    }
-    None
+    resolve_conductor_subdir(worktree_path, repo_path, "workflows")
 }
 
 /// Load a single workflow definition by name.


### PR DESCRIPTION
The worktree-first fallback pattern for .conductor/<subdir> resolution was
duplicated across review_config.rs, agent_config.rs, workflow_config.rs, and
workflow_dsl.rs. Extract a shared helper `resolve_conductor_subdir()` in
text_util.rs and use it consistently.

- Added `resolve_conductor_subdir(worktree_path, repo_path, subdir) -> Option<PathBuf>` to text_util.rs
- Updated review_config.rs load_reviewer_roles to use the helper
- Updated agent_config.rs load_all_agents to use the helper
- Simplified private resolve_workflows_dir in workflow_config.rs and workflow_dsl.rs to delegate to the helper
- All 349 tests pass

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
