### PR TITLE
refactor: add WorkflowStepStatus::short_label() to eliminate duplicated mapping

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -1420,17 +1420,7 @@ fn main() -> Result<()> {
                         if !steps.is_empty() {
                             println!("\nSteps:");
                             for step in &steps {
-                                let marker = match step.status {
-                                    conductor_core::workflow::WorkflowStepStatus::Completed => "ok",
-                                    conductor_core::workflow::WorkflowStepStatus::Failed => "FAIL",
-                                    conductor_core::workflow::WorkflowStepStatus::Skipped => "skip",
-                                    conductor_core::workflow::WorkflowStepStatus::Running => "...",
-                                    conductor_core::workflow::WorkflowStepStatus::Pending => "-",
-                                    conductor_core::workflow::WorkflowStepStatus::Waiting => "wait",
-                                    conductor_core::workflow::WorkflowStepStatus::TimedOut => {
-                                        "tout"
-                                    }
-                                };
+                                let marker = step.status.short_label();
                                 let commit_flag = if step.can_commit { " [commit]" } else { "" };
                                 let iter_label = if step.iteration > 0 {
                                     format!(" iter={}", step.iteration)

--- a/conductor-core/src/workflow.rs
+++ b/conductor-core/src/workflow.rs
@@ -240,6 +240,21 @@ impl std::fmt::Display for WorkflowStepStatus {
     }
 }
 
+impl WorkflowStepStatus {
+    /// Short display label used in summaries and status columns.
+    pub fn short_label(&self) -> &'static str {
+        match self {
+            Self::Completed => "ok",
+            Self::Failed => "FAIL",
+            Self::Skipped => "skip",
+            Self::Running => "...",
+            Self::Pending => "-",
+            Self::Waiting => "wait",
+            Self::TimedOut => "tout",
+        }
+    }
+}
+
 impl std::str::FromStr for WorkflowStepStatus {
     type Err = String;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
@@ -2623,15 +2638,7 @@ fn build_workflow_summary(state: &ExecutionState<'_>) -> String {
     ));
 
     for step in &steps {
-        let marker = match step.status {
-            WorkflowStepStatus::Completed => "ok",
-            WorkflowStepStatus::Failed => "FAIL",
-            WorkflowStepStatus::Skipped => "skip",
-            WorkflowStepStatus::Running => "...",
-            WorkflowStepStatus::Pending => "-",
-            WorkflowStepStatus::Waiting => "wait",
-            WorkflowStepStatus::TimedOut => "tout",
-        };
+        let marker = step.status.short_label();
         let iter_label = if step.iteration > 0 {
             format!(" (iter {})", step.iteration)
         } else {


### PR DESCRIPTION
Single-source the status-to-short-label mapping ("ok", "FAIL", "skip",
etc.) via a new `pub fn short_label(&self) -> &'static str` method on
WorkflowStepStatus, replacing identical match blocks in
build_workflow_summary (workflow.rs) and the CLI step display.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
