### PR TITLE
fix: move timeout clock start after watcher setup to exclude slow initialization

### DIFF
--- a/conductor-core/src/pr_review.rs
+++ b/conductor-core/src/pr_review.rs
@@ -1003,7 +1003,6 @@ fn poll_all_reviewers(
     poll_interval: Duration,
     timeout: Duration,
 ) -> Vec<ReviewerResult> {
-    let start = std::time::Instant::now();
     let mut results: Vec<Option<ReviewerResult>> = vec![None; child_runs.len()];
     let mut pending_count = child_runs.len();
     let watched_ids: HashSet<String> = child_runs.iter().map(|(_, r, _)| r.id.clone()).collect();
@@ -1039,6 +1038,11 @@ fn poll_all_reviewers(
         }
         watcher.ok()
     };
+
+    // Start the timeout clock after watcher initialisation so that slow watcher
+    // setup (e.g. FSEvents on macOS) does not consume time that should count
+    // against actual polling.
+    let start = std::time::Instant::now();
 
     // Run IDs notified by the file watcher since last poll cycle.
     // When empty (timeout or first iteration), all pending runs are scanned as a fallback.
@@ -1759,7 +1763,7 @@ mod tests {
             &child_runs,
             &steps,
             Duration::from_millis(10),
-            Duration::from_secs(2),
+            Duration::from_millis(100),
         );
 
         assert_eq!(results.len(), 2);
@@ -2411,7 +2415,7 @@ mod tests {
             &child_runs,
             &steps,
             Duration::from_millis(10),
-            Duration::from_secs(2),
+            Duration::from_millis(100),
         );
 
         // Clean up log file


### PR DESCRIPTION
The notify file watcher (FSEvents on macOS) can take 50ms+ to initialize. By
starting the timeout clock before setup, the watcher initialization time was
being consumed from the timeout budget, causing previously-completed runs to be
incorrectly marked as timed out on the first poll iteration.

Move the start timer to after watcher setup so the timeout accurately measures
only the actual polling duration. This allows tests to use their original
smaller timeouts (50-100ms) instead of 2s, reducing test suite runtime.

Fixes #231

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
