### PR TITLE
fix: propagate errors from worktree deletion in merge_and_cleanup

### DIFF
--- a/conductor-core/src/post_run.rs
+++ b/conductor-core/src/post_run.rs
@@ -619,7 +619,7 @@ fn merge_and_cleanup(
         }
     }
 
-    let _ = wt_mgr.delete_by_id(&wt.id);
+    wt_mgr.delete_by_id(&wt.id)?;
     eprintln!("{log_prefix} Cleaned up worktree '{}'", wt.slug);
     Ok(())
 }


### PR DESCRIPTION
Changed `let _ = wt_mgr.delete_by_id(&wt.id)` to `wt_mgr.delete_by_id(&wt.id)?`
to propagate errors from worktree cleanup instead of silently discarding them.
If git cleanup fails (e.g. worktree path does not exist, permissions), the caller
now knows the operation failed rather than having an invisible partial failure.

Fixes #242

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
