### PR TITLE
feat(tui): run workflow on selected PR from repo detail PR pane (#498)

### DIFF
--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -206,6 +206,7 @@ pub enum Action {
 
     // Workflow actions
     RunWorkflow,
+    RunPrWorkflow,
     ResumeWorkflow,
     CancelWorkflow,
     ApproveGate,

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -588,6 +588,7 @@ impl App {
 
             // Workflow actions
             Action::RunWorkflow => self.handle_run_workflow(),
+            Action::RunPrWorkflow => self.handle_run_pr_workflow(),
             Action::ResumeWorkflow => self.handle_resume_workflow(),
             Action::CancelWorkflow => self.handle_cancel_workflow(),
             Action::ApproveGate => self.handle_approve_gate(),
@@ -1012,6 +1013,14 @@ impl App {
                 wrap_decrement(selected, sources.len());
                 return;
             }
+            Modal::PrWorkflowPicker {
+                ref workflow_defs,
+                ref mut selected,
+                ..
+            } => {
+                wrap_decrement(selected, workflow_defs.len());
+                return;
+            }
             Modal::GithubDiscoverOrgs {
                 ref orgs,
                 ref mut cursor,
@@ -1131,6 +1140,14 @@ impl App {
                 ..
             } => {
                 wrap_increment(selected, sources.len());
+                return;
+            }
+            Modal::PrWorkflowPicker {
+                ref workflow_defs,
+                ref mut selected,
+                ..
+            } => {
+                wrap_increment(selected, workflow_defs.len());
                 return;
             }
             Modal::GithubDiscoverOrgs {
@@ -1633,6 +1650,12 @@ impl App {
     }
 
     fn handle_input_submit(&mut self) {
+        // PrWorkflowPicker: confirm the selected workflow
+        if matches!(self.state.modal, Modal::PrWorkflowPicker { .. }) {
+            self.handle_pr_workflow_picker_confirm();
+            return;
+        }
+
         // ConfirmByName: only proceed if typed value matches expected slug
         if let Modal::ConfirmByName {
             ref expected,
@@ -4478,6 +4501,171 @@ impl App {
 
         self.workflow_threads.push(handle);
         self.state.status_message = Some(format!("Starting workflow '{workflow_name}'…"));
+    }
+
+    fn handle_run_pr_workflow(&mut self) {
+        let pr = match self.state.detail_prs.get(self.state.detail_pr_index) {
+            Some(pr) => pr.clone(),
+            None => {
+                self.state.status_message = Some("No PR selected".to_string());
+                return;
+            }
+        };
+
+        let pr_defs: Vec<conductor_core::workflow::WorkflowDef> = self
+            .state
+            .data
+            .workflow_defs
+            .iter()
+            .filter(|d| d.targets.iter().any(|t| t == "pr"))
+            .cloned()
+            .collect();
+
+        if pr_defs.is_empty() {
+            self.state.modal = Modal::Error {
+                message:
+                    "No PR-compatible workflows found.\nAdd targets: [pr] to a workflow definition."
+                        .to_string(),
+            };
+            return;
+        }
+
+        self.state.modal = Modal::PrWorkflowPicker {
+            pr_number: pr.number,
+            pr_title: pr.title.clone(),
+            workflow_defs: pr_defs,
+            selected: 0,
+        };
+    }
+
+    fn handle_pr_workflow_picker_confirm(&mut self) {
+        let (pr_number, def) = if let Modal::PrWorkflowPicker {
+            pr_number,
+            ref workflow_defs,
+            selected,
+            ..
+        } = self.state.modal
+        {
+            let def = match workflow_defs.get(selected) {
+                Some(d) => d.clone(),
+                None => return,
+            };
+            (pr_number, def)
+        } else {
+            return;
+        };
+
+        // Get owner/repo from selected repo's remote_url
+        let remote_url = match self
+            .state
+            .selected_repo_id
+            .as_ref()
+            .and_then(|id| self.state.data.repos.iter().find(|r| &r.id == id))
+            .map(|r| r.remote_url.clone())
+        {
+            Some(url) => url,
+            None => {
+                self.state.modal = Modal::Error {
+                    message: "No repo selected".to_string(),
+                };
+                return;
+            }
+        };
+
+        let (owner, repo) = match conductor_core::github::parse_github_remote(&remote_url) {
+            Some(pair) => pair,
+            None => {
+                self.state.modal = Modal::Error {
+                    message: format!(
+                        "Could not parse GitHub owner/repo from remote URL: {remote_url}"
+                    ),
+                };
+                return;
+            }
+        };
+
+        let pr_ref = conductor_core::workflow_ephemeral::PrRef {
+            owner,
+            repo,
+            number: pr_number as u64,
+        };
+
+        self.state.modal = Modal::None;
+        self.spawn_pr_workflow_in_background(pr_ref, def);
+    }
+
+    /// Spawn an ephemeral PR workflow execution in a background thread.
+    fn spawn_pr_workflow_in_background(
+        &mut self,
+        pr_ref: conductor_core::workflow_ephemeral::PrRef,
+        def: conductor_core::workflow::WorkflowDef,
+    ) {
+        use conductor_core::config::db_path;
+        use conductor_core::db::open_database;
+
+        let config = self.config.clone();
+        let bg_tx = self.bg_tx.clone();
+        let workflow_name = def.name.clone();
+        let pr_label = format!("{}#{}", pr_ref.repo_slug(), pr_ref.number);
+        let shutdown = Arc::clone(&self.workflow_shutdown);
+
+        self.state.status_message = Some(format!(
+            "Starting workflow '{workflow_name}' on {pr_label}…"
+        ));
+
+        let handle = std::thread::spawn(move || {
+            use conductor_core::workflow::{WorkflowExecConfig, WorkflowResult};
+            use conductor_core::workflow_ephemeral::run_workflow_on_pr;
+
+            let db = db_path();
+            let conn = match open_database(&db) {
+                Ok(c) => c,
+                Err(e) => {
+                    if let Some(ref tx) = bg_tx {
+                        let _ = tx.send(Action::BackgroundError {
+                            message: format!("Failed to open database: {e}"),
+                        });
+                    }
+                    return;
+                }
+            };
+
+            let exec_config = WorkflowExecConfig {
+                shutdown: Some(shutdown),
+                ..WorkflowExecConfig::default()
+            };
+
+            let result = run_workflow_on_pr(
+                &conn,
+                &config,
+                &pr_ref,
+                &def.name,
+                None,
+                exec_config,
+                std::collections::HashMap::new(),
+                false,
+            );
+
+            if let Some(ref tx) = bg_tx {
+                let msg = match result {
+                    Ok(WorkflowResult { all_succeeded, .. }) => {
+                        if all_succeeded {
+                            format!(
+                                "Workflow '{workflow_name}' on {pr_label} completed successfully"
+                            )
+                        } else {
+                            format!(
+                                "Workflow '{workflow_name}' on {pr_label} completed with failures"
+                            )
+                        }
+                    }
+                    Err(e) => format!("Workflow '{workflow_name}' on {pr_label} failed: {e}"),
+                };
+                let _ = tx.send(Action::BackgroundSuccess { message: msg });
+            }
+        });
+
+        self.workflow_threads.push(handle);
     }
 
     fn handle_resume_workflow(&mut self) {

--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -229,6 +229,15 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
                 _ => Action::None,
             };
         }
+        Modal::PrWorkflowPicker { .. } => {
+            return match key.code {
+                KeyCode::Esc => Action::DismissModal,
+                KeyCode::Up | KeyCode::Char('k') => Action::MoveUp,
+                KeyCode::Down | KeyCode::Char('j') => Action::MoveDown,
+                KeyCode::Enter => Action::InputSubmit,
+                _ => Action::None,
+            };
+        }
         Modal::None => {}
     }
 
@@ -323,6 +332,11 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
 
     // View-specific keybindings (RepoDetail)
     if state.view == View::RepoDetail {
+        if state.repo_detail_focus == crate::state::RepoDetailFocus::Prs {
+            if let KeyCode::Char('r') = key.code {
+                return Action::RunPrWorkflow;
+            }
+        }
         match key.code {
             KeyCode::Char('m') => return Action::SetModel,
             KeyCode::Char('I') => return Action::ToggleAgentIssues,

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -310,6 +310,13 @@ pub enum Modal {
         ticket_id: String,
         repo_path: String,
     },
+    /// Workflow picker for running a PR-targeted workflow against a selected PR.
+    PrWorkflowPicker {
+        pr_number: i64,
+        pr_title: String,
+        workflow_defs: Vec<WorkflowDef>,
+        selected: usize,
+    },
 }
 
 impl fmt::Debug for Modal {
@@ -351,6 +358,11 @@ impl fmt::Debug for Modal {
                 )
             }
             Modal::PostCreatePicker { .. } => write!(f, "Modal::PostCreatePicker"),
+            Modal::PrWorkflowPicker {
+                pr_number,
+                pr_title,
+                ..
+            } => write!(f, "Modal::PrWorkflowPicker(#{pr_number} {pr_title:?})"),
         }
     }
 }

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -183,5 +183,18 @@ pub fn render(frame: &mut Frame, state: &AppState) {
             *loading,
             error.as_deref(),
         ),
+        Modal::PrWorkflowPicker {
+            pr_number,
+            pr_title,
+            workflow_defs,
+            selected,
+        } => modal::render_pr_workflow_picker(
+            frame,
+            area,
+            *pr_number,
+            pr_title,
+            workflow_defs,
+            *selected,
+        ),
     }
 }

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -527,6 +527,69 @@ pub fn render_post_create_picker(
     frame.render_widget(content, popup);
 }
 
+pub fn render_pr_workflow_picker(
+    frame: &mut Frame,
+    area: Rect,
+    pr_number: i64,
+    pr_title: &str,
+    workflow_defs: &[conductor_core::workflow::WorkflowDef],
+    selected: usize,
+) {
+    let height = (workflow_defs.len() as u16 + 7).min(25);
+    let percent_y = ((height as f32 / area.height as f32) * 100.0) as u16;
+    let popup = centered_rect(60, percent_y.max(25), area);
+    frame.render_widget(Clear, popup);
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("  Run workflow on PR #{pr_number}: {pr_title}"),
+            Style::default().fg(Color::Cyan),
+        )),
+        Line::from(""),
+    ];
+
+    for (i, def) in workflow_defs.iter().enumerate() {
+        let is_selected = i == selected;
+        let prefix = if is_selected { "▸ " } else { "  " };
+
+        let style = if is_selected {
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::White)
+        };
+
+        let mut row = vec![
+            Span::styled(format!("  {prefix}"), style),
+            Span::styled(&def.name, style),
+        ];
+        if !def.description.is_empty() {
+            row.push(Span::styled(
+                format!("  — {}", def.description),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        lines.push(Line::from(row));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  Enter confirm  Esc cancel",
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    let content = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(" Run Workflow on PR "),
+    );
+
+    frame.render_widget(content, popup);
+}
+
 pub fn render_work_target_manager(
     frame: &mut Frame,
     area: Rect,

--- a/conductor-tui/src/ui/repo_detail.rs
+++ b/conductor-tui/src/ui/repo_detail.rs
@@ -237,12 +237,18 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
             .collect()
     };
 
+    let pr_title = if pr_focused && !state.detail_prs.is_empty() {
+        " PRs  r:run workflow "
+    } else {
+        " PRs "
+    };
+
     let pr_list = List::new(pr_items)
         .block(
             Block::default()
                 .borders(Borders::ALL)
                 .border_style(pr_border)
-                .title(" PRs "),
+                .title(pr_title),
         )
         .highlight_style(
             Style::default()


### PR DESCRIPTION
Wire up `r` keybinding in the PR pane of the repo detail view to open
a PrWorkflowPicker modal filtered to workflows with targets: [pr], then
spawn an ephemeral run via run_workflow_on_pr() using PrRef constructed
from the repo's remote URL and selected PR number.

- action.rs: add RunPrWorkflow action
- input.rs: emit RunPrWorkflow when r pressed with Prs focus; handle
  PrWorkflowPicker modal keys (Up/Down/Enter/Esc)
- state.rs: add Modal::PrWorkflowPicker { pr_number, pr_title,
  workflow_defs, selected }
- app.rs: handle_run_pr_workflow(), handle_pr_workflow_picker_confirm(),
  spawn_pr_workflow_in_background(); MoveUp/MoveDown for picker modal
- ui/modal.rs: render_pr_workflow_picker() popup
- ui/mod.rs: dispatch PrWorkflowPicker to renderer
- ui/repo_detail.rs: show "r:run workflow" hint in PR pane title when
  focused and PRs are present

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
