### PR TITLE
refactor: extract warn_and_default closure in sync_and_close_tickets

### DIFF
--- a/conductor-core/src/tickets.rs
+++ b/conductor-core/src/tickets.rs
@@ -199,17 +199,22 @@ impl<'a> TicketSyncer<'a> {
         source_type: &str,
         tickets: &[TicketInput],
     ) -> (usize, usize) {
-        let synced_ids: Vec<&str> = tickets.iter().map(|t| t.source_id.as_str()).collect();
-        let synced = self.upsert_tickets(repo_id, tickets).unwrap_or(0);
-        let closed = self
-            .close_missing_tickets(repo_id, source_type, &synced_ids)
-            .unwrap_or_else(|e| {
-                warn!("close_missing_tickets failed for {repo_id}: {e}");
+        let warn_and_default = |result: Result<usize>, ctx: &str| {
+            result.unwrap_or_else(|e| {
+                warn!("{ctx} failed for {repo_id}: {e}");
                 0
-            });
-        if let Err(e) = self.mark_worktrees_for_closed_tickets(repo_id) {
-            warn!("mark_worktrees_for_closed_tickets failed for {repo_id}: {e}");
-        }
+            })
+        };
+        let synced_ids: Vec<&str> = tickets.iter().map(|t| t.source_id.as_str()).collect();
+        let synced = warn_and_default(self.upsert_tickets(repo_id, tickets), "upsert_tickets");
+        let closed = warn_and_default(
+            self.close_missing_tickets(repo_id, source_type, &synced_ids),
+            "close_missing_tickets",
+        );
+        warn_and_default(
+            self.mark_worktrees_for_closed_tickets(repo_id),
+            "mark_worktrees_for_closed_tickets",
+        );
         (synced, closed)
     }
 


### PR DESCRIPTION
Unifies three fallible call sites (upsert_tickets, close_missing_tickets,
mark_worktrees_for_closed_tickets) into a single warn_and_default closure,
eliminating repeated warn-and-continue pattern. Also adds warning logging
for upsert_tickets failures, matching the intent that one source failure
should not abort the entire sync.

Addresses #339.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
