### PR TITLE
fix: reap stale git worktrees and set completed_at on merge-queue close (#414)

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -648,97 +648,112 @@ fn main() -> Result<()> {
                 }
             }
         },
-        Commands::Worktree { command } => match command {
-            WorktreeCommands::Create {
-                repo,
-                name,
-                from,
-                ticket,
-                auto_agent,
-            } => {
-                let mgr = WorktreeManager::new(&conn, &config);
-                let (wt, warnings) =
-                    mgr.create(&repo, &name, from.as_deref(), ticket.as_deref())?;
-                for warning in &warnings {
-                    eprintln!("warning: {warning}");
-                }
-                println!("Created worktree: {} ({})", wt.slug, wt.branch);
-                println!("  Path: {}", wt.path);
+        Commands::Worktree { command } => {
+            // Reap stale worktrees before handling any worktree command.
+            {
+                let wt_mgr = WorktreeManager::new(&conn, &config);
+                let _ = wt_mgr.reap_stale_worktrees();
+            }
+            match command {
+                WorktreeCommands::Create {
+                    repo,
+                    name,
+                    from,
+                    ticket,
+                    auto_agent,
+                } => {
+                    let mgr = WorktreeManager::new(&conn, &config);
+                    let (wt, warnings) =
+                        mgr.create(&repo, &name, from.as_deref(), ticket.as_deref())?;
+                    for warning in &warnings {
+                        eprintln!("warning: {warning}");
+                    }
+                    println!("Created worktree: {} ({})", wt.slug, wt.branch);
+                    println!("  Path: {}", wt.path);
 
-                if auto_agent {
-                    if let Some(ref tid) = ticket {
-                        let syncer = TicketSyncer::new(&conn);
-                        match syncer.get_by_id(tid) {
-                            Ok(t) => {
-                                let prompt = build_agent_prompt(&t);
-                                println!("Starting agent...");
-                                // Resolve model: per-worktree → per-repo → global config
-                                let repo_mgr = RepoManager::new(&conn, &config);
-                                let repo_model =
-                                    repo_mgr.get_by_slug(&repo).ok().and_then(|r| r.model);
-                                let model = wt
-                                    .model
-                                    .as_deref()
-                                    .or(repo_model.as_deref())
-                                    .or(config.general.model.as_deref());
-                                let agent_mgr = AgentManager::new(&conn);
-                                let run =
-                                    agent_mgr.create_run(&wt.id, &prompt, Some(&wt.slug), model)?;
-                                run_agent(&conn, &run.id, &wt.path, &prompt, None, model)?;
+                    if auto_agent {
+                        if let Some(ref tid) = ticket {
+                            let syncer = TicketSyncer::new(&conn);
+                            match syncer.get_by_id(tid) {
+                                Ok(t) => {
+                                    let prompt = build_agent_prompt(&t);
+                                    println!("Starting agent...");
+                                    // Resolve model: per-worktree → per-repo → global config
+                                    let repo_mgr = RepoManager::new(&conn, &config);
+                                    let repo_model =
+                                        repo_mgr.get_by_slug(&repo).ok().and_then(|r| r.model);
+                                    let model = wt
+                                        .model
+                                        .as_deref()
+                                        .or(repo_model.as_deref())
+                                        .or(config.general.model.as_deref());
+                                    let agent_mgr = AgentManager::new(&conn);
+                                    let run = agent_mgr.create_run(
+                                        &wt.id,
+                                        &prompt,
+                                        Some(&wt.slug),
+                                        model,
+                                    )?;
+                                    run_agent(&conn, &run.id, &wt.path, &prompt, None, model)?;
+                                }
+                                Err(e) => {
+                                    eprintln!(
+                                        "Warning: could not load ticket for agent prompt: {e}"
+                                    );
+                                }
                             }
-                            Err(e) => {
-                                eprintln!("Warning: could not load ticket for agent prompt: {e}");
-                            }
+                        } else {
+                            eprintln!("Warning: --auto-agent requires --ticket to be set");
                         }
+                    }
+                }
+                WorktreeCommands::List { repo } => {
+                    let mgr = WorktreeManager::new(&conn, &config);
+                    let worktrees = mgr.list(repo.as_deref(), false)?;
+                    if worktrees.is_empty() {
+                        println!("No worktrees.");
                     } else {
-                        eprintln!("Warning: --auto-agent requires --ticket to be set");
+                        for wt in worktrees {
+                            println!("  {}  {}  [{}]", wt.slug, wt.branch, wt.status);
+                        }
+                    }
+                }
+                WorktreeCommands::Delete { repo, name } => {
+                    let mgr = WorktreeManager::new(&conn, &config);
+                    let wt = mgr.delete(&repo, &name)?;
+                    println!("Worktree {name} marked as {} ✓", wt.status);
+                }
+                WorktreeCommands::Purge { repo, name } => {
+                    let mgr = WorktreeManager::new(&conn, &config);
+                    let count = mgr.purge(&repo, name.as_deref())?;
+                    if count == 0 {
+                        println!("No completed worktrees to purge.");
+                    } else {
+                        println!("Purged {count} completed worktree record(s).");
+                    }
+                }
+                WorktreeCommands::Push { repo, name } => {
+                    let mgr = WorktreeManager::new(&conn, &config);
+                    let msg = mgr.push(&repo, &name)?;
+                    println!("{msg}");
+                }
+                WorktreeCommands::Pr { repo, name, draft } => {
+                    let mgr = WorktreeManager::new(&conn, &config);
+                    let url = mgr.create_pr(&repo, &name, draft)?;
+                    println!("PR created: {url}");
+                }
+                WorktreeCommands::SetModel { repo, name, model } => {
+                    let mgr = WorktreeManager::new(&conn, &config);
+                    mgr.set_model(&repo, &name, model.as_deref())?;
+                    match model {
+                        Some(m) => println!("Set model for {name} to: {m}"),
+                        None => {
+                            println!("Cleared model override for {name} (will use global default)")
+                        }
                     }
                 }
             }
-            WorktreeCommands::List { repo } => {
-                let mgr = WorktreeManager::new(&conn, &config);
-                let worktrees = mgr.list(repo.as_deref(), false)?;
-                if worktrees.is_empty() {
-                    println!("No worktrees.");
-                } else {
-                    for wt in worktrees {
-                        println!("  {}  {}  [{}]", wt.slug, wt.branch, wt.status);
-                    }
-                }
-            }
-            WorktreeCommands::Delete { repo, name } => {
-                let mgr = WorktreeManager::new(&conn, &config);
-                let wt = mgr.delete(&repo, &name)?;
-                println!("Worktree {name} marked as {} ✓", wt.status);
-            }
-            WorktreeCommands::Purge { repo, name } => {
-                let mgr = WorktreeManager::new(&conn, &config);
-                let count = mgr.purge(&repo, name.as_deref())?;
-                if count == 0 {
-                    println!("No completed worktrees to purge.");
-                } else {
-                    println!("Purged {count} completed worktree record(s).");
-                }
-            }
-            WorktreeCommands::Push { repo, name } => {
-                let mgr = WorktreeManager::new(&conn, &config);
-                let msg = mgr.push(&repo, &name)?;
-                println!("{msg}");
-            }
-            WorktreeCommands::Pr { repo, name, draft } => {
-                let mgr = WorktreeManager::new(&conn, &config);
-                let url = mgr.create_pr(&repo, &name, draft)?;
-                println!("PR created: {url}");
-            }
-            WorktreeCommands::SetModel { repo, name, model } => {
-                let mgr = WorktreeManager::new(&conn, &config);
-                mgr.set_model(&repo, &name, model.as_deref())?;
-                match model {
-                    Some(m) => println!("Set model for {name} to: {m}"),
-                    None => println!("Cleared model override for {name} (will use global default)"),
-                }
-            }
-        },
+        }
         Commands::Agent { command } => {
             // Reap orphaned runs before handling any agent command.
             {

--- a/conductor-core/src/tickets.rs
+++ b/conductor-core/src/tickets.rs
@@ -242,13 +242,14 @@ impl<'a> TicketSyncer<'a> {
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )?;
 
+        let now = Utc::now().to_rfc3339();
         let count = self.conn.execute(
-            "UPDATE worktrees SET status = 'merged'
+            "UPDATE worktrees SET status = 'merged', completed_at = ?2
              WHERE repo_id = ?1
              AND status != 'merged'
              AND ticket_id IS NOT NULL
              AND ticket_id IN (SELECT id FROM tickets WHERE state = 'closed')",
-            params![repo_id],
+            params![repo_id, now],
         )?;
 
         for (repo_path, worktree_path, branch) in artifacts {
@@ -686,6 +687,48 @@ mod tests {
         let count = syncer.mark_worktrees_for_closed_tickets("r1").unwrap();
         assert_eq!(count, 1);
         assert_eq!(get_worktree_status(&conn, "wt1"), "merged");
+    }
+
+    #[test]
+    fn test_mark_worktrees_sets_completed_at() {
+        let conn = setup_db();
+        let syncer = TicketSyncer::new(&conn);
+
+        let tickets = vec![make_ticket("1", "Issue 1")];
+        syncer.upsert_tickets("r1", &tickets).unwrap();
+        let ticket_id: String = conn
+            .query_row("SELECT id FROM tickets WHERE source_id = '1'", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        insert_worktree(&conn, "wt1", "r1", Some(&ticket_id), "active");
+
+        // Verify completed_at starts as NULL
+        let before: Option<String> = conn
+            .query_row(
+                "SELECT completed_at FROM worktrees WHERE id = 'wt1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(before.is_none());
+
+        syncer
+            .close_missing_tickets("r1", "github", &["999"])
+            .unwrap();
+        syncer.mark_worktrees_for_closed_tickets("r1").unwrap();
+
+        let after: Option<String> = conn
+            .query_row(
+                "SELECT completed_at FROM worktrees WHERE id = 'wt1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            after.is_some(),
+            "completed_at must be set when marking as merged"
+        );
     }
 
     #[test]

--- a/conductor-core/src/worktree.rs
+++ b/conductor-core/src/worktree.rs
@@ -472,6 +472,72 @@ impl<'a> WorktreeManager<'a> {
         Ok((repo, worktree))
     }
 
+    /// Reap stale worktrees whose status is `merged` or `abandoned` but whose
+    /// filesystem artifacts still exist. For each stale worktree:
+    /// 1. Remove git worktree directory and branch (best-effort)
+    /// 2. Run `git worktree prune` on the parent repo
+    /// 3. Backfill `completed_at` if NULL
+    ///
+    /// Returns the number of worktrees cleaned up.
+    pub fn reap_stale_worktrees(&self) -> Result<usize> {
+        let stale: Vec<(String, String, String, String, Option<String>)> = query_collect(
+            self.conn,
+            "SELECT w.id, r.local_path, w.path, w.branch, w.completed_at
+             FROM worktrees w
+             JOIN repos r ON r.id = w.repo_id
+             WHERE w.status IN ('merged', 'abandoned')",
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )?;
+
+        let mut reaped = 0;
+        let mut pruned_repos = std::collections::HashSet::new();
+
+        for (wt_id, repo_path, wt_path, branch, completed_at) in &stale {
+            if !Path::new(wt_path).exists() {
+                // Backfill completed_at if missing even when path is already gone
+                if completed_at.is_none() {
+                    let now = Utc::now().to_rfc3339();
+                    self.conn.execute(
+                        "UPDATE worktrees SET completed_at = ?1 WHERE id = ?2 AND completed_at IS NULL",
+                        params![now, wt_id],
+                    )?;
+                    reaped += 1;
+                }
+                continue;
+            }
+
+            remove_git_artifacts(repo_path, wt_path, branch);
+            pruned_repos.insert(repo_path.clone());
+
+            // Backfill completed_at if NULL
+            if completed_at.is_none() {
+                let now = Utc::now().to_rfc3339();
+                self.conn.execute(
+                    "UPDATE worktrees SET completed_at = ?1 WHERE id = ?2 AND completed_at IS NULL",
+                    params![now, wt_id],
+                )?;
+            }
+
+            reaped += 1;
+        }
+
+        // Run git worktree prune on each affected repo
+        for repo_path in &pruned_repos {
+            let _ = git_in(repo_path).args(["worktree", "prune"]).output();
+        }
+
+        Ok(reaped)
+    }
+
     /// Permanently delete completed (merged/abandoned) worktree records from the database.
     pub fn purge(&self, repo_slug: &str, name: Option<&str>) -> Result<usize> {
         let repo_mgr = RepoManager::new(self.conn, self.config);
@@ -1174,5 +1240,135 @@ mod tests {
 
         assert!(logs_contain("git worktree remove failed"));
         assert!(logs_contain("git branch -D failed"));
+    }
+
+    #[test]
+    fn test_reap_stale_worktrees_backfills_completed_at() {
+        let conn = crate::test_helpers::setup_db();
+        let config = Config::default();
+        // Insert a merged worktree with no completed_at and a nonexistent path
+        conn.execute(
+            "INSERT INTO worktrees (id, repo_id, slug, branch, path, status, created_at) \
+             VALUES ('wt-stale', 'r1', 'feat-stale', 'feat/stale', '/nonexistent/stale-wt', 'merged', '2024-01-01T00:00:00Z')",
+            [],
+        ).unwrap();
+
+        let mgr = WorktreeManager::new(&conn, &config);
+        let reaped = mgr.reap_stale_worktrees().unwrap();
+        assert_eq!(reaped, 1);
+
+        // completed_at should now be set
+        let completed_at: Option<String> = conn
+            .query_row(
+                "SELECT completed_at FROM worktrees WHERE id = 'wt-stale'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(completed_at.is_some());
+    }
+
+    #[test]
+    fn test_reap_stale_worktrees_skips_active() {
+        let conn = crate::test_helpers::setup_db();
+        let config = Config::default();
+        // w1 from setup_db is active — should not be reaped
+        let mgr = WorktreeManager::new(&conn, &config);
+        let reaped = mgr.reap_stale_worktrees().unwrap();
+        assert_eq!(reaped, 0);
+    }
+
+    #[test]
+    fn test_reap_stale_worktrees_skips_already_completed() {
+        let conn = crate::test_helpers::setup_db();
+        let config = Config::default();
+        // Insert a merged worktree that already has completed_at and nonexistent path
+        conn.execute(
+            "INSERT INTO worktrees (id, repo_id, slug, branch, path, status, created_at, completed_at) \
+             VALUES ('wt-done', 'r1', 'feat-done', 'feat/done', '/nonexistent/done-wt', 'merged', '2024-01-01T00:00:00Z', '2024-02-01T00:00:00Z')",
+            [],
+        ).unwrap();
+
+        let mgr = WorktreeManager::new(&conn, &config);
+        let reaped = mgr.reap_stale_worktrees().unwrap();
+        // Path doesn't exist and completed_at is already set → not reaped
+        assert_eq!(reaped, 0);
+    }
+
+    #[test]
+    fn test_reap_stale_worktrees_removes_existing_path() {
+        let conn = crate::test_helpers::setup_db();
+        let config = Config::default();
+        let (_tmp, _, local) = setup_repo_with_remote();
+        let local_str = local.to_str().unwrap();
+
+        // Update repo to use real local path
+        conn.execute(
+            "UPDATE repos SET local_path = ?1 WHERE id = 'r1'",
+            params![local_str],
+        )
+        .unwrap();
+
+        // Create a real worktree
+        let wt_path = local.parent().unwrap().join("stale-wt");
+        git(&["branch", "feat/stale-wt"], &local);
+        git(
+            &[
+                "worktree",
+                "add",
+                &wt_path.to_string_lossy(),
+                "feat/stale-wt",
+            ],
+            &local,
+        );
+        assert!(wt_path.exists());
+
+        // Insert as merged with no completed_at
+        conn.execute(
+            "INSERT INTO worktrees (id, repo_id, slug, branch, path, status, created_at) \
+             VALUES ('wt-real', 'r1', 'feat-stale-wt', 'feat/stale-wt', ?1, 'merged', '2024-01-01T00:00:00Z')",
+            params![wt_path.to_str().unwrap()],
+        ).unwrap();
+
+        let mgr = WorktreeManager::new(&conn, &config);
+        let reaped = mgr.reap_stale_worktrees().unwrap();
+        assert_eq!(reaped, 1);
+
+        // Worktree directory should be removed
+        assert!(!wt_path.exists());
+
+        // completed_at should be backfilled
+        let completed_at: Option<String> = conn
+            .query_row(
+                "SELECT completed_at FROM worktrees WHERE id = 'wt-real'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(completed_at.is_some());
+    }
+
+    #[test]
+    fn test_reap_stale_worktrees_handles_abandoned() {
+        let conn = crate::test_helpers::setup_db();
+        let config = Config::default();
+        conn.execute(
+            "INSERT INTO worktrees (id, repo_id, slug, branch, path, status, created_at) \
+             VALUES ('wt-aband', 'r1', 'feat-aband', 'feat/aband', '/nonexistent/aband-wt', 'abandoned', '2024-01-01T00:00:00Z')",
+            [],
+        ).unwrap();
+
+        let mgr = WorktreeManager::new(&conn, &config);
+        let reaped = mgr.reap_stale_worktrees().unwrap();
+        assert_eq!(reaped, 1);
+
+        let completed_at: Option<String> = conn
+            .query_row(
+                "SELECT completed_at FROM worktrees WHERE id = 'wt-aband'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(completed_at.is_some());
     }
 }

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -40,7 +40,8 @@ pub fn poll_data() -> Option<Action> {
     let ticket_syncer = TicketSyncer::new(&conn);
     let agent_mgr = AgentManager::new(&conn);
 
-    // Reap orphaned runs whose tmux windows have disappeared.
+    // Reap orphaned runs whose tmux windows have disappeared and clean up
+    // stale worktrees whose artifacts persist on disk after merge/abandon.
     // Throttle to at most once every 30 seconds to avoid spawning tmux
     // subprocesses on every poll tick.
     {
@@ -52,6 +53,7 @@ pub fn poll_data() -> Option<Action> {
         if now - LAST_REAP.load(Ordering::Relaxed) >= 30 {
             LAST_REAP.store(now, Ordering::Relaxed);
             let _ = agent_mgr.reap_orphaned_runs();
+            let _ = wt_mgr.reap_stale_worktrees();
         }
     }
 

--- a/conductor-web/src/main.rs
+++ b/conductor-web/src/main.rs
@@ -28,25 +28,41 @@ async fn main() -> Result<()> {
         }
     }
 
+    // Reap stale worktrees on startup.
+    {
+        use conductor_core::worktree::WorktreeManager;
+        let wt_mgr = WorktreeManager::new(&conn, &config);
+        if let Ok(n) = wt_mgr.reap_stale_worktrees() {
+            if n > 0 {
+                tracing::info!("Reaped {n} stale worktree(s) on startup");
+            }
+        }
+    }
+
     let state = AppState {
         db: Arc::new(Mutex::new(conn)),
         config: Arc::new(RwLock::new(config)),
         events: EventBus::new(64),
     };
 
-    // Spawn a background task that periodically reaps orphaned runs.
-    // Uses spawn_blocking to avoid blocking the tokio runtime with
-    // synchronous DB queries and tmux subprocess calls.
+    // Spawn a background task that periodically reaps orphaned runs and
+    // stale worktrees. Uses spawn_blocking to avoid blocking the tokio
+    // runtime with synchronous DB queries and subprocess calls.
     let reaper_state = state.clone();
+    let reaper_config = state.config.clone();
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
         loop {
             interval.tick().await;
             let db = reaper_state.db.clone();
+            let cfg = reaper_config.clone();
             let _ = tokio::task::spawn_blocking(move || {
                 let conn = db.blocking_lock();
                 let mgr = AgentManager::new(&conn);
-                mgr.reap_orphaned_runs()
+                mgr.reap_orphaned_runs()?;
+                let cfg = cfg.blocking_read();
+                let wt_mgr = conductor_core::worktree::WorktreeManager::new(&conn, &cfg);
+                wt_mgr.reap_stale_worktrees()
             })
             .await;
         }


### PR DESCRIPTION
Two bugs fixed:

1. `mark_worktrees_for_closed_tickets` never set `completed_at`, leaving
   it NULL in the DB even after setting `status = 'merged'`. The UPDATE
   now sets both fields, matching the `delete_internal` pattern.

2. `remove_artifacts` failures were silently swallowed with no retry.
   A new `WorktreeManager::reap_stale_worktrees()` method queries all
   `merged`/`abandoned` worktrees, removes any that still exist on disk
   via `remove_git_artifacts` + `git worktree prune`, and backfills
   `completed_at` if NULL — mirroring `AgentManager::reap_orphaned_runs`
   from #277.

Integration points:
- TUI: throttled call (30s) in `poll_data()` alongside agent reaper
- Web: startup call + 30s periodic tokio task
- CLI: called before handling any worktree subcommand

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
