### PR TITLE
fix(workflow): fix ticket-to-pr conditions and add lint-fix step

### DIFF
--- a/.conductor/workflows/ticket-to-pr.wf
+++ b/.conductor/workflows/ticket-to-pr.wf
@@ -14,6 +14,8 @@ workflow ticket-to-pr {
     retries = 2
   }
 
+  call workflow lint-fix
+
   call push-and-pr
 
   do {
@@ -23,8 +25,8 @@ workflow ticket-to-pr {
 
     call workflow review-pr
 
-    if review-aggregator.has_review_issues {
+    if review-pr.has_review_issues {
       call address-reviews
     }
-  } while review-aggregator.has_review_issues
+  } while review-pr.has_review_issues
 }


### PR DESCRIPTION
## Summary

- **Fix conditions:** `review-aggregator.has_review_issues` → `review-pr.has_review_issues`. Sub-workflow markers are stored under the sub-workflow's step key in the parent context, not the inner step name. Tracked in #474 for proper fix via result bubbling.
- **Add lint-fix:** Insert `call workflow lint-fix` before `push-and-pr` so clippy errors are caught and fixed before the PR is opened.

## Test plan
- [ ] Run `ticket-to-pr` — lint-fix should run after implement
- [ ] If review-aggregator finds issues, `address-reviews` should now be called on the next iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)