### PR TITLE
fix: push parallel block agent contexts to prior_contexts (#450)

### DIFF
--- a/conductor-core/src/workflow.rs
+++ b/conductor-core/src/workflow.rs
@@ -2229,6 +2229,12 @@ fn execute_parallel(
                         let step_status = if succeeded {
                             successes += 1;
                             merged_markers.extend(markers.iter().cloned());
+                            // Push parallel agent context so downstream {{prior_contexts}} can see it
+                            state.contexts.push(ContextEntry {
+                                step: child.agent_name.clone(),
+                                iteration,
+                                context: context.clone(),
+                            });
                             WorkflowStepStatus::Completed
                         } else {
                             failures += 1;
@@ -3660,6 +3666,40 @@ And here is my actual output:
         assert_eq!(vars.get("branch").unwrap(), "main");
         assert_eq!(vars.get("prior_context").unwrap(), "previous output");
         assert!(vars.get("prior_contexts").unwrap().contains("step-a"));
+    }
+
+    #[test]
+    fn test_parallel_contexts_included_in_prior_contexts() {
+        let conn = setup_db();
+        let mut state = make_test_state(&conn);
+
+        // Simulate multiple parallel agents completing and pushing contexts
+        // (this is the pattern now used in execute_parallel's success branch)
+        state.contexts.push(ContextEntry {
+            step: "reviewer-a".to_string(),
+            iteration: 0,
+            context: "LGTM from reviewer A".to_string(),
+        });
+        state.contexts.push(ContextEntry {
+            step: "reviewer-b".to_string(),
+            iteration: 0,
+            context: "Needs changes from reviewer B".to_string(),
+        });
+
+        let vars = build_variable_map(&state);
+
+        // prior_context should be the last context pushed
+        assert_eq!(
+            vars.get("prior_context").unwrap(),
+            "Needs changes from reviewer B"
+        );
+
+        // prior_contexts should contain both parallel agent entries
+        let prior_contexts = vars.get("prior_contexts").unwrap();
+        assert!(prior_contexts.contains("reviewer-a"));
+        assert!(prior_contexts.contains("reviewer-b"));
+        assert!(prior_contexts.contains("LGTM from reviewer A"));
+        assert!(prior_contexts.contains("Needs changes from reviewer B"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Parallel block agent results were not being added to `state.contexts`, so subsequent workflow steps couldn't reference them via `prior_contexts`
- Added a `ContextEntry` push in `execute_parallel()`'s success branch, mirroring the existing pattern in `record_step_success()`
- Added test `test_parallel_contexts_included_in_prior_contexts` verifying parallel results appear in `prior_contexts`

## Test plan
- [x] New unit test passes: `test_parallel_contexts_included_in_prior_contexts`
- [x] All 518 existing tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --all --check` clean

Fixes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)