### PR TITLE
feat: extract review swarm into standalone review-pr workflow

### DIFF
--- a/.conductor/workflows/review-pr.wf
+++ b/.conductor/workflows/review-pr.wf
@@ -1,0 +1,21 @@
+workflow review-pr {
+  meta {
+    description = "Run review swarm and aggregate findings"
+    trigger     = "manual"
+  }
+
+  parallel {
+    output    = "review-findings"
+    with      = ["review-diff-scope"]
+    fail_fast = false
+    call review-architecture
+    call review-security
+    call review-performance
+    call review-dry-abstraction
+    call review-error-handling
+    call review-test-coverage
+    call review-db-migrations
+  }
+
+  call review-aggregator { output = "review-aggregator" }
+}

--- a/.conductor/workflows/ticket-to-pr.wf
+++ b/.conductor/workflows/ticket-to-pr.wf
@@ -21,20 +21,7 @@ workflow ticket-to-pr {
     stuck_after    = 2
     on_max_iter    = fail
 
-    parallel {
-      output    = "review-findings"
-      with      = ["review-diff-scope"]
-      fail_fast = false
-      call review-architecture
-      call review-security
-      call review-performance
-      call review-dry-abstraction
-      call review-error-handling
-      call review-test-coverage
-      call review-db-migrations
-    }
-
-    call review-aggregator { output = "review-aggregator" }
+    call workflow review-pr
 
     if review-aggregator.has_review_issues {
       call address-reviews


### PR DESCRIPTION
## Summary
- Add `.conductor/workflows/review-pr.wf` — parallel review swarm + aggregator as a reusable sub-workflow
- Update `ticket-to-pr.wf` to call `review-pr` via `call workflow review-pr` (before and inside the while loop)

## Test plan
- [ ] Verify `ticket-to-pr` workflow runs end-to-end and invokes `review-pr` at each step
- [ ] Verify `review-pr` can be triggered standalone on an existing PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)