### PR TITLE
fix: ticket list selection off-by-one when filter or closed-hiding is active (#415)

### DIFF
--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -273,8 +273,14 @@ impl App {
 
             // Filter
             Action::EnterFilter => self.state.active_filter_mut().enter(),
-            Action::FilterChar(c) => self.state.active_filter_mut().push(c),
-            Action::FilterBackspace => self.state.active_filter_mut().backspace(),
+            Action::FilterChar(c) => {
+                self.state.active_filter_mut().push(c);
+                self.state.rebuild_filtered_tickets();
+            }
+            Action::FilterBackspace => {
+                self.state.active_filter_mut().backspace();
+                self.state.rebuild_filtered_tickets();
+            }
             Action::ExitFilter => self.state.active_filter_mut().exit(),
 
             // Modal
@@ -389,6 +395,7 @@ impl App {
             // Ticket closed visibility toggle
             Action::ToggleClosedTickets => {
                 self.state.show_closed_tickets = !self.state.show_closed_tickets;
+                self.state.rebuild_filtered_tickets();
                 // Reset selection indices so they don't point past the filtered list
                 self.state.ticket_index = 0;
                 self.state.detail_ticket_index = 0;
@@ -549,6 +556,7 @@ impl App {
                 self.refresh_pending_feedback();
                 self.state.data.rebuild_maps();
                 self.reload_agent_events();
+                self.state.rebuild_filtered_tickets();
                 self.clamp_indices();
                 // Redraw when viewing worktree detail / workflows, or on the
                 // dashboard (which now has a live workflow panel).
@@ -621,10 +629,9 @@ impl App {
 
         self.state.data.rebuild_maps();
         self.reload_agent_events();
-        self.clamp_indices();
 
-        // If in repo detail, refresh scoped data
-        if let Some(ref repo_id) = self.state.selected_repo_id {
+        // If in repo detail, refresh scoped data before rebuilding filtered vecs
+        if let Some(ref repo_id) = self.state.selected_repo_id.clone() {
             self.state.detail_worktrees = self
                 .state
                 .data
@@ -642,6 +649,9 @@ impl App {
                 .cloned()
                 .collect();
         }
+
+        self.state.rebuild_filtered_tickets();
+        self.clamp_indices();
     }
 
     fn reload_agent_events(&mut self) {
@@ -770,9 +780,14 @@ impl App {
             self.state.worktree_index = wt_len - 1;
         }
 
-        let t_len = self.state.data.tickets.len();
+        let t_len = self.state.filtered_tickets.len();
         if t_len > 0 && self.state.ticket_index >= t_len {
             self.state.ticket_index = t_len - 1;
+        }
+
+        let dt_len = self.state.filtered_detail_tickets.len();
+        if dt_len > 0 && self.state.detail_ticket_index >= dt_len {
+            self.state.detail_ticket_index = dt_len - 1;
         }
     }
 
@@ -1015,7 +1030,10 @@ impl App {
                     );
                 }
                 DashboardFocus::Tickets => {
-                    clamp_increment(&mut self.state.ticket_index, self.state.data.tickets.len());
+                    clamp_increment(
+                        &mut self.state.ticket_index,
+                        self.state.filtered_tickets.len(),
+                    );
                 }
             },
             View::RepoDetail => match self.state.repo_detail_focus {
@@ -1028,12 +1046,15 @@ impl App {
                 RepoDetailFocus::Tickets => {
                     clamp_increment(
                         &mut self.state.detail_ticket_index,
-                        self.state.detail_tickets.len(),
+                        self.state.filtered_detail_tickets.len(),
                     );
                 }
             },
             View::Tickets => {
-                clamp_increment(&mut self.state.ticket_index, self.state.data.tickets.len());
+                clamp_increment(
+                    &mut self.state.ticket_index,
+                    self.state.filtered_tickets.len(),
+                );
             }
             View::Workflows => match self.state.workflows_focus {
                 WorkflowsFocus::Defs => {
@@ -1088,6 +1109,7 @@ impl App {
                             .collect();
                         self.state.detail_wt_index = 0;
                         self.state.detail_ticket_index = 0;
+                        self.state.rebuild_filtered_tickets();
                         self.state.repo_detail_focus = RepoDetailFocus::Worktrees;
                         self.state.view = View::RepoDetail;
                     }
@@ -1103,7 +1125,7 @@ impl App {
                     }
                 }
                 DashboardFocus::Tickets => {
-                    if let Some(ticket) = self.state.data.tickets.get(self.state.ticket_index) {
+                    if let Some(ticket) = self.state.filtered_tickets.get(self.state.ticket_index) {
                         self.state.modal = Modal::TicketInfo {
                             ticket: Box::new(ticket.clone()),
                         };
@@ -1123,7 +1145,7 @@ impl App {
                 RepoDetailFocus::Tickets => {
                     if let Some(ticket) = self
                         .state
-                        .detail_tickets
+                        .filtered_detail_tickets
                         .get(self.state.detail_ticket_index)
                     {
                         self.state.modal = Modal::TicketInfo {
@@ -1133,7 +1155,7 @@ impl App {
                 }
             },
             View::Tickets => {
-                if let Some(ticket) = self.state.data.tickets.get(self.state.ticket_index) {
+                if let Some(ticket) = self.state.filtered_tickets.get(self.state.ticket_index) {
                     self.state.modal = Modal::TicketInfo {
                         ticket: Box::new(ticket.clone()),
                     };
@@ -1853,19 +1875,17 @@ impl App {
         let ticket_context = match self.state.view {
             View::Dashboard if self.state.dashboard_focus == DashboardFocus::Tickets => self
                 .state
-                .data
-                .tickets
+                .filtered_tickets
                 .get(self.state.ticket_index)
                 .cloned(),
             View::RepoDetail if self.state.repo_detail_focus == RepoDetailFocus::Tickets => self
                 .state
-                .detail_tickets
+                .filtered_detail_tickets
                 .get(self.state.detail_ticket_index)
                 .cloned(),
             View::Tickets => self
                 .state
-                .data
-                .tickets
+                .filtered_tickets
                 .get(self.state.ticket_index)
                 .cloned(),
             _ => None,

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -571,6 +571,10 @@ pub struct AppState {
     pub detail_wt_index: usize,
     pub detail_ticket_index: usize,
 
+    // Pre-filtered ticket lists (closed + text filter applied); index into these for nav/actions
+    pub filtered_tickets: Vec<Ticket>,
+    pub filtered_detail_tickets: Vec<Ticket>,
+
     // Agent activity list navigation (replaces the old Paragraph scroll offset)
     pub agent_list_state: RefCell<ListState>,
     /// Tracks pending `g` keypress for `gg` chord (go to top)
@@ -624,6 +628,8 @@ impl AppState {
             detail_tickets: Vec::new(),
             detail_wt_index: 0,
             detail_ticket_index: 0,
+            filtered_tickets: Vec::new(),
+            filtered_detail_tickets: Vec::new(),
             agent_list_state: RefCell::new(ListState::default()),
             pending_g: false,
             filter: FilterState::default(),
@@ -762,23 +768,55 @@ impl AppState {
         }
     }
 
+    /// Rebuild the pre-filtered ticket vecs from the current source data,
+    /// `show_closed_tickets`, and the active text filters.  Must be called
+    /// whenever any of those inputs change.
+    pub fn rebuild_filtered_tickets(&mut self) {
+        let filter_query = self.filter.as_query();
+        self.filtered_tickets = self
+            .data
+            .tickets
+            .iter()
+            .filter(|t| self.show_closed_tickets || t.state != "closed")
+            .filter(|t| match filter_query.as_deref() {
+                Some(f) if !f.is_empty() => t.matches_filter(f),
+                _ => true,
+            })
+            .cloned()
+            .collect();
+
+        let detail_filter_query = self.detail_ticket_filter.as_query();
+        self.filtered_detail_tickets = self
+            .detail_tickets
+            .iter()
+            .filter(|t| self.show_closed_tickets || t.state != "closed")
+            .filter(|t| match detail_filter_query.as_deref() {
+                Some(f) if !f.is_empty() => t.matches_filter(f),
+                _ => true,
+            })
+            .cloned()
+            .collect();
+    }
+
     /// Returns (current_index, list_length) for the currently focused pane.
     pub fn focused_index_and_len(&self) -> (usize, usize) {
         match self.view {
             View::Dashboard => match self.dashboard_focus {
                 DashboardFocus::Repos => (self.repo_index, self.data.repos.len()),
                 DashboardFocus::Worktrees => (self.worktree_index, self.data.worktrees.len()),
-                DashboardFocus::Tickets => (self.ticket_index, self.data.tickets.len()),
+                DashboardFocus::Tickets => (self.ticket_index, self.filtered_tickets.len()),
             },
             View::RepoDetail => match self.repo_detail_focus {
                 RepoDetailFocus::Worktrees => (self.detail_wt_index, self.detail_worktrees.len()),
-                RepoDetailFocus::Tickets => (self.detail_ticket_index, self.detail_tickets.len()),
+                RepoDetailFocus::Tickets => {
+                    (self.detail_ticket_index, self.filtered_detail_tickets.len())
+                }
             },
             View::WorktreeDetail => {
                 let idx = self.agent_list_state.borrow().selected().unwrap_or(0);
                 (idx, self.data.agent_activity_len())
             }
-            View::Tickets => (self.ticket_index, self.data.tickets.len()),
+            View::Tickets => (self.ticket_index, self.filtered_tickets.len()),
             View::Workflows => match self.workflows_focus {
                 WorkflowsFocus::Defs => (self.workflow_def_index, self.data.workflow_defs.len()),
                 WorkflowsFocus::Runs => (self.workflow_run_index, self.data.workflow_runs.len()),
@@ -1169,5 +1207,104 @@ mod tests {
             }
             _ => panic!("expected Agent item"),
         }
+    }
+
+    fn make_ticket(id: &str, state: &str) -> conductor_core::tickets::Ticket {
+        conductor_core::tickets::Ticket {
+            id: id.to_string(),
+            repo_id: "repo-1".to_string(),
+            source_type: "github".to_string(),
+            source_id: id.to_string(),
+            title: format!("Ticket {id}"),
+            body: String::new(),
+            state: state.to_string(),
+            labels: String::new(),
+            assignee: None,
+            priority: None,
+            url: String::new(),
+            synced_at: "2026-01-01T00:00:00Z".to_string(),
+            raw_json: String::new(),
+        }
+    }
+
+    #[test]
+    fn rebuild_filtered_tickets_hides_closed() {
+        let mut state = AppState::new();
+        state.data.tickets = vec![
+            make_ticket("1", "open"),
+            make_ticket("2", "closed"),
+            make_ticket("3", "open"),
+        ];
+        state.show_closed_tickets = false;
+        state.rebuild_filtered_tickets();
+        assert_eq!(state.filtered_tickets.len(), 2);
+        assert!(state.filtered_tickets.iter().all(|t| t.state != "closed"));
+    }
+
+    #[test]
+    fn rebuild_filtered_tickets_shows_closed_when_toggled() {
+        let mut state = AppState::new();
+        state.data.tickets = vec![
+            make_ticket("1", "open"),
+            make_ticket("2", "closed"),
+            make_ticket("3", "open"),
+        ];
+        state.show_closed_tickets = true;
+        state.rebuild_filtered_tickets();
+        assert_eq!(state.filtered_tickets.len(), 3);
+    }
+
+    #[test]
+    fn rebuild_filtered_tickets_applies_text_filter() {
+        let mut state = AppState::new();
+        state.data.tickets = vec![
+            make_ticket("1", "open"),
+            make_ticket("2", "open"),
+            make_ticket("3", "open"),
+        ];
+        state.show_closed_tickets = true;
+        state.filter.active = true;
+        state.filter.text = "Ticket 2".to_lowercase();
+        state.rebuild_filtered_tickets();
+        // Only ticket whose title contains "ticket 2"
+        assert_eq!(state.filtered_tickets.len(), 1);
+        assert_eq!(state.filtered_tickets[0].id, "2");
+    }
+
+    #[test]
+    fn rebuild_filtered_detail_tickets_independent_of_global() {
+        let mut state = AppState::new();
+        state.data.tickets = vec![make_ticket("1", "open"), make_ticket("2", "closed")];
+        // detail_tickets has different content
+        state.detail_tickets = vec![make_ticket("3", "open"), make_ticket("4", "closed")];
+        state.show_closed_tickets = false;
+        state.rebuild_filtered_tickets();
+        assert_eq!(state.filtered_tickets.len(), 1);
+        assert_eq!(state.filtered_detail_tickets.len(), 1);
+        assert_eq!(state.filtered_tickets[0].id, "1");
+        assert_eq!(state.filtered_detail_tickets[0].id, "3");
+    }
+
+    /// Regression: index into filtered list must match what's rendered.
+    /// Given [#1 open, #2 closed, #3 open] with closed hidden, ticket_index=1
+    /// should point to #3 (the 2nd visible item), not #2 (the 2nd raw item).
+    #[test]
+    fn filtered_tickets_index_matches_rendered_order() {
+        let mut state = AppState::new();
+        state.data.tickets = vec![
+            make_ticket("1", "open"),
+            make_ticket("2", "closed"),
+            make_ticket("3", "open"),
+            make_ticket("4", "open"),
+        ];
+        state.show_closed_tickets = false;
+        state.rebuild_filtered_tickets();
+        // filtered: [#1, #3, #4]
+        assert_eq!(state.filtered_tickets.len(), 3);
+        assert_eq!(state.filtered_tickets[0].id, "1");
+        assert_eq!(state.filtered_tickets[1].id, "3");
+        assert_eq!(state.filtered_tickets[2].id, "4");
+        // ticket_index=2 now correctly resolves to #4
+        assert_eq!(state.filtered_tickets[2].id, "4");
     }
 }

--- a/conductor-tui/src/ui/dashboard.rs
+++ b/conductor-tui/src/ui/dashboard.rs
@@ -137,14 +137,8 @@ fn render_tickets(frame: &mut Frame, area: Rect, state: &AppState) {
     };
 
     let items: Vec<ListItem> = state
-        .data
-        .tickets
+        .filtered_tickets
         .iter()
-        .filter(|t| state.show_closed_tickets || t.state != "closed")
-        .filter(|t| match state.filter.as_query().as_deref() {
-            Some(f) if !f.is_empty() => t.matches_filter(f),
-            _ => true,
-        })
         .map(|t| {
             let repo_slug = state
                 .data
@@ -199,7 +193,7 @@ fn render_tickets(frame: &mut Frame, area: Rect, state: &AppState) {
         .highlight_symbol("> ");
 
     let mut list_state = ListState::default();
-    if focused && !state.data.tickets.is_empty() {
+    if focused && !state.filtered_tickets.is_empty() {
         list_state.select(Some(state.ticket_index));
     }
 

--- a/conductor-tui/src/ui/repo_detail.rs
+++ b/conductor-tui/src/ui/repo_detail.rs
@@ -117,13 +117,8 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
     };
     let detail_filter = state.detail_ticket_filter.as_query();
     let ticket_items: Vec<ListItem> = state
-        .detail_tickets
+        .filtered_detail_tickets
         .iter()
-        .filter(|t| state.show_closed_tickets || t.state != "closed")
-        .filter(|t| match detail_filter.as_deref() {
-            Some(f) if !f.is_empty() => t.matches_filter(f),
-            _ => true,
-        })
         .map(|t| {
             let state_color = match t.state.as_str() {
                 "open" => Color::Green,
@@ -181,7 +176,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
         .highlight_symbol("> ");
 
     let mut ticket_state = ListState::default();
-    if ticket_focused && !state.detail_tickets.is_empty() {
+    if ticket_focused && !state.filtered_detail_tickets.is_empty() {
         ticket_state.select(Some(state.detail_ticket_index));
     }
     frame.render_stateful_widget(ticket_list, layout[2], &mut ticket_state);

--- a/conductor-tui/src/ui/tickets.rs
+++ b/conductor-tui/src/ui/tickets.rs
@@ -11,14 +11,8 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
     let filter = state.filter.as_query();
 
     let items: Vec<ListItem> = state
-        .data
-        .tickets
+        .filtered_tickets
         .iter()
-        .filter(|t| state.show_closed_tickets || t.state != "closed")
-        .filter(|t| match filter.as_deref() {
-            Some(f) if !f.is_empty() => t.matches_filter(f),
-            _ => true,
-        })
         .map(|t| {
             let repo_slug = state
                 .data
@@ -97,7 +91,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
         .highlight_symbol("> ");
 
     let mut list_state = ListState::default();
-    if !state.data.tickets.is_empty() {
+    if !state.filtered_tickets.is_empty() {
         list_state.select(Some(state.ticket_index));
     }
 


### PR DESCRIPTION
Navigation indices (ticket_index, detail_ticket_index) were bounded against
unfiltered lists but the UI rendered a filtered subset, causing the highlighted
row to diverge from the record that Enter/'c'/etc. operated on.

Pre-filter tickets into filtered_tickets / filtered_detail_tickets on every
data refresh, toggle, and filter-text change. Navigation, rendering, and action
handlers all index into these filtered vecs, matching what is actually visible.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
