### PR TITLE
refactor: move apply_ticket_sync to TicketSyncer in conductor-core (#333)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "tracing",
  "ulid",
 ]
 

--- a/conductor-core/Cargo.toml
+++ b/conductor-core/Cargo.toml
@@ -18,6 +18,7 @@ dirs = "6"
 jsonwebtoken = "9"
 serde_yml = "0.0"
 notify = "6"
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/conductor-core/src/tickets.rs
+++ b/conductor-core/src/tickets.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 use crate::db::query_collect;
 use crate::error::{ConductorError, Result};
@@ -188,6 +189,27 @@ impl<'a> TicketSyncer<'a> {
             })
     }
 
+    /// Upsert a batch of synced tickets, close any missing ones, and mark their
+    /// worktrees. Returns `(synced, closed)` counts. Errors from the close and
+    /// mark steps are logged as warnings rather than propagated, matching the
+    /// intent that one source failure should not abort the entire sync.
+    pub fn sync_and_close_tickets(
+        &self,
+        repo_id: &str,
+        source_type: &str,
+        tickets: &[TicketInput],
+    ) -> (usize, usize) {
+        let synced_ids: Vec<&str> = tickets.iter().map(|t| t.source_id.as_str()).collect();
+        let synced = self.upsert_tickets(repo_id, tickets).unwrap_or(0);
+        let closed = self
+            .close_missing_tickets(repo_id, source_type, &synced_ids)
+            .unwrap_or(0);
+        if let Err(e) = self.mark_worktrees_for_closed_tickets(repo_id) {
+            warn!("mark_worktrees_for_closed_tickets failed for {repo_id}: {e}");
+        }
+        (synced, closed)
+    }
+
     /// After syncing tickets, mark any linked worktrees whose ticket is now
     /// closed by setting their status to `'merged'`. Called as part of the
     /// ticket sync flow, typically after [`TicketSyncer::close_missing_tickets`].
@@ -287,6 +309,34 @@ mod tests {
             |row| row.get(0),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn test_sync_and_close_tickets_returns_counts_and_marks_worktrees() {
+        let conn = setup_db();
+        let syncer = TicketSyncer::new(&conn);
+
+        // First sync: two open tickets
+        let first = vec![make_ticket("1", "Issue 1"), make_ticket("2", "Issue 2")];
+        let (synced, closed) = syncer.sync_and_close_tickets("r1", "github", &first);
+        assert_eq!(synced, 2);
+        assert_eq!(closed, 0);
+
+        // Get ticket id for issue 1 and link a worktree to it
+        let ticket_id: String = conn
+            .query_row("SELECT id FROM tickets WHERE source_id = '1'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        insert_worktree(&conn, "wt1", "r1", Some(&ticket_id), "active");
+
+        // Second sync: only issue 2 remains open → issue 1 closed, worktree merged
+        let second = vec![make_ticket("2", "Issue 2")];
+        let (synced2, closed2) = syncer.sync_and_close_tickets("r1", "github", &second);
+        assert_eq!(synced2, 1);
+        assert_eq!(closed2, 1);
+        assert_eq!(get_ticket_state(&conn, "1"), "closed");
+        assert_eq!(get_worktree_status(&conn, "wt1"), "merged");
     }
 
     #[test]

--- a/conductor-web/src/routes/tickets.rs
+++ b/conductor-web/src/routes/tickets.rs
@@ -1,14 +1,13 @@
 use axum::extract::{Path, State};
 use axum::Json;
 use serde::Serialize;
-use tracing::warn;
 
 use conductor_core::agent::{AgentManager, TicketAgentTotals};
 use conductor_core::github;
 use conductor_core::issue_source::{GitHubConfig, IssueSourceManager, JiraConfig};
 use conductor_core::jira_acli;
 use conductor_core::repo::RepoManager;
-use conductor_core::tickets::{Ticket, TicketInput, TicketSyncer};
+use conductor_core::tickets::{Ticket, TicketSyncer};
 use conductor_core::worktree::{Worktree, WorktreeManager};
 
 use crate::error::ApiError;
@@ -48,27 +47,6 @@ pub async fn list_tickets(
     Ok(Json(tickets))
 }
 
-/// Upsert a batch of synced tickets, close any missing ones, and mark their
-/// worktrees. Returns `(synced, closed)` counts. Errors from the close and
-/// mark steps are logged as warnings rather than propagated, matching the
-/// intent that one source failure should not abort the entire sync.
-fn apply_ticket_sync(
-    syncer: &TicketSyncer,
-    repo_id: &str,
-    source_type: &str,
-    tickets: &[TicketInput],
-) -> (usize, usize) {
-    let synced_ids: Vec<&str> = tickets.iter().map(|t| t.source_id.as_str()).collect();
-    let synced = syncer.upsert_tickets(repo_id, tickets).unwrap_or(0);
-    let closed = syncer
-        .close_missing_tickets(repo_id, source_type, &synced_ids)
-        .unwrap_or(0);
-    if let Err(e) = syncer.mark_worktrees_for_closed_tickets(repo_id) {
-        warn!("mark_worktrees_for_closed_tickets failed for {repo_id}: {e}");
-    }
-    (synced, closed)
-}
-
 pub async fn sync_tickets(
     State(state): State<AppState>,
     Path(repo_id): Path<String>,
@@ -87,7 +65,7 @@ pub async fn sync_tickets(
         // Backward compat: auto-detect GitHub from remote URL
         if let Some((owner, name)) = github::parse_github_remote(&repo.remote_url) {
             let tickets = github::sync_github_issues(&owner, &name)?;
-            let (synced, closed) = apply_ticket_sync(&syncer, &repo.id, "github", &tickets);
+            let (synced, closed) = syncer.sync_and_close_tickets(&repo.id, "github", &tickets);
             total_synced += synced;
             total_closed += closed;
         }
@@ -98,7 +76,7 @@ pub async fn sync_tickets(
                     if let Ok(cfg) = serde_json::from_str::<GitHubConfig>(&source.config_json) {
                         if let Ok(tickets) = github::sync_github_issues(&cfg.owner, &cfg.repo) {
                             let (synced, closed) =
-                                apply_ticket_sync(&syncer, &repo.id, "github", &tickets);
+                                syncer.sync_and_close_tickets(&repo.id, "github", &tickets);
                             total_synced += synced;
                             total_closed += closed;
                         }
@@ -108,7 +86,7 @@ pub async fn sync_tickets(
                     if let Ok(cfg) = serde_json::from_str::<JiraConfig>(&source.config_json) {
                         if let Ok(tickets) = jira_acli::sync_jira_issues_acli(&cfg.jql, &cfg.url) {
                             let (synced, closed) =
-                                apply_ticket_sync(&syncer, &repo.id, "jira", &tickets);
+                                syncer.sync_and_close_tickets(&repo.id, "jira", &tickets);
                             total_synced += synced;
                             total_closed += closed;
                         }


### PR DESCRIPTION
Move the upsert-close-mark orchestration pattern from conductor-web
route module to TicketSyncer as sync_and_close_tickets method. This
makes the pattern reusable by CLI, TUI, or other layers that need the
same sync flow.

- Add tracing dependency to conductor-core for warning logs
- Add TicketSyncer::sync_and_close_tickets public method
- Remove local apply_ticket_sync helper from conductor-web routes
- Update call sites to use syncer.sync_and_close_tickets(...)
- Add test covering full sync, close, and worktree mark flow

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
