### PR TITLE
perf: cache conductor_dir() result in OnceLock to avoid repeated home_dir() calls (#229)

### DIFF
--- a/conductor-core/src/config.rs
+++ b/conductor-core/src/config.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use crate::error::{ConductorError, Result};
 
@@ -216,10 +217,17 @@ impl Default for DefaultsConfig {
 }
 
 /// Returns the Conductor data directory: ~/.conductor
-pub fn conductor_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("could not determine home directory")
-        .join(".conductor")
+///
+/// The result is cached after the first call so that repeated invocations
+/// (e.g. inside loops that call `agent_log_path`) avoid redundant OS-level
+/// `home_dir()` lookups.
+pub fn conductor_dir() -> &'static PathBuf {
+    static CONDUCTOR_DIR: OnceLock<PathBuf> = OnceLock::new();
+    CONDUCTOR_DIR.get_or_init(|| {
+        dirs::home_dir()
+            .expect("could not determine home directory")
+            .join(".conductor")
+    })
 }
 
 /// Returns the path to the SQLite database.


### PR DESCRIPTION
conductor_dir() was being recomputed on every invocation, triggering an OS-level
dirs::home_dir() call. Code that loops calling agent_log_path() paid this cost
repeatedly. Now the result is cached in a static OnceLock so repeated calls are free.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
