### PR TITLE
fix: TUI should redraw on every tick and poll workflows unconditionally

### DIFF
--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -215,12 +215,14 @@ impl App {
         match action {
             Action::None => return false,
             Action::Tick => {
-                // On workflow views, poll workflow data asynchronously
-                // to avoid blocking the main loop with FS + DB I/O.
-                if matches!(self.state.view, View::Workflows | View::WorkflowRunDetail) {
-                    self.poll_workflow_data_async();
-                }
-                return false;
+                // Poll workflow data asynchronously on every tick so the global
+                // status bar (and workflow views) stay current regardless of which
+                // view is active.
+                self.poll_workflow_data_async();
+                // Always redraw on tick so elapsed times, spinners, and other
+                // time-sensitive indicators update smoothly (ratatui diffs cells,
+                // so this is cheap).
+                return true;
             }
             Action::Quit => self.state.should_quit = true,
 


### PR DESCRIPTION
The Tick handler was returning false (no redraw) and conditionally polling
workflow data only on Workflows/WorkflowRunDetail views. This caused:

1. UI frozen between user input and 5s DB polls — elapsed times and spinners
   don't update smoothly
2. Global status bar (#389) stale when viewing other panels — workflow/agent
   data only refreshes when switching views or on DB poll

Fixed by:
1. Return true from Action::Tick so UI redraws every 200ms (ratatui's cell
   diffing makes this cheap)
2. Poll workflow data on every tick unconditionally so the global status bar
   stays current regardless of active view

This fixes #392 and ensures indicators like elapsed times and agent spinners
update smoothly in real time.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
