### PR TITLE
feat(workflow): increase ticket-to-pr review loop max_iterations to 10

### DIFF
--- a/.conductor/workflows/ticket-to-pr.wf
+++ b/.conductor/workflows/ticket-to-pr.wf
@@ -20,7 +20,7 @@ workflow ticket-to-pr {
   call push-and-pr
 
   do {
-    max_iterations = 4
+    max_iterations = 10
     on_max_iter    = fail
 
     call workflow review-pr


### PR DESCRIPTION
## Summary

- Bumps `max_iterations` in the `ticket-to-pr` do-while review loop from 4 to 10
- 4 was too low for complex PRs requiring multiple review/address-reviews cycles

## Test plan

- [ ] Run `ticket-to-pr` on a non-trivial ticket and verify the loop doesn't terminate prematurely

🤖 Generated with [Claude Code](https://claude.com/claude-code)