### PR TITLE
refactor: avoid redundant ticket-state DB query in delete_internal

### DIFF
--- a/conductor-core/src/post_run.rs
+++ b/conductor-core/src/post_run.rs
@@ -619,7 +619,7 @@ fn merge_and_cleanup(
         }
     }
 
-    wt_mgr.delete_by_id(&wt.id)?;
+    wt_mgr.delete_by_id_as_merged(&wt.id)?;
     eprintln!("{log_prefix} Cleaned up worktree '{}'", wt.slug);
     Ok(())
 }

--- a/conductor-core/src/worktree.rs
+++ b/conductor-core/src/worktree.rs
@@ -257,33 +257,51 @@ impl<'a> WorktreeManager<'a> {
                 slug: name.to_string(),
             })?;
 
-        self.delete_internal(&repo, worktree)
+        self.delete_internal(&repo, worktree, None)
     }
 
     pub fn delete_by_id(&self, worktree_id: &str) -> Result<Worktree> {
         let worktree = self.get_by_id(worktree_id)?;
         let repo_mgr = RepoManager::new(self.conn, self.config);
         let repo = repo_mgr.get_by_id(&worktree.repo_id)?;
-        self.delete_internal(&repo, worktree)
+        self.delete_internal(&repo, worktree, None)
     }
 
-    fn delete_internal(&self, repo: &crate::repo::Repo, worktree: Worktree) -> Result<Worktree> {
+    /// Like [`delete_by_id`] but skips the ticket-state DB query when the
+    /// caller already knows the worktree was merged.
+    pub(crate) fn delete_by_id_as_merged(&self, worktree_id: &str) -> Result<Worktree> {
+        let worktree = self.get_by_id(worktree_id)?;
+        let repo_mgr = RepoManager::new(self.conn, self.config);
+        let repo = repo_mgr.get_by_id(&worktree.repo_id)?;
+        self.delete_internal(&repo, worktree, Some(true))
+    }
+
+    /// `ticket_closed_hint`: when `Some(true)` the caller already knows the
+    /// linked ticket is closed; the per-ticket DB query is skipped.
+    fn delete_internal(
+        &self,
+        repo: &crate::repo::Repo,
+        worktree: Worktree,
+        ticket_closed_hint: Option<bool>,
+    ) -> Result<Worktree> {
         // Determine merged vs abandoned:
         // 1. Check if the linked ticket is closed (covers squash merges that git can't detect)
         // 2. Fall back to git branch --merged (covers cases without a linked ticket)
-        let ticket_closed = worktree
-            .ticket_id
-            .as_ref()
-            .map(|tid| {
-                self.conn
-                    .query_row(
-                        "SELECT state = 'closed' FROM tickets WHERE id = ?1",
-                        params![tid],
-                        |row| row.get::<_, bool>(0),
-                    )
-                    .unwrap_or(false)
-            })
-            .unwrap_or(false);
+        let ticket_closed = ticket_closed_hint.unwrap_or_else(|| {
+            worktree
+                .ticket_id
+                .as_ref()
+                .map(|tid| {
+                    self.conn
+                        .query_row(
+                            "SELECT state = 'closed' FROM tickets WHERE id = ?1",
+                            params![tid],
+                            |row| row.get::<_, bool>(0),
+                        )
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false)
+        });
         let is_merged = ticket_closed
             || is_branch_merged(&repo.local_path, &worktree.branch, &repo.default_branch);
         let new_status = if is_merged { "merged" } else { "abandoned" };


### PR DESCRIPTION
Add `ticket_closed_hint: Option<bool>` parameter to delete_internal to let
callers short-circuit the per-ticket SELECT query when they already know the
ticket is closed. This eliminates the redundant query in merge_and_cleanup,
which calls the deletion immediately after squash-merging the PR.

Changes:
- delete_internal now accepts optional ticket_closed_hint parameter
- Added pub(crate) delete_by_id_as_merged method for merged worktree deletions
- merge_and_cleanup now uses delete_by_id_as_merged to skip the query

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
