### PR TITLE
fix: prevent GitHub App JWT exposure in process listing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +339,7 @@ dependencies = [
  "tracing",
  "tracing-test",
  "ulid",
+ "ureq",
 ]
 
 [[package]]
@@ -406,6 +413,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -608,6 +624,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1315,6 +1341,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,7 +1856,9 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2052,6 +2090,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simple_asn1"
@@ -2592,6 +2636,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,6 +2806,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/conductor-core/Cargo.toml
+++ b/conductor-core/Cargo.toml
@@ -16,6 +16,7 @@ ulid = "1"
 toml = "0.8"
 dirs = "6"
 jsonwebtoken = "9"
+ureq = { version = "2", features = ["json"] }
 serde_yml = "0.0"
 notify = "6"
 tracing = "0.1"

--- a/conductor-core/src/github_app.rs
+++ b/conductor-core/src/github_app.rs
@@ -78,40 +78,30 @@ fn generate_jwt(app_config: &GitHubAppConfig) -> Result<String> {
 
 /// Exchange a GitHub App JWT for a short-lived installation access token.
 ///
-/// Uses `gh api` with the JWT as an explicit `Authorization: Bearer` header to
-/// call the `POST /app/installations/{installation_id}/access_tokens` endpoint.
-///
-/// Note: `GH_TOKEN` / `--auth-token` make `gh` send `Authorization: token <value>`,
-/// which is the PAT format. GitHub App JWT auth requires `Authorization: Bearer <jwt>`,
-/// so we override the header directly.
+/// Makes a direct HTTPS request to the GitHub API instead of using `gh api`,
+/// so that the JWT is kept in memory and never exposed as a command-line
+/// argument (which would be visible to other processes via `ps`/`/proc`).
 fn exchange_installation_token(app_config: &GitHubAppConfig, jwt: &str) -> Result<String> {
     let url = format!(
-        "app/installations/{}/access_tokens",
+        "https://api.github.com/app/installations/{}/access_tokens",
         app_config.installation_id
     );
 
-    let auth_header = format!("Authorization: Bearer {jwt}");
-    let output =
-        crate::github::build_gh_cmd(&["api", "--method", "POST", "-H", &auth_header, &url], None)
-            .output()
-            .map_err(|e| {
-                ConductorError::TicketSync(format!(
-                    "failed to exchange GitHub App installation token: {e}"
-                ))
-            })?;
+    let resp = ureq::post(&url)
+        .set("Authorization", &format!("Bearer {jwt}"))
+        .set("Accept", "application/vnd.github+json")
+        .set("X-GitHub-Api-Version", "2022-11-28")
+        .set("User-Agent", "conductor-ai")
+        .call()
+        .map_err(|e| {
+            ConductorError::TicketSync(format!("GitHub App token exchange failed: {e}"))
+        })?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(ConductorError::TicketSync(format!(
-            "GitHub App token exchange failed: {stderr}"
-        )));
-    }
-
-    let resp: InstallationTokenResponse = serde_json::from_slice(&output.stdout).map_err(|e| {
+    let token_resp: InstallationTokenResponse = resp.into_json().map_err(|e| {
         ConductorError::TicketSync(format!("failed to parse installation token response: {e}"))
     })?;
 
-    Ok(resp.token)
+    Ok(token_resp.token)
 }
 
 /// Obtain a GitHub App installation token, if configured.


### PR DESCRIPTION
Replace gh api subprocess call with direct HTTPS request to
github.com/api/github so the JWT is kept in memory and never exposed
as a command-line argument (visible via ps/proc). Uses ureq crate
for sync HTTPS requests, maintaining the library-first sync design.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
