### PR TITLE
feat(workflow): add retries = 1 to review-pr parallel reviewer calls

### DIFF
--- a/.conductor/workflows/review-pr.wf
+++ b/.conductor/workflows/review-pr.wf
@@ -9,13 +9,13 @@ workflow review-pr {
     output    = "review-findings"
     with      = ["review-diff-scope"]
     fail_fast = false
-    call review-architecture
-    call review-security
-    call review-performance
-    call review-dry-abstraction
-    call review-error-handling
-    call review-test-coverage
-    call review-db-migrations
+    call review-architecture    { retries = 1 }
+    call review-security        { retries = 1 }
+    call review-performance     { retries = 1 }
+    call review-dry-abstraction { retries = 1 }
+    call review-error-handling  { retries = 1 }
+    call review-test-coverage   { retries = 1 }
+    call review-db-migrations   { retries = 1 }
   }
 
   call review-aggregator { output = "review-aggregator" }


### PR DESCRIPTION
## Summary

- Adds `retries = 1` to all seven parallel reviewer calls in `review-pr.wf`
- A transient tmux session loss was causing the entire parallel block to fail, preventing `review-aggregator` from running even when all other reviewers completed successfully

## Motivation

Discovered during the review run for #491 — `review-test-coverage` lost its tmux session mid-run (infrastructure failure, not a code issue), which failed the whole workflow. The other 6 reviewers all approved. One retry per reviewer handles this class of transient failure cleanly.

## Test plan

- [ ] Run `review-pr` workflow and verify it completes normally
- [ ] Confirm `review-aggregator` runs after all parallel reviewers finish

🤖 Generated with [Claude Code](https://claude.com/claude-code)