### PR TITLE
fix: replace eprintln! with tracing macros in file_off_diff_issues

### DIFF
--- a/conductor-core/src/pr_review.rs
+++ b/conductor-core/src/pr_review.rs
@@ -748,9 +748,10 @@ fn file_off_diff_issues(
             app_token,
         ) {
             Ok((_number, url)) => {
-                eprintln!(
-                    "[review-swarm] Filed off-diff issue '{}': {}",
-                    finding.title, url
+                tracing::info!(
+                    title = %finding.title,
+                    url = %url,
+                    "[review-swarm] Filed off-diff issue"
                 );
                 filed.push(FiledIssue {
                     finding: finding.clone(),
@@ -758,9 +759,10 @@ fn file_off_diff_issues(
                 });
             }
             Err(e) => {
-                eprintln!(
-                    "[review-swarm] Failed to file off-diff issue '{}': {e}",
-                    finding.title
+                tracing::warn!(
+                    title = %finding.title,
+                    error = %e,
+                    "[review-swarm] Failed to file off-diff issue"
                 );
             }
         }


### PR DESCRIPTION
Replace direct stderr writes with tracing::info! for successful issue filing
and tracing::warn! for failures, using structured logging fields. Aligns with
the project's preference for tracing macros in conductor-core library code.

Fixes #371.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
