### PR TITLE
docs: add known limitations section to ROADMAP

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,6 +33,12 @@ High value but require more design and implementation work.
 | 9 | [#142](https://github.com/devinrosen/conductor-ai/issues/142) | Cost budgeting and spending limits per run, campaign, and repo | Safety net before running workflows at scale |
 | 10 | [#144](https://github.com/devinrosen/conductor-ai/issues/144) | Cost analytics dashboard — spend over time by repo | Do after #142 |
 
+## Known Limitations
+
+| Area | Limitation | Details |
+|------|-----------|---------|
+| GitHub sync | Sub-issues not supported | Ticket sync uses `gh issue list` which returns a flat list. GitHub sub-issues (parent/child relationships) require the GraphQL API and are not yet pulled in. |
+
 ## Deferred — Phase 5
 
 | Issue | Title | Notes |


### PR DESCRIPTION
## Summary
- Adds a "Known Limitations" section to `docs/ROADMAP.md`
- Documents that GitHub sub-issues (parent/child relationships) are not supported since `gh issue list` returns a flat list

## Test plan
- [ ] Docs-only change, no CI impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)