### PR TITLE
docs: Claude Agent SDK vs subprocess vs tmux research

### DIFF
--- a/docs/claude-agent-integration.md
+++ b/docs/claude-agent-integration.md
@@ -138,6 +138,112 @@ Each worktree can have its own agent running in a separate tmux window. The `lat
 
 ---
 
+## Research: Claude Agent SDK vs. Subprocess vs. tmux
+
+*Researched 2026-03-09*
+
+### What is the Claude Agent SDK?
+
+The Claude Agent SDK (Python/TypeScript) wraps the `claude` CLI's agent loop and exposes it programmatically. It handles the full tool execution loop automatically — Claude evaluates, calls tools, gets results, and repeats until done. Key features:
+
+- **Structured lifecycle**: `ResultMessage.subtype` gives clean `success` / `error_max_turns` / `error_during_execution` states
+- **Session management**: sessions persist as `.jsonl` files; resumption via `resume=session_id`
+- **Cost + usage tracking**: `total_cost_usd`, `num_turns`, token counts per run
+- **Permission hooks**: `canUseTool` callback surfaces approval requests programmatically
+- **Streaming output**: yields `AssistantMessage`, `UserMessage`, `ResultMessage` as the loop runs
+
+### Why the SDK doesn't apply directly to Conductor
+
+**The SDK is Python/TypeScript only.** Conductor is Rust. Options:
+
+1. **Wrap in a Python/TS subprocess** — adds a runtime dependency, another process layer, and the complexity of managing that subprocess from Rust.
+2. **Call `claude` CLI directly** — the SDK is essentially a wrapper around this anyway. Use `--output-format stream-json` for structured output.
+3. **Keep tmux** — users can watch/interact with the agent in real-time; human-in-the-loop is a feature.
+
+The SDK is designed for "embed Claude in your app and build the UI yourself" use cases. Conductor's current UX *is* the tmux terminal — that interactive terminal window has genuine value.
+
+### Billing: SDK vs. CLI
+
+| Mode | Auth | Billing |
+|------|------|---------|
+| `claude` CLI | Claude Code subscription | Included in subscription |
+| Claude Agent SDK | `ANTHROPIC_API_KEY` | Usage-based, separate billing |
+| Direct Anthropic API | `ANTHROPIC_API_KEY` | Usage-based, separate billing |
+
+Switching to the SDK would change the billing model for users.
+
+### Option: Headless subprocess (`--output-format stream-json`)
+
+Instead of tmux, conductor could manage the `claude` process directly:
+
+```
+┌───────────────┐     ┌────────────────────────────────┐
+│  AgentManager │     │  claude subprocess (per run)   │
+│               │     │                                │
+│  spawn()      │────►│  claude -p "..." \             │
+│  read stdout  │◄────│    --output-format stream-json │
+│  update DB    │     │    --permission-mode acceptEdits│
+└───────────────┘     └────────────────────────────────┘
+```
+
+**Gains:**
+- Eliminates tmux dependency and orphan reaper logic
+- Real-time structured output → live status in TUI without 5s polling delay
+- Cleaner process lifecycle — death of subprocess is immediately detectable
+- Single `conductor-tui` or `conductor-web` process owns everything
+
+**Loses:**
+- No interactive terminal for the user to attach to (no `press a to attach`)
+- No scrollback / visible execution trace in a tmux pane
+- Agent runs tied to conductor process lifetime (background daemon becomes necessary for resilience)
+
+### When each approach makes sense
+
+| Concern | tmux | Headless subprocess |
+|---------|------|---------------------|
+| User watches agent work | Best | Not possible |
+| Human-in-the-loop prompts | Easy (attach to pane) | Needs separate UI |
+| Process resilience if TUI crashes | Good (tmux outlives TUI) | Run dies with TUI |
+| Structured output / live status | Polling only | Native streaming |
+| No extra runtime dependency | Yes | Yes (same) |
+| Orphan reaper complexity | Required | Not needed |
+| v2 daemon extraction | Fits naturally | Also fits naturally |
+
+### Process Resilience: headless subprocess vs. tmux
+
+A common concern with the headless approach is whether the agent survives a TUI crash or restart.
+
+**Default `Command::spawn()` behavior (Unix):** child processes survive parent exit — they get reparented to PID 1. So `conductor agent run` (and `claude` underneath it) would keep running if the TUI exits cleanly.
+
+**The edge case that kills it:** if the user closes the terminal window while the TUI is running, the OS sends `SIGHUP` to the entire process group. A directly-spawned child inherits the TUI's process group and controlling terminal, so it receives SIGHUP and dies — taking the agent with it.
+
+tmux avoids this because `conductor agent run` runs inside a tmux session with its own process group and no controlling terminal tied to the user's window.
+
+**The fix:** spawn the child in its own process group:
+
+```rust
+Command::new("conductor")
+    .args(["agent", "run", ...])
+    .process_group(0)  // new process group, detached from TUI's group
+    .spawn()
+```
+
+With `process_group(0)`, the child won't receive SIGHUP when the terminal closes — same resilience guarantee as tmux, without the extra indirection.
+
+**PID tracking:** after a TUI restart, you need to reconnect to the running process. With tmux that's a window name lookup; with headless it requires storing the PID in the DB (or a pidfile) and checking liveness via `kill -0 <pid>`. The orphan reaper would replace tmux window checks with PID checks.
+
+### Recommendation
+
+The tmux approach remains the right default for the **interactive TUI use case**. The headless subprocess approach becomes compelling when:
+
+- Building a daemon (v2) where the daemon owns agent processes and TUI is a thin client
+- Running agents from the web UI where there's no terminal to attach to
+- Wanting live streaming output in the TUI panel (vs. 5s polling)
+
+A hybrid is possible: use `stream-json` subprocess for the web backend (which has no tmux), keep tmux for the TUI where attach-to-agent is a first-class interaction.
+
+---
+
 ## Future: v2 Daemon Extraction
 
 See `docs/VISION.md` section "v2: Daemon Extraction" for the full analysis. The daemon becomes the single owner of agent processes, DB writes, and state. The TUI becomes a thin display client connected via IPC.


### PR DESCRIPTION
## Summary

- Adds research section to `docs/claude-agent-integration.md` analyzing three approaches for managing agent processes: Claude Agent SDK, headless subprocess (`--output-format stream-json`), and the current tmux approach
- Covers billing model differences, process resilience (SIGHUP handling, `process_group(0)`), and UX tradeoffs
- Recommends keeping tmux as default for TUI, with headless subprocess compelling for web UI and v2 daemon

## Test plan

- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)