### PR TITLE
chore: suppress verbose reviewer boilerplate in PR review output

### DIFF
--- a/conductor-core/src/pr_review.rs
+++ b/conductor-core/src/pr_review.rs
@@ -447,11 +447,16 @@ fn build_reviewer_prompt(role: &ReviewerRole, diff: &str, branch: &str) -> Strin
          ```diff\n\
          {diff}\n\
          ```\n\n\
-         Review the diff above. At the end of your review, include a verdict line:\n\
+         Review the diff above. Output ONLY the findings — do not include:\n\
+         - A title or header for your review\n\
+         - A list of files reviewed\n\
+         - Notes on things you checked but found no issues with\n\
+         - Summaries of what the PR does\n\
+         - Any preamble or closing remarks\n\n\
+         At the end of your review, include a verdict line:\n\
          - `VERDICT: APPROVE` if no critical or warning issues found in `+` lines\n\
          - `VERDICT: REQUEST_CHANGES` if any critical or warning issues found in `+` lines\n\n\
-         Important: `suggestion`-severity findings alone should NOT produce REQUEST_CHANGES.\n\n\
-         Be thorough but concise.",
+         Important: `suggestion`-severity findings alone should NOT produce REQUEST_CHANGES.",
         system_prompt = role.system_prompt,
         branch = branch,
         focus = role.focus,


### PR DESCRIPTION
## Summary
Adds explicit "do not include" instructions to the reviewer prompt to cut padding from review output:
- No title/header for the review
- No "files reviewed" list
- No "non-issue notes" (things checked but found clean)
- No preamble, scope summaries, or closing remarks

Reviewers should output findings only, then a verdict line.

## Expected impact
- Shorter, more scannable `<details>` blocks in PR comments
- Reduced output tokens for reviewers that find issues

## Test plan
- [ ] Run a review on a PR with findings and verify output is findings-only
- [ ] Verify verdict line is still detected correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)