### PR TITLE
refactor: remove redundant has_running_agent and has_waiting_feedback in input.rs

### DIFF
--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -309,6 +309,11 @@ impl AgentRun {
         )
     }
 
+    /// Returns true if this run is waiting for human feedback.
+    pub fn is_waiting_for_feedback(&self) -> bool {
+        self.status == AgentRunStatus::WaitingForFeedback
+    }
+
     /// Returns true if this run ended (failed/cancelled) with incomplete plan steps
     /// and has a session_id available for resume.
     pub fn needs_resume(&self) -> bool {

--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -250,19 +250,15 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
             .and_then(|wt_id| state.data.latest_agent_runs.get(wt_id));
 
         let is_active = agent_run.is_some_and(|run| run.is_active());
-        let has_running_agent = agent_run
-            .is_some_and(|run| run.status == conductor_core::agent::AgentRunStatus::Running);
-        let has_waiting_feedback = agent_run.is_some_and(|run| {
-            run.status == conductor_core::agent::AgentRunStatus::WaitingForFeedback
-        });
+        let is_waiting_for_feedback = agent_run.is_some_and(|run| run.is_waiting_for_feedback());
         let has_log = agent_run.is_some_and(|run| run.log_file.is_some());
 
         match key.code {
             KeyCode::Char('r') => return Action::LaunchAgent,
-            KeyCode::Char('o') if !has_running_agent => return Action::OrchestrateAgent,
+            KeyCode::Char('o') if !is_active => return Action::OrchestrateAgent,
             KeyCode::Char('x') if is_active => return Action::StopAgent,
-            KeyCode::Char('f') if has_waiting_feedback => return Action::SubmitFeedback,
-            KeyCode::Char('F') if has_waiting_feedback => return Action::DismissFeedback,
+            KeyCode::Char('f') if is_waiting_for_feedback => return Action::SubmitFeedback,
+            KeyCode::Char('F') if is_waiting_for_feedback => return Action::DismissFeedback,
             KeyCode::Char('L') if has_log => return Action::ViewAgentLog,
             KeyCode::Char('y') if has_log => return Action::CopyLastCodeBlock,
             KeyCode::Char('e') => return Action::ExpandAgentEvent,


### PR DESCRIPTION
Add is_waiting_for_feedback() method to AgentRun alongside is_active() to eliminate duplicate status checks in the TUI keybinding logic. Replace has_running_agent with is_active (more semantically correct—waiting for feedback is also an active state where orchestrate should be disabled) and has_waiting_feedback with is_waiting_for_feedback() call.

This addresses #214: consolidates agent status checks into reusable helper methods.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
