### PR TITLE
fix: add 'workflow' role to DB constraint, fixing call workflow execution

### DIFF
--- a/conductor-core/src/db/migrations.rs
+++ b/conductor-core/src/db/migrations.rs
@@ -430,5 +430,56 @@ pub fn run(conn: &Connection) -> Result<()> {
         bump_version(conn, 24)?;
     }
 
+    // Migration 025: add 'workflow' to the workflow_run_steps role CHECK constraint.
+    if version < 25 {
+        conn.pragma_update(None, "foreign_keys", "off")?;
+
+        conn.execute_batch(
+            "BEGIN;
+            CREATE TABLE workflow_run_steps_new (
+                id                TEXT PRIMARY KEY,
+                workflow_run_id   TEXT NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+                step_name         TEXT NOT NULL,
+                role              TEXT NOT NULL CHECK (role IN ('actor','reviewer','gate','workflow')),
+                can_commit        INTEGER NOT NULL DEFAULT 0,
+                condition_expr    TEXT,
+                status            TEXT NOT NULL DEFAULT 'pending'
+                                  CHECK (status IN ('pending','running','waiting','completed','failed','skipped','timed_out')),
+                child_run_id      TEXT REFERENCES agent_runs(id) ON DELETE SET NULL,
+                position          INTEGER NOT NULL,
+                started_at        TEXT,
+                ended_at          TEXT,
+                result_text       TEXT,
+                condition_met     INTEGER,
+                iteration         INTEGER NOT NULL DEFAULT 0,
+                parallel_group_id TEXT,
+                context_out       TEXT,
+                markers_out       TEXT,
+                retry_count       INTEGER NOT NULL DEFAULT 0,
+                gate_type         TEXT,
+                gate_prompt       TEXT,
+                gate_timeout      TEXT,
+                gate_approved_by  TEXT,
+                gate_approved_at  TEXT,
+                gate_feedback     TEXT,
+                structured_output TEXT
+            );
+            INSERT INTO workflow_run_steps_new SELECT
+                id, workflow_run_id, step_name, role, can_commit, condition_expr,
+                status, child_run_id, position, started_at, ended_at, result_text,
+                condition_met, iteration, parallel_group_id, context_out, markers_out,
+                retry_count, gate_type, gate_prompt, gate_timeout, gate_approved_by,
+                gate_approved_at, gate_feedback, structured_output
+                FROM workflow_run_steps;
+            DROP TABLE workflow_run_steps;
+            ALTER TABLE workflow_run_steps_new RENAME TO workflow_run_steps;
+            CREATE INDEX IF NOT EXISTS idx_workflow_run_steps_run ON workflow_run_steps(workflow_run_id);
+            COMMIT;",
+        )?;
+
+        conn.pragma_update(None, "foreign_keys", "on")?;
+        bump_version(conn, 25)?;
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

- **Root cause:** `call workflow` steps were inserted into `workflow_run_steps` with `role='workflow'`, but the CHECK constraint only allowed `'actor'`, `'reviewer'`, `'gate'`. This caused a silent DB error that prevented the do-while body from ever executing — appearing as a clean `push-and-pr` success followed by immediate workflow failure with no step records.
- **Migration 025:** Adds `'workflow'` to the role CHECK constraint via table swap (SQLite requires this for CHECK changes).
- **ticket-to-pr.wf:** Migrated from old `do x.y {}` syntax to new `do {} while x.y` syntax introduced in #463.
- **workflow.rs:** Surface body execution errors in `result_summary` for visibility — previously swallowed silently since the TUI has no tracing subscriber.

## Test plan
- [ ] Restart TUI (migration runs on startup)
- [ ] Run `ticket-to-pr` on a worktree — do-while body should now execute and `workflow:review-pr` step should appear
- [ ] Verify `review-pr` sub-workflow runs as expected inside the loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)