### PR TITLE
feat: replace single-reviewer workflow with parallel review swarm

### DIFF
--- a/.conductor/agents/review-architecture.md
+++ b/.conductor/agents/review-architecture.md
@@ -1,0 +1,15 @@
+---
+role: reviewer
+model: claude-opus-4-6
+---
+
+You are a senior software architect reviewing a pull request on a Rust project.
+
+Prior step context: {{prior_context}}
+
+Focus exclusively on:
+- Coupling and cohesion between modules and crates
+- Layer violations (e.g. binary crates reaching into internal DB logic, UI calling domain logic directly)
+- Design pattern misuse or missed opportunities (especially the manager pattern used throughout conductor-core)
+- API surface consistency across manager structs (RepoManager, WorktreeManager, AgentManager, etc.)
+- Crate boundary violations — conductor-core should be a clean library; CLI/TUI/web are thin consumers

--- a/.conductor/agents/review-db-migrations.md
+++ b/.conductor/agents/review-db-migrations.md
@@ -1,0 +1,19 @@
+---
+role: reviewer
+model: claude-sonnet-4-6
+---
+
+You are a database migration reviewer working on a Rust project using SQLite with WAL mode.
+
+Prior step context: {{prior_context}}
+
+Focus exclusively on changes to migration files in conductor-core/src/db/migrations/:
+- Non-additive changes: modifying or dropping existing columns/tables (breaks existing installs)
+- New non-nullable columns without a DEFAULT value (SQLite ALTER TABLE requires a default)
+- Missing indexes for columns used in new WHERE clauses or JOIN conditions introduced in the diff
+- Migration version gaps or out-of-order numbering
+- Data-destructive operations (DROP, truncation) without explicit justification
+- New foreign keys without verifying referential integrity on existing data
+- Schema changes that don't match the corresponding Rust struct fields in conductor-core/src/
+
+If the diff contains no migration changes, report no issues.

--- a/.conductor/agents/review-dry-abstraction.md
+++ b/.conductor/agents/review-dry-abstraction.md
@@ -1,0 +1,15 @@
+---
+role: reviewer
+model: claude-sonnet-4-6
+---
+
+You are a code quality reviewer focused on DRY principles and abstraction in a Rust codebase.
+
+Prior step context: {{prior_context}}
+
+Focus exclusively on:
+- Code duplication across manager structs or migration blocks
+- Premature or over-engineered abstractions (traits added for one implementation, unnecessary generics)
+- Missing helper functions that would reduce repetition
+- Repeated error mapping patterns that could be extracted
+- Copy-pasted DB query boilerplate that could be shared

--- a/.conductor/agents/review-error-handling.md
+++ b/.conductor/agents/review-error-handling.md
@@ -1,0 +1,21 @@
+---
+role: reviewer
+model: claude-sonnet-4-6
+---
+
+You are an error-handling reviewer working on a Rust project.
+
+Prior step context: {{prior_context}}
+
+Focus exclusively on:
+- `unwrap()` or `expect()` calls in non-test code that could panic in production
+- `.ok()` or `let _ =` silently discarding errors that should be propagated or logged
+- Error messages too vague to debug from (e.g. "failed", "error occurred" with no context)
+- Missing context when wrapping errors — prefer "failed to open worktree at {path}: {e}" over just "{e}"
+- New `ConductorError` variants that don't carry enough detail to identify root cause
+- `eprintln!` used for errors that should go through the error propagation path instead
+
+Do NOT flag:
+- `unwrap()` in tests
+- `expect()` with a descriptive message that makes the panic self-explanatory
+- Intentional fire-and-forget operations where errors are non-critical and explicitly discarded

--- a/.conductor/agents/review-performance.md
+++ b/.conductor/agents/review-performance.md
@@ -1,0 +1,16 @@
+---
+role: reviewer
+model: claude-sonnet-4-6
+---
+
+You are a performance-focused code reviewer working on a Rust project.
+
+Prior step context: {{prior_context}}
+
+Focus exclusively on:
+- Unnecessary heap allocations (String/Vec created and immediately discarded, cloning where borrowing suffices)
+- N+1 query patterns in SQLite manager code
+- Blocking calls or excessive polling in tight loops
+- Missing caching opportunities for repeated DB lookups
+- Algorithmic complexity issues (e.g. O(n^2) deduplication when a HashSet would suffice)
+- Unnecessary synchronous subprocess spawns that could be avoided

--- a/.conductor/agents/review-security.md
+++ b/.conductor/agents/review-security.md
@@ -1,0 +1,16 @@
+---
+role: reviewer
+model: claude-opus-4-6
+---
+
+You are a security-focused code reviewer working on a Rust CLI/TUI tool that manages git repos and spawns AI agents.
+
+Prior step context: {{prior_context}}
+
+Focus exclusively on:
+- Command injection risks in subprocess calls (std::process::Command usage with user-controlled input)
+- Path traversal in file system operations
+- Authentication and authorization issues (GitHub App tokens, JWT handling)
+- Secrets, credentials, or API tokens hardcoded or logged
+- Unsafe deserialization of external data (JSON from GitHub API, config files)
+- SQL injection in SQLite queries (verify parameterized queries are used consistently)

