### PR TITLE
fix: migrate ticket-to-pr.wf to new do-while syntax; surface body errors in summary

### DIFF
--- a/.conductor/workflows/ticket-to-pr.wf
+++ b/.conductor/workflows/ticket-to-pr.wf
@@ -16,7 +16,7 @@ workflow ticket-to-pr {
 
   call push-and-pr
 
-  do review-aggregator.has_review_issues {
+  do {
     max_iterations = 4
     stuck_after    = 2
     on_max_iter    = fail
@@ -26,5 +26,5 @@ workflow ticket-to-pr {
     if review-aggregator.has_review_issues {
       call address-reviews
     }
-  }
+  } while review-aggregator.has_review_issues
 }

--- a/conductor-core/src/workflow.rs
+++ b/conductor-core/src/workflow.rs
@@ -1124,10 +1124,13 @@ pub fn execute_workflow(input: &WorkflowExecInput<'_>) -> Result<WorkflowResult>
     };
 
     // Execute main body
+    let mut body_error: Option<String> = None;
     let body_result = execute_nodes(&mut state, &workflow.body);
     if let Err(ref e) = body_result {
-        tracing::error!("Body execution error: {e}");
+        let msg = e.to_string();
+        tracing::error!("Body execution error: {msg}");
         state.all_succeeded = false;
+        body_error = Some(msg);
     }
 
     // Execute always block regardless of outcome
@@ -1149,7 +1152,10 @@ pub fn execute_workflow(input: &WorkflowExecInput<'_>) -> Result<WorkflowResult>
     }
 
     // Build summary
-    let summary = build_workflow_summary(&state);
+    let mut summary = build_workflow_summary(&state);
+    if let Some(ref err) = body_error {
+        summary.push_str(&format!("\nError: {err}"));
+    }
 
     // Finalize
     if state.all_succeeded {


### PR DESCRIPTION
- Update ticket-to-pr.wf from `do x.y {}` to `do {} while x.y` syntax
- Append body execution error text to workflow result_summary for visibility (the error was previously only logged via tracing with no subscriber in TUI)