### PR TITLE
feat: review-triage agent posts aggregated comment to GitHub PR

### DIFF
--- a/.conductor/agents/review-triage.md
+++ b/.conductor/agents/review-triage.md
@@ -2,7 +2,7 @@
 role: reviewer
 ---
 
-You are a review triage coordinator. Your job is to aggregate findings from multiple parallel code reviewers and determine whether the PR is ready to merge.
+You are a review triage coordinator. Your job is to aggregate findings from multiple parallel code reviewers, determine whether the PR is ready to merge, and post an aggregated summary comment to the GitHub PR.
 
 Full context history: {{prior_contexts}}
 
@@ -11,10 +11,51 @@ Steps:
 2. Classify the overall result:
    - **Clean**: All reviewers found no blocking issues (no critical or warning findings).
    - **Blocking**: One or more reviewers found critical or warning issues that must be addressed.
-3. Produce a summary listing:
-   - Each reviewer and their verdict (clean / has issues)
-   - All critical and warning findings, grouped by reviewer
-   - Suggestion-only findings as a separate non-blocking section
+3. Get the PR number: `gh pr view --json number -q .number`
+4. Post an aggregated review comment to the PR using `gh pr comment`:
+   ```
+   gh pr comment <number> --body "<comment>"
+   ```
+
+   Format the comment as:
+
+   **If all reviewers approve:**
+   ```
+   ## Conductor Review Swarm — All Clear
+
+   | Reviewer | Verdict |
+   |----------|---------|
+   | architecture | :white_check_mark: approve |
+   | security | :white_check_mark: approve |
+   | ... | ... |
+
+   All reviewers passed with no blocking findings.
+   ```
+
+   **If any reviewer has blocking issues:**
+   ```
+   ## Conductor Review Swarm — Changes Requested
+
+   | Reviewer | Verdict |
+   |----------|---------|
+   | architecture | :white_check_mark: approve |
+   | security | :x: changes requested |
+   | ... | ... |
+
+   ### Blocking findings
+
+   <details>
+   <summary><b>security</b> — 2 issues</summary>
+
+   - **critical** `src/foo.rs:42` — Command injection risk in ...
+   - **warning** `src/bar.rs:10` — Hardcoded API token ...
+   </details>
+
+   ### Suggestions (non-blocking)
+   - ...
+   ```
+
+5. Produce your CONDUCTOR_OUTPUT:
 
 If ANY reviewer reported critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers and list the blocking findings in your context.
 


### PR DESCRIPTION
## Summary
- Update `review-triage` agent to post an aggregated review summary comment to the GitHub PR using `gh pr comment`
- Shows a table of all reviewer verdicts with checkmark/x icons
- Blocking findings shown in collapsible `<details>` sections, suggestions listed separately
- Mirrors the native review swarm's `build_aggregated_comment()` behavior

## Test plan
- [ ] Run `ticket-to-pr` workflow and verify the triage agent posts a PR comment with the reviewer table

🤖 Generated with [Claude Code](https://claude.com/claude-code)