### PR TITLE
fix: replace eprintln! with tracing::warn! in conductor-core library functions

### DIFF
--- a/conductor-core/src/github_app.rs
+++ b/conductor-core/src/github_app.rs
@@ -55,11 +55,10 @@ fn generate_jwt(app_config: &GitHubAppConfig) -> Result<String> {
     // Warn early when a configured value looks wrong so auth failures are easier to diagnose.
     if let Some(ref cid) = app_config.client_id {
         if !cid.starts_with("Iv") {
-            eprintln!(
-                "warning: github.app.client_id {:?} does not match the expected \
-                 GitHub App client ID format (\"Iv...\"). \
-                 Verify the value on your App's settings page.",
-                cid
+            tracing::warn!(
+                client_id = %cid,
+                "github.app.client_id does not match the expected GitHub App client ID format \
+                 (\"Iv...\"). Verify the value on your App's settings page."
             );
         }
     }
@@ -180,7 +179,7 @@ pub fn resolve_app_token(config: &Config, context: &str) -> TokenResolution {
     match get_app_token(app_config) {
         Ok(token) => TokenResolution::AppToken(token),
         Err(e) => {
-            eprintln!("[{context}] GitHub App token failed, falling back to gh user: {e}");
+            tracing::warn!(context, error = %e, "GitHub App token failed, falling back to gh user");
             TokenResolution::Fallback {
                 reason: e.to_string(),
             }


### PR DESCRIPTION
Remove direct stderr output from library code by replacing two eprintln! calls
in github_app.rs with structured tracing::warn! logs:

1. generate_jwt: client_id format validation warning now uses tracing with
   structured field for easier filtering and log aggregation.

2. resolve_app_token: token-failure fallback warning now uses tracing with
   context and error fields, allowing callers to configure logging behavior
   rather than forcing stderr output.

TokenResolution::Fallback { reason } already makes error details available
to callers, eliminating the need for library-level stderr output.

Fixes #237

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
