### PR TITLE
fix(tui): skip list_defs FS scan when a run is selected to unblock step polling (#495)

### DIFF
--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -21,7 +21,7 @@ pub struct GithubDiscoverPayload {
 /// Payload for workflow data refresh (workflow runs + steps for current context).
 #[derive(Debug)]
 pub struct WorkflowDataPayload {
-    pub workflow_defs: Vec<WorkflowDef>,
+    pub workflow_defs: Option<Vec<WorkflowDef>>, // None = defs not re-scanned, keep existing
     pub workflow_runs: Vec<WorkflowRun>,
     pub workflow_steps: Vec<WorkflowRunStep>,
     /// Agent events for the selected step's child_run_id (live activity)

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -590,7 +590,9 @@ impl App {
                 }
             }
             Action::WorkflowDataRefreshed(payload) => {
-                self.state.data.workflow_defs = payload.workflow_defs;
+                if let Some(defs) = payload.workflow_defs {
+                    self.state.data.workflow_defs = defs;
+                }
                 self.state.data.workflow_runs = payload.workflow_runs;
                 self.state.data.workflow_steps = payload.workflow_steps;
                 self.state.data.step_agent_events = payload.step_agent_events;

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -259,9 +259,11 @@ fn poll_workflow_data(
     let db = db_path();
     let conn = open_database(&db).ok()?;
 
-    // Load defs: scoped to one worktree, or aggregated across all worktrees in global mode.
-    let defs = if let Some(wt_path) = worktree_path {
-        WorkflowManager::list_defs(wt_path, repo_path.unwrap_or("")).unwrap_or_default()
+    // Skip FS scan when a run is selected — defs don't change during a run.
+    let defs: Option<Vec<_>> = if selected_run_id.is_some() {
+        None
+    } else if let Some(wt_path) = worktree_path {
+        Some(WorkflowManager::list_defs(wt_path, repo_path.unwrap_or("")).unwrap_or_default())
     } else {
         // Global mode: scan every registered worktree for workflow definitions.
         let mut all_defs = Vec::new();
@@ -283,7 +285,7 @@ fn poll_workflow_data(
                 all_defs.append(&mut wt_defs);
             }
         }
-        all_defs
+        Some(all_defs)
     };
     let wf_mgr = WorkflowManager::new(&conn);
     let runs = wf_mgr


### PR DESCRIPTION
When a workflow run is selected, workflow defs don't change so there's no need
to run the slow filesystem scan on every poll tick. Change WorkflowDataPayload.workflow_defs
to Option<Vec<WorkflowDef>> (None = no update) so the fast DB queries for runs,
steps, and agent events are no longer blocked by the FS scan on the hot path.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
