### PR TITLE
fix: log close_missing_tickets errors in sync_and_close_tickets

### DIFF
--- a/conductor-core/src/tickets.rs
+++ b/conductor-core/src/tickets.rs
@@ -203,7 +203,10 @@ impl<'a> TicketSyncer<'a> {
         let synced = self.upsert_tickets(repo_id, tickets).unwrap_or(0);
         let closed = self
             .close_missing_tickets(repo_id, source_type, &synced_ids)
-            .unwrap_or(0);
+            .unwrap_or_else(|e| {
+                warn!("close_missing_tickets failed for {repo_id}: {e}");
+                0
+            });
         if let Err(e) = self.mark_worktrees_for_closed_tickets(repo_id) {
             warn!("mark_worktrees_for_closed_tickets failed for {repo_id}: {e}");
         }


### PR DESCRIPTION
Add warn! logging for close_missing_tickets failures in sync_and_close_tickets,
making it consistent with mark_worktrees_for_closed_tickets error handling.
Addresses issue #328 by ensuring errors are logged instead of silently
swallowed with unwrap_or(0).

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
