### PR TITLE
refactor: remove duplicate resolve_workflows_dir wrappers (#323)

### DIFF
--- a/conductor-core/src/workflow_config.rs
+++ b/conductor-core/src/workflow_config.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde::Deserialize;
 
@@ -210,17 +210,13 @@ fn parse_sections(body: &str) -> HashMap<String, String> {
     sections
 }
 
-/// Resolve the `.conductor/workflows/` directory, preferring worktree over repo.
-fn resolve_workflows_dir(worktree_path: &str, repo_path: &str) -> Option<PathBuf> {
-    resolve_conductor_subdir(worktree_path, repo_path, "workflows")
-}
-
 /// Load all workflow definitions from `.conductor/workflows/*.md`.
 ///
 /// Checks `worktree_path` first, then falls back to `repo_path`,
 /// consistent with `load_reviewer_roles`.
 pub fn load_workflow_defs(worktree_path: &str, repo_path: &str) -> Result<Vec<WorkflowDef>> {
-    let Some(workflows_dir) = resolve_workflows_dir(worktree_path, repo_path) else {
+    let Some(workflows_dir) = resolve_conductor_subdir(worktree_path, repo_path, "workflows")
+    else {
         // No workflows directory — return empty list (not an error, unlike reviewers).
         return Ok(Vec::new());
     };
@@ -254,11 +250,12 @@ pub fn load_workflow_by_name(
 ) -> Result<WorkflowDef> {
     crate::workflow_dsl::validate_workflow_name(name)?;
 
-    let workflows_dir = resolve_workflows_dir(worktree_path, repo_path).ok_or_else(|| {
-        ConductorError::Workflow(format!(
-            "Workflow '{name}' not found in .conductor/workflows/"
-        ))
-    })?;
+    let workflows_dir = resolve_conductor_subdir(worktree_path, repo_path, "workflows")
+        .ok_or_else(|| {
+            ConductorError::Workflow(format!(
+                "Workflow '{name}' not found in .conductor/workflows/"
+            ))
+        })?;
 
     let path = workflows_dir.join(format!("{name}.md"));
     if !path.is_file() {

--- a/conductor-core/src/workflow_dsl.rs
+++ b/conductor-core/src/workflow_dsl.rs
@@ -22,7 +22,7 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
@@ -836,7 +836,7 @@ pub fn parse_workflow_str(input: &str, source_path: &str) -> Result<WorkflowDef>
 
 /// Load all workflow definitions from `.conductor/workflows/*.wf`.
 pub fn load_workflow_defs(worktree_path: &str, repo_path: &str) -> Result<Vec<WorkflowDef>> {
-    let workflows_dir = match resolve_workflows_dir(worktree_path, repo_path) {
+    let workflows_dir = match resolve_conductor_subdir(worktree_path, repo_path, "workflows") {
         Some(dir) => dir,
         None => return Ok(Vec::new()),
     };
@@ -880,11 +880,6 @@ pub fn validate_workflow_name(name: &str) -> Result<()> {
     Ok(())
 }
 
-/// Resolve the `.conductor/workflows/` directory, preferring worktree over repo.
-fn resolve_workflows_dir(worktree_path: &str, repo_path: &str) -> Option<PathBuf> {
-    resolve_conductor_subdir(worktree_path, repo_path, "workflows")
-}
-
 /// Load a single workflow definition by name.
 pub fn load_workflow_by_name(
     worktree_path: &str,
@@ -893,11 +888,12 @@ pub fn load_workflow_by_name(
 ) -> Result<WorkflowDef> {
     validate_workflow_name(name)?;
 
-    let workflows_dir = resolve_workflows_dir(worktree_path, repo_path).ok_or_else(|| {
-        ConductorError::Workflow(format!(
-            "Workflow '{name}' not found in .conductor/workflows/"
-        ))
-    })?;
+    let workflows_dir = resolve_conductor_subdir(worktree_path, repo_path, "workflows")
+        .ok_or_else(|| {
+            ConductorError::Workflow(format!(
+                "Workflow '{name}' not found in .conductor/workflows/"
+            ))
+        })?;
 
     let path = workflows_dir.join(format!("{name}.wf"));
     if !path.is_file() {


### PR DESCRIPTION
Both workflow_config.rs and workflow_dsl.rs defined identical private
resolve_workflows_dir functions that were trivial one-liner wrappers
around resolve_conductor_subdir. Remove the wrappers and call
resolve_conductor_subdir directly at all call sites.

Also remove unused PathBuf imports from both files.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
