### PR TITLE
fix: web UI should filter to active worktrees only, matching TUI behavior (#394)

### DIFF
--- a/conductor-web/src/routes/worktrees.rs
+++ b/conductor-web/src/routes/worktrees.rs
@@ -38,7 +38,7 @@ pub async fn list_worktrees(
     // Verify repo exists
     RepoManager::new(&db, &config).get_by_id(&repo_id)?;
     let mgr = WorktreeManager::new(&db, &config);
-    let worktrees = mgr.list_by_repo_id(&repo_id, false)?;
+    let worktrees = mgr.list_by_repo_id(&repo_id, true)?;
     Ok(Json(worktrees))
 }
 


### PR DESCRIPTION
Changed list_by_repo_id(&repo_id, false) to list_by_repo_id(&repo_id, true)
in the web API's list_worktrees handler to exclude merged and abandoned
worktrees, providing consistency with the TUI implementation.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