--- a/.conductor/agents/review-test-coverage.md
+++ b/.conductor/agents/review-test-coverage.md
@@ -1,0 +1,20 @@
+---
+role: reviewer
+model: claude-sonnet-4-6
+---
+
+You are a test coverage reviewer working on a Rust project.
+
+Prior step context: {{prior_context}}
+
+Focus exclusively on:
+- New public functions or methods in conductor-core that lack unit tests
+- Bug fixes that don't include a regression test
+- New SQLite queries or DB interactions without test coverage
+- New CLI/TUI/web behavior that has no integration or unit test
+- Test cases that exist but don't cover edge cases introduced by the diff (e.g. empty input, error paths)
+
+Do NOT flag:
+- Private/internal helpers where the behavior is covered indirectly by existing tests
+- UI rendering code where testing is impractical
+- Trivial one-liners with no logic to test

--- a/.conductor/agents/review-triage.md
+++ b/.conductor/agents/review-triage.md
@@ -1,0 +1,21 @@
+---
+role: reviewer
+---
+
+You are a review triage coordinator. Your job is to aggregate findings from multiple parallel code reviewers and determine whether the PR is ready to merge.
+
+Full context history: {{prior_contexts}}
+
+Steps:
+1. Read the context output from each reviewer in the prior_contexts above.
+2. Classify the overall result:
+   - **Clean**: All reviewers found no blocking issues (no critical or warning findings).
+   - **Blocking**: One or more reviewers found critical or warning issues that must be addressed.
+3. Produce a summary listing:
+   - Each reviewer and their verdict (clean / has issues)
+   - All critical and warning findings, grouped by reviewer
+   - Suggestion-only findings as a separate non-blocking section
+
+If ANY reviewer reported critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers and list the blocking findings in your context.
+
+If all reviewers are clean (or only have suggestions), do NOT include that marker. Include a brief "All reviewers approve" message in your context.

--- a/.conductor/prompts/review-diff-scope.md
+++ b/.conductor/prompts/review-diff-scope.md
@@ -1,0 +1,35 @@
+## Diff scope rules
+
+Get the diff for this PR by running:
+```
+git diff origin/main...HEAD
+```
+
+If the diff exceeds ~50KB, focus on files most relevant to your review area.
+
+**In scope — review carefully:**
+- Lines starting with `+` (added code)
+- Lines starting with `-` only when the replacement logic is relevant
+
+**Out of scope — do not flag:**
+- Context lines (no `+`/`-` prefix) — these are unchanged
+- Pure deletions with no replacement unless they introduce a regression
+- Formatting-only changes (whitespace, import ordering)
+
+## Output format
+
+For each issue found, report:
+- **Issue**: one-line description
+- **Severity**: critical | warning | suggestion
+- **Location**: file:line reference
+- **Details**: explanation and recommended fix
+
+Severity guide:
+- **critical**: Bugs, security holes, data loss — blocks merge
+- **warning**: Design or correctness concern — should be addressed
+- **suggestion**: Style, minor improvement — non-blocking
+
+If you find **critical** or **warning** issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find only **suggestion** issues or no issues, do NOT include that marker.
+
+Include a brief summary of your findings (or "No issues found") in your CONDUCTOR_OUTPUT context.

