### PR TITLE
feat(tui): add worktree path to workflow run detail header (#472)

### DIFF
--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -652,6 +652,9 @@ pub struct AppState {
     /// When true, force the global status bar detail line to expand even when
     /// there are 4+ active items (which default to the collapsed 1-line view).
     pub status_bar_expanded: bool,
+
+    /// Cached home directory path for `~` substitution in path display. Never changes.
+    pub home_dir: Option<String>,
 }
 
 impl AppState {
@@ -691,6 +694,7 @@ impl AppState {
             show_closed_tickets: false,
             ticket_sync_in_progress: false,
             status_bar_expanded: false,
+            home_dir: dirs::home_dir().map(|p| p.to_string_lossy().into_owned()),
         }
     }
 

--- a/conductor-tui/src/ui/helpers.rs
+++ b/conductor-tui/src/ui/helpers.rs
@@ -1,13 +1,13 @@
 /// Replace absolute worktree and home-directory paths with short placeholders.
-pub fn shorten_paths(summary: &str, worktree_path: &str) -> String {
+pub fn shorten_paths(summary: &str, worktree_path: &str, home_dir: Option<&str>) -> String {
     // Replace worktree path first (more specific), then home dir (less specific)
     let s = if !worktree_path.is_empty() {
         summary.replacen(worktree_path, "{worktree}", 1)
     } else {
         summary.to_string()
     };
-    match dirs::home_dir() {
-        Some(home) => s.replacen(home.to_string_lossy().as_ref(), "~", 1),
+    match home_dir {
+        Some(home) => s.replacen(home, "~", 1),
         None => s,
     }
 }

--- a/conductor-tui/src/ui/workflows.rs
+++ b/conductor-tui/src/ui/workflows.rs
@@ -1,4 +1,3 @@
-use dirs;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -248,8 +247,8 @@ pub fn render_run_detail(frame: &mut Frame, area: Rect, state: &AppState) {
                 Span::styled(" Branch:   ", Style::default().fg(Color::DarkGray)),
                 Span::raw(wt.branch.clone()),
             ]));
-            let display_path = match dirs::home_dir() {
-                Some(home) => wt.path.replacen(home.to_string_lossy().as_ref(), "~", 1),
+            let display_path = match state.home_dir.as_deref() {
+                Some(home) => wt.path.replacen(home, "~", 1),
                 None => wt.path.clone(),
             };
             header_lines.push(Line::from(vec![
@@ -505,7 +504,10 @@ fn render_step_agent_activity(
                 .map(|ms| format!(" ({:.1}s)", ms as f64 / 1000.0))
                 .unwrap_or_default();
             let ts = ev.started_at.get(11..19).unwrap_or(&ev.started_at);
-            let summary = truncate(&shorten_paths(&ev.summary, worktree_path), 80);
+            let summary = truncate(
+                &shorten_paths(&ev.summary, worktree_path, state.home_dir.as_deref()),
+                80,
+            );
             let spans = vec![
                 Span::styled(format!("{ts} "), Style::default().fg(Color::DarkGray)),
                 Span::styled(format!("{:<10}", ev.kind), style),

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -284,8 +284,9 @@ fn render_agent_activity(frame: &mut Frame, area: Rect, state: &AppState) {
                 let (display_text, effective_style) = if ev.kind == "prompt" {
                     let step_label = extract_step_label(&ev.summary);
                     let is_step = step_label.is_some();
-                    let label =
-                        step_label.unwrap_or_else(|| shorten_paths(&ev.summary, worktree_path));
+                    let label = step_label.unwrap_or_else(|| {
+                        shorten_paths(&ev.summary, worktree_path, state.home_dir.as_deref())
+                    });
                     let s = if is_step {
                         Style::default().fg(Color::Magenta)
                     } else {
@@ -294,11 +295,14 @@ fn render_agent_activity(frame: &mut Frame, area: Rect, state: &AppState) {
                     (label, s)
                 } else if conductor_core::agent::parse_feedback_marker(&ev.summary).is_some() {
                     (
-                        shorten_paths(&ev.summary, worktree_path),
+                        shorten_paths(&ev.summary, worktree_path, state.home_dir.as_deref()),
                         Style::default().fg(Color::Magenta),
                     )
                 } else {
-                    (shorten_paths(&ev.summary, worktree_path), style)
+                    (
+                        shorten_paths(&ev.summary, worktree_path, state.home_dir.as_deref()),
+                        style,
+                    )
                 };
                 let mut spans = vec![Span::styled(display_text, effective_style)];
                 if let Some(dur) = ev.duration_ms() {


### PR DESCRIPTION
Show a Path: row below Branch: in the run detail header, with ~ substitution for the home directory. Fix header_height formula to correctly account for two worktree rows (branch + path) instead of hardcoded +1.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
