### PR TITLE
fix(workflow): remove stuck_after from ticket-to-pr do-while loop

### DIFF
--- a/.conductor/workflows/ticket-to-pr.wf
+++ b/.conductor/workflows/ticket-to-pr.wf
@@ -20,7 +20,6 @@ workflow ticket-to-pr {
 
   do {
     max_iterations = 4
-    stuck_after    = 2
     on_max_iter    = fail
 
     call workflow review-pr


### PR DESCRIPTION
## Summary
- Removes `stuck_after = 2` from the `do {} while` loop in `ticket-to-pr.wf`
- Root cause: `stuck_after` compares marker *names* across iterations — since `has_review_issues` is a binary marker (present or absent), the marker set is identical on every iteration that still has review issues, regardless of whether progress is being made
- After 2 identical marker sets, the stuck detector fires and fails the workflow with: `do review-aggregator.has_review_issues stuck after 2 iterations with identical markers`
- `max_iterations = 4` already provides the infinite-loop safety net

## Test plan
- [ ] Run `ticket-to-pr` on a worktree — confirm it completes all 4 iterations if review issues persist, rather than failing at iteration 2
- [ ] Confirm `max_iterations = 4` + `on_max_iter = fail` still prevents runaway loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)