### PR TITLE
fix: shorten absolute paths in workflow run agent activity view (#440)

### DIFF
--- a/conductor-tui/src/ui/helpers.rs
+++ b/conductor-tui/src/ui/helpers.rs
@@ -1,0 +1,13 @@
+/// Replace absolute worktree and home-directory paths with short placeholders.
+pub fn shorten_paths(summary: &str, worktree_path: &str) -> String {
+    // Replace worktree path first (more specific), then home dir (less specific)
+    let s = if !worktree_path.is_empty() {
+        summary.replacen(worktree_path, "{worktree}", 1)
+    } else {
+        summary.to_string()
+    };
+    match dirs::home_dir() {
+        Some(home) => s.replacen(home.to_string_lossy().as_ref(), "~", 1),
+        None => s,
+    }
+}

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -1,6 +1,7 @@
 mod common;
 mod dashboard;
 mod help;
+pub(crate) mod helpers;
 mod modal;
 mod repo_detail;
 mod tickets;

--- a/conductor-tui/src/ui/workflows.rs
+++ b/conductor-tui/src/ui/workflows.rs
@@ -7,6 +7,7 @@ use ratatui::Frame;
 use conductor_core::worktree::Worktree;
 
 use super::common::truncate;
+use super::helpers::shorten_paths;
 use crate::state::AppState;
 use crate::state::WorkflowsFocus;
 
@@ -395,6 +396,22 @@ fn render_step_agent_activity(frame: &mut Frame, area: Rect, state: &AppState) {
         return;
     }
 
+    let worktree_path = state
+        .selected_worktree_id
+        .as_ref()
+        .and_then(|id| state.data.worktrees.iter().find(|w| &w.id == id))
+        .or_else(|| {
+            state.data.step_agent_run.as_ref().and_then(|run| {
+                state
+                    .data
+                    .worktrees
+                    .iter()
+                    .find(|w| w.id == run.worktree_id)
+            })
+        })
+        .map(|wt| wt.path.as_str())
+        .unwrap_or("");
+
     let items: Vec<ListItem> = events
         .iter()
         .map(|ev| {
@@ -404,7 +421,7 @@ fn render_step_agent_activity(frame: &mut Frame, area: Rect, state: &AppState) {
                 .map(|ms| format!(" ({:.1}s)", ms as f64 / 1000.0))
                 .unwrap_or_default();
             let ts = ev.started_at.get(11..19).unwrap_or(&ev.started_at);
-            let summary = truncate(&ev.summary, 80);
+            let summary = truncate(&shorten_paths(&ev.summary, worktree_path), 80);
             let spans = vec![
                 Span::styled(format!("{ts} "), Style::default().fg(Color::DarkGray)),
                 Span::styled(format!("{:<10}", ev.kind), style),

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -6,6 +6,7 @@ use ratatui::Frame;
 
 use conductor_core::worktree::WorktreeStatus;
 
+use super::helpers::shorten_paths;
 use crate::state::{AppState, VisualRow};
 
 pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -319,19 +320,6 @@ fn render_agent_activity(frame: &mut Frame, area: Rect, state: &AppState) {
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
 
     frame.render_stateful_widget(list, area, &mut state.agent_list_state.borrow_mut());
-}
-
-fn shorten_paths(summary: &str, worktree_path: &str) -> String {
-    // Replace worktree path first (more specific), then home dir (less specific)
-    let s = if !worktree_path.is_empty() {
-        summary.replacen(worktree_path, "{worktree}", 1)
-    } else {
-        summary.to_string()
-    };
-    match dirs::home_dir() {
-        Some(home) => s.replacen(home.to_string_lossy().as_ref(), "~", 1),
-        None => s,
-    }
 }
 
 /// Extract a clean display label from an orchestrator child prompt.


### PR DESCRIPTION
## Summary
- Extracted `shorten_paths()` helper to a shared `conductor-tui/src/ui/helpers.rs` module
- Applied `shorten_paths()` in `render_step_agent_activity()` so workflow agent events display `{worktree}/~` prefixes instead of full absolute paths
- Resolves worktree path from state with fallback via `step_agent_run.worktree_id`

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test --workspace` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] Verify workflow run agent activity view shows shortened paths in TUI

Closes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)