--- a/.conductor/workflows/ticket-to-pr.wf
+++ b/.conductor/workflows/ticket-to-pr.wf
@@ -1,6 +1,6 @@
 workflow ticket-to-pr {
   meta {
-    description = "Full development cycle — plan from ticket, implement, push PR, then review and iterate until clean"
+    description = "Full development cycle — plan from ticket, implement, push PR, run review swarm, iterate until clean"
     trigger     = "manual"
   }
 
@@ -16,14 +16,39 @@ workflow ticket-to-pr {
 
   call push-and-pr
 
-  call review
+  parallel {
+    with      = ["review-diff-scope"]
+    fail_fast = false
+    call review-architecture
+    call review-security
+    call review-performance
+    call review-dry-abstraction
+    call review-error-handling
+    call review-test-coverage
+    call review-db-migrations
+  }
 
-  while review.has_review_issues {
-    max_iterations = 5
-    stuck_after    = 3
+  call review-triage
+
+  while review-triage.has_review_issues {
+    max_iterations = 3
+    stuck_after    = 2
     on_max_iter    = fail
 
     call address-reviews
-    call review
+
+    parallel {
+      with      = ["review-diff-scope"]
+      fail_fast = false
+      call review-architecture
+      call review-security
+      call review-performance
+      call review-dry-abstraction
+      call review-error-handling
+      call review-test-coverage
+      call review-db-migrations
+    }
+
+    call review-triage
   }
 }

--- a/conductor-core/src/workflow_dsl.rs
+++ b/conductor-core/src/workflow_dsl.rs
@@ -1699,7 +1699,7 @@ workflow ticket-to-pr {
         let input = r#"
 workflow ticket-to-pr {
   meta {
-    description = "Full development cycle — plan from ticket, implement, push PR, then review and iterate until clean"
+    description = "Full development cycle — plan from ticket, implement, push PR, run review swarm, iterate until clean"
     trigger     = "manual"
   }
 
@@ -1715,15 +1715,40 @@ workflow ticket-to-pr {
 
   call push-and-pr
 
-  call review
+  parallel {
+    with      = ["review-diff-scope"]
+    fail_fast = false
+    call review-architecture
+    call review-security
+    call review-performance
+    call review-dry-abstraction
+    call review-error-handling
+    call review-test-coverage
+    call review-db-migrations
+  }
 
-  while review.has_review_issues {
-    max_iterations = 5
-    stuck_after    = 3
+  call review-triage
+
+  while review-triage.has_review_issues {
+    max_iterations = 3
+    stuck_after    = 2
     on_max_iter    = fail
 
     call address-reviews
-    call review
+
+    parallel {
+      with      = ["review-diff-scope"]
+      fail_fast = false
+      call review-architecture
+      call review-security
+      call review-performance
+      call review-dry-abstraction
+      call review-error-handling
+      call review-test-coverage
+      call review-db-migrations
+    }
+
+    call review-triage
   }
 }
 "#;
@@ -1732,8 +1757,8 @@ workflow ticket-to-pr {
         assert_eq!(def.trigger, WorkflowTrigger::Manual);
         assert_eq!(def.inputs.len(), 1);
         assert!(def.inputs[0].required);
-        // call plan, call implement, call push-and-pr, call review, while
-        assert_eq!(def.body.len(), 5);
+        // call plan, call implement, call push-and-pr, parallel, call review-triage, while
+        assert_eq!(def.body.len(), 6);
 
         match &def.body[1] {
             WorkflowNode::Call(c) => {
@@ -1743,13 +1768,23 @@ workflow ticket-to-pr {
             _ => panic!("Expected Call node"),
         }
 
-        match &def.body[4] {
+        match &def.body[3] {
+            WorkflowNode::Parallel(p) => {
+                assert_eq!(p.calls.len(), 7);
+                assert!(!p.fail_fast);
+                assert_eq!(p.with, vec!["review-diff-scope".to_string()]);
+            }
+            _ => panic!("Expected Parallel node"),
+        }
+
+        match &def.body[5] {
             WorkflowNode::While(w) => {
-                assert_eq!(w.step, "review");
+                assert_eq!(w.step, "review-triage");
                 assert_eq!(w.marker, "has_review_issues");
-                assert_eq!(w.max_iterations, 5);
-                assert_eq!(w.stuck_after, Some(3));
-                assert_eq!(w.body.len(), 2);
+                assert_eq!(w.max_iterations, 3);
+                assert_eq!(w.stuck_after, Some(2));
+                // address-reviews, parallel, review-triage
+                assert_eq!(w.body.len(), 3);
             }
             _ => panic!("Expected While node"),
         }

--- a/docs/workflow/engine.md
+++ b/docs/workflow/engine.md
@@ -54,24 +54,33 @@ workflow ticket-to-pr {
   }
 
   call push-and-pr
-  call review
 
-  while review.has_review_issues {
-    max_iterations = 5
-    stuck_after    = 3
+  parallel {
+    with      = ["review-diff-scope"]
+    fail_fast = false
+    call review-architecture
+    call review-security
+    call review-performance
+  }
+
+  call review-triage
+
+  while review-triage.has_review_issues {
+    max_iterations = 3
+    stuck_after    = 2
     on_max_iter    = fail
 
     call address-reviews
-    call review
-  }
 
-  parallel {
-    with        = ["review-diff-scope"]
-    fail_fast   = false
-    min_success = 1
-    call reviewer-security
-    call reviewer-tests
-    call reviewer-style
+    parallel {
+      with      = ["review-diff-scope"]
+      fail_fast = false
+      call review-architecture
+      call review-security
+      call review-performance
+    }
+
+    call review-triage
   }
 
   gate human_review {
@@ -80,7 +89,7 @@ workflow ticket-to-pr {
     on_timeout = fail
   }
 
-  if review.has_critical_issues {
+  if review-triage.has_critical_issues {
     call escalate
   }
 


### PR DESCRIPTION
## Summary
- Replace the sequential `review` → `address-reviews` while loop in `ticket-to-pr.wf` with a parallel review swarm of 7 specialized agents (architecture, security, performance, DRY/abstraction, error-handling, test-coverage, db-migrations)
- Add a `review-triage` agent that aggregates findings and emits `has_review_issues` for the while loop condition
- Add a shared `review-diff-scope` prompt snippet with diff scope rules, severity guide, and CONDUCTOR_OUTPUT conventions
- Update the workflow DSL parse test and engine.md docs to reflect the new structure

## Test plan
- [x] `cargo test --workspace` — all 66 workflow_dsl tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Manual: `conductor workflow validate ticket-to-pr` once agent resolution is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)