### PR TITLE
feat(skills): add Claude Code skills for workflow authoring (#499)

### DIFF
--- a/.claude/skills/conductor-workflow-create/SKILL.md
+++ b/.claude/skills/conductor-workflow-create/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: conductor-workflow-create
+description: Create a new conductor workflow (.wf file) from a plain-English description.
+---
+
+# conductor-workflow-create
+
+Guide the user through creating a new conductor workflow `.wf` file from scratch.
+
+## Steps
+
+### 0. Read the canonical DSL reference
+
+Read `docs/workflow/engine.md` for the full grammar, all constructs, and design rationale. This is the authoritative source — use it throughout this session.
+
+### 1. Gather intent
+
+Ask the user:
+- What should this workflow do? (plain-English description)
+- What does it operate on? (`worktree` for branch-level work, `repo` for repo-level work, or both)
+- What should the workflow be named? (suggest a hyphenated slug from their description if they don't provide one)
+- Are there any required inputs the workflow needs from the user at run time? (e.g., `ticket_id`, `pr_url`)
+
+If the user already provided this information as arguments to the skill, skip to step 2.
+
+### 2. Introspect existing repo state
+
+Run these commands to understand what's available:
+
+```bash
+ls .conductor/agents/
+```
+```bash
+ls .conductor/workflows/
+```
+```bash
+ls .conductor/prompts/ 2>/dev/null || echo "(no prompts directory)"
+```
+
+Note the exact filenames (without `.md`/`.wf` extension) — these are the identifiers you can use in `call` statements. Do not suggest `call` targets that don't exist without noting they need to be created.
+
+### 3. Draft the workflow structure
+
+Design the `.wf` file using the correct DSL constructs. Key rules:
+
+**Structure:**
+```
+workflow <name> {
+  meta {
+    description = "..."
+    trigger     = "manual"
+    targets     = ["worktree"]   # or ["repo"] or ["worktree", "repo"]
+  }
+
+  inputs {
+    my_input required
+    optional_input default = "value"
+  }
+
+  # steps go here
+}
+```
+
+**Choosing constructs:**
+- Sequential agent call: `call <agent-name>`
+- Conditional: `if <step>.<marker> { ... }` or `unless <step>.<marker> { ... }`
+- Loop (check before first run): `while <step>.<marker> { max_iterations = N ... }`
+- Loop (always run at least once): `do { ... } while <step>.<marker>`
+- Parallel agents: `parallel { call a; call b; call c }`
+- Human gate: `gate human_review { prompt = "..." timeout = "48h" on_timeout = fail }`
+- Automated gate: `gate pr_checks { timeout = "2h" on_timeout = fail }`
+- Always run (cleanup/notify): `always { call notify-result }`
+- Compose another workflow: `call workflow <name>`
+
+**Loop options** (required/optional):
+- `max_iterations = N` — **required** on `while` and `do {} while`
+- `stuck_after = N` — optional, must be < `max_iterations`
+- `on_max_iter = fail` — optional, defaults to `fail`
+
+**Context threading:**
+- `{{prior_context}}` — context string from the immediately preceding step
+- `{{prior_contexts}}` — JSON array of all prior step contexts
+- `{{gate_feedback}}` — feedback text from a `human_review` gate
+
+**Prompt snippets** (reusable `.md` files from `.conductor/prompts/`):
+```
+call review { with = ["review-diff-scope"] }
+parallel { with = ["review-diff-scope"]; call review-security }
+```
+
+**Workflow composition:**
+```
+call workflow lint-fix
+call workflow test-coverage { inputs { pr_url = "{{pr_url}}" } }
+```
+Avoid creating a cycle — check existing `.wf` files to ensure the workflow you're creating doesn't reference a workflow that would transitively reference it back.
+
+### 4. Identify missing agents
+
+Compare the `call` statements in your draft against the existing agents listed in step 2. For any agent that doesn't exist yet, note that you will need to create a stub `.md` file at `.conductor/agents/<name>.md`.
+
+Stub format:
+```markdown
+---
+role: actor
+can_commit: false
+---
+
+You are a ... agent. Your task is: ...
+
+Prior step context: {{prior_context}}
+
+[TODO: flesh out this prompt]
+```
+
+Use `role: reviewer` and `can_commit: false` for read-only agents (reviewers, validators).
+Use `role: actor` and `can_commit: true` for agents that write code or commit changes.
+
+### 5. Present the plan and confirm
+
+Show the user:
+1. The proposed `.wf` file contents
+2. Any new agent stub files that will be created
+3. A brief explanation of why each construct was chosen
+
+Ask for confirmation before writing any files. If the user wants changes, revise and show again.
+
+### 6. Write the files
+
+Write the `.wf` file:
+```
+.conductor/workflows/<name>.wf
+```
+
+Write any new agent stub files:
+```
+.conductor/agents/<name>.md
+```
+
+### 7. Validate
+
+Run validation using one of these commands (try `conductor` first, fall back to `cargo run`):
+
+```bash
+conductor workflow validate <name>
+```
+
+If that fails with "command not found":
+```bash
+cargo run --bin conductor -- workflow validate <name>
+```
+
+### 8. Report results
+
+If validation passes:
+- Confirm what was created
+- List any agent stub files that still need their prompts fleshed out
+- Suggest a test run: `conductor workflow run <name> --dry-run`
+
+If validation fails:
+- Interpret each error (see `/conductor-workflow-validate` for error guidance)
+- Fix the issues and re-validate before declaring done
+
+## Notes
+
+- The `targets` field in `meta` is required. Use `["worktree"]` for branch-scoped work, `["repo"]` for repository-level work.
+- Agent names in `call` statements must match the filename without `.md` (e.g., `call review-security` resolves to `.conductor/agents/review-security.md`).
+- `while` and `do {} while` conditions reference `<step-name>.<marker>` where `<step-name>` is the name of a prior `call` statement and `<marker>` is a string the agent emits in its `CONDUCTOR_OUTPUT` markers array.
+- A workflow that only calls read-only agents can still be useful — dry-run mode is safe for all agents with `can_commit: false`.

--- a/.claude/skills/conductor-workflow-update/SKILL.md
+++ b/.claude/skills/conductor-workflow-update/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: conductor-workflow-update
+description: Apply a plain-English change request to an existing conductor workflow (.wf file).
+---
+
+# conductor-workflow-update
+
+Apply a plain-English change to an existing conductor workflow `.wf` file.
+
+## Steps
+
+### 0. Read the canonical DSL reference
+
+Read `docs/workflow/engine.md` for the full grammar, all constructs, and design rationale. This is the authoritative source — use it throughout this session.
+
+### 1. Identify the target workflow
+
+If the user specified a workflow name in their request, use it. Otherwise:
+
+```bash
+ls .conductor/workflows/
+```
+
+List the available workflows and ask the user which one to modify.
+
+### 2. Read the current workflow
+
+Read the `.wf` file:
+```bash
+cat .conductor/workflows/<name>.wf
+```
+
+Also introspect available agents and prompts to ensure any additions you suggest actually exist:
+
+```bash
+ls .conductor/agents/
+ls .conductor/prompts/ 2>/dev/null || echo "(no prompts directory)"
+```
+
+### 3. Understand the change request
+
+Parse the user's plain-English request. Map it to the relevant DSL construct. Common patterns:
+
+| Request | DSL change |
+|---|---|
+| "Add a human review gate before merging" | Insert `gate human_review { ... }` at the correct position |
+| "Increase the review loop iteration cap" | Update `max_iterations` on the `while`/`do {} while` block |
+| "Add a performance reviewer to the parallel block" | Add `call review-performance` inside `parallel { ... }` |
+| "Run cleanup even if the workflow fails" | Wrap the cleanup call in `always { ... }` |
+| "Skip the tests if tests are already passing" | Add `unless build.has_test_failures { call run-tests }` |
+| "Make the review loop run at least once" | Change `while` to `do { ... } while` |
+| "Add a prompt snippet for code conventions" | Add `with = ["<snippet-name>"]` to the relevant `call` or `parallel` |
+| "Add an input parameter" | Add entry to the `inputs { }` block |
+
+If the change involves adding a new `call <agent>`:
+- Check if `.conductor/agents/<agent>.md` exists
+- If not, note that you'll need to create a stub and warn the user
+
+If the change involves adding a `call workflow <name>`:
+- Check if `.conductor/workflows/<name>.wf` exists
+- Check for potential cycles: verify the referenced workflow does not (directly or transitively) call back to the workflow being modified
+
+### 4. Plan the edit
+
+Before making changes, state explicitly:
+1. Which line(s)/block(s) in the current `.wf` file will change
+2. What DSL construct is being added/modified and why it's the right choice
+3. Any new files that need to be created (agent stubs, prompt files)
+
+Example explanation: "Changing `while` to `do {} while` so the review step always runs at least once — with `while`, if the prior step emits no markers the body never executes."
+
+### 5. Apply the change
+
+Make the minimal edit necessary. Do not refactor or reformat parts of the file that the user didn't ask to change. Preserve existing comments and spacing.
+
+Key rules to maintain:
+- `while` and `do {} while` require `max_iterations = N` (required)
+- `stuck_after` must be strictly less than `max_iterations` if both are set
+- `targets` must remain in `meta { }` (required field)
+- All `call <agent>` targets must resolve to existing `.md` files (or new stubs you create)
+- All `with = [...]` snippet references must resolve to existing `.md` files in `.conductor/prompts/`
+
+### 6. Create any new agent stubs
+
+For each new `call` target that doesn't have an existing agent file:
+
+```markdown
+---
+role: actor
+can_commit: false
+---
+
+You are a ... agent. Your task is: ...
+
+Prior step context: {{prior_context}}
+
+[TODO: flesh out this prompt]
+```
+
+Write to `.conductor/agents/<name>.md`.
+
+### 7. Write the updated workflow
+
+Rewrite `.conductor/workflows/<name>.wf` with the applied changes.
+
+### 8. Validate
+
+```bash
+conductor workflow validate <name>
+```
+
+If `conductor` is not on PATH:
+```bash
+cargo run --bin conductor -- workflow validate <name>
+```
+
+### 9. Summarize
+
+Report:
+- What changed (line-level summary)
+- Why the chosen DSL construct is correct for this use case
+- Any new files created
+- Any TODOs remaining (e.g., "stub agent at `.conductor/agents/review-performance.md` still needs its prompt fleshed out")
+- If validation passed
+
+If validation failed, interpret and fix each error before declaring done.
+
+## Notes
+
+- Prefer minimal diffs. Only change what the user asked to change.
+- If the user's request is ambiguous (e.g., "make the loop better"), ask a clarifying question before editing.
+- When adding a gate, consider the most natural position: human approval gates typically come before irreversible steps (push, merge, deploy); human review gates come after agent-generated findings.
+- `gate human_review` accepts written feedback via `{{gate_feedback}}` in the next step — mention this if the user is adding a review gate so they know to thread it into the downstream agent prompt.
+- Dry-run the updated workflow to verify it is structurally sound: `conductor workflow run <name> --dry-run`.

--- a/.claude/skills/conductor-workflow-validate/SKILL.md
+++ b/.claude/skills/conductor-workflow-validate/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: conductor-workflow-validate
+description: Run conductor workflow validate, interpret each error, and offer actionable fixes.
+---
+
+# conductor-workflow-validate
+
+Run `conductor workflow validate`, interpret each error type, and offer actionable fixes.
+
+## Steps
+
+### 1. Determine which workflow(s) to validate
+
+If the user named a specific workflow, validate that one. Otherwise, validate all:
+
+```bash
+ls .conductor/workflows/
+```
+
+### 2. Run validation
+
+For a specific workflow:
+```bash
+conductor workflow validate <name>
+```
+
+For all workflows (iterate over each `.wf` file):
+```bash
+for f in .conductor/workflows/*.wf; do
+  name="${f%.wf}"; name="${name#.conductor/workflows/}"
+  echo "=== $name ==="
+  conductor workflow validate "$name"
+done
+```
+
+If `conductor` is not on PATH, use:
+```bash
+cargo run --bin conductor -- workflow validate <name>
+```
+
+### 3. Interpret each error
+
+Parse the output and categorize every error. For each one, explain the root cause and suggest a concrete fix.
+
+---
+
+#### Missing agent `.md` file
+
+**Symptom:** `agent not found: <name>` or similar, listing paths that were searched.
+
+**Cause:** A `call <name>` statement references an agent that has no `.md` file in the resolution order:
+1. `.conductor/workflows/<workflow>/agents/<name>.md` (workflow-local)
+2. `.conductor/agents/<name>.md` (shared)
+
+(Each path is checked in the worktree first, then the repo root.)
+
+**Fix options:**
+- Create the agent file at `.conductor/agents/<name>.md` (most common)
+- Create a workflow-local override at `.conductor/workflows/<workflow>/agents/<name>.md`
+- Rename the `call` statement to match an existing agent
+
+Offer to create a stub:
+```markdown
+---
+role: reviewer
+can_commit: false
+---
+
+You are a ... agent. Your task is: ...
+
+Prior step context: {{prior_context}}
+
+[TODO: flesh out this prompt]
+```
+
+---
+
+#### Unresolved `with` snippet
+
+**Symptom:** `prompt snippet not found: <name>` or similar, listing paths searched.
+
+**Cause:** A `with = ["<name>"]` reference has no matching `.md` file in the resolution order:
+1. `.conductor/workflows/<workflow>/prompts/<name>.md` (workflow-local)
+2. `.conductor/prompts/<name>.md` (shared)
+
+**Fix options:**
+- Create the snippet at `.conductor/prompts/<name>.md`
+- Create a workflow-local snippet at `.conductor/workflows/<workflow>/prompts/<name>.md`
+- Remove the `with` reference if it's no longer needed
+- Correct the snippet name to match an existing file
+
+Offer to create a stub prompt file with placeholder content.
+
+---
+
+#### Circular workflow reference
+
+**Symptom:** `Circular workflow reference: a -> b -> c -> a` or similar.
+
+**Cause:** `call workflow` statements create a reference cycle. The engine detects this statically (it does not depend on runtime conditions — even an `if`-guarded reference counts).
+
+**Fix:** Break the cycle by refactoring. Options:
+- Extract the shared steps into a third workflow that both can call without creating a cycle
+- Inline the steps from one workflow into the other instead of using `call workflow`
+- Remove one of the `call workflow` references if it was unintentional
+
+Show the full cycle chain (e.g., `a → b → c → a`) and identify which link is the easiest to break.
+
+---
+
+#### Missing `targets` declaration
+
+**Symptom:** `missing required field: targets` or similar.
+
+**Cause:** The `meta { }` block does not include a `targets` field.
+
+**Fix:** Add `targets` to the `meta` block:
+```
+meta {
+  description = "..."
+  trigger     = "manual"
+  targets     = ["worktree"]
+}
+```
+
+Valid values:
+- `["worktree"]` — workflow operates on a git worktree (branch-scoped work)
+- `["repo"]` — workflow operates at the repository level
+- `["worktree", "repo"]` — workflow can run in either context
+
+---
+
+#### Loop configuration error (`max_iterations` / `stuck_after`)
+
+**Symptom:** `max_iterations is required` or `stuck_after must be less than max_iterations`.
+
+**Cause A — missing `max_iterations`:** Every `while` and `do {} while` loop requires `max_iterations = N`. This is mandatory to prevent infinite loops.
+
+**Fix:** Add `max_iterations = N` inside the loop body. Choose a value that allows enough iterations for the task but prevents runaway loops (e.g., 5–10 for review loops).
+
+```
+while review.has_issues {
+  max_iterations = 5
+  on_max_iter    = fail
+  call address-reviews
+  call review
+}
+```
+
+**Cause B — `stuck_after` ≥ `max_iterations`:** If `stuck_after` is set, it must be strictly less than `max_iterations`.
+
+**Fix:** Either decrease `stuck_after` or increase `max_iterations`.
+
+---
+
+#### Unknown gate type
+
+**Symptom:** `unknown gate type: <value>`.
+
+**Cause:** `gate` only accepts: `human_approval`, `human_review`, `pr_approval`, `pr_checks`.
+
+**Fix:** Correct the gate type to one of the valid values.
+
+| Gate type | Use case |
+|---|---|
+| `human_approval` | Block until a human explicitly approves (no feedback text) |
+| `human_review` | Block for human review; feedback injected as `{{gate_feedback}}` |
+| `pr_approval` | Block until the PR has the required number of GitHub approvals |
+| `pr_checks` | Block until all PR CI checks pass |
+
+---
+
+#### Other / unknown errors
+
+For any error not covered above:
+1. Quote the exact error message
+2. Identify the line in the `.wf` file it refers to (read the file if needed)
+3. Explain what the parser expected vs. what it found
+4. Offer a concrete fix
+
+### 4. Apply fixes
+
+For each error, offer to apply the fix directly. Make the smallest correct change. After applying all fixes, re-run validation.
+
+### 5. Confirm clean
+
+Re-run `conductor workflow validate <name>` after all fixes. Report the final result:
+- If clean: "Validation passed — no errors found."
+- If still failing: iterate until clean or ask the user for clarification.
+
+## Notes
+
+- Validation is always safe to run — it reads files and checks structure, it does not execute any agents or modify state.
+- If `conductor` is not built yet, run `cargo build --bin conductor` first.
+- `conductor workflow validate` checks agents, snippets, and cycles. It does not check that agent prompts make semantic sense — that requires reading the individual `.md` files.
+- After validation passes, suggest a dry run to verify runtime behavior: `conductor workflow run <name> --dry-run`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,114 @@
+# Plan: Claude Code Skill for Workflow Authoring (#499)
+
+## Summary
+
+Add three Claude Code skills to lower the barrier for workflow authoring. Skills live in `.claude/skills/` as `SKILL.md` files and appear in Claude Code's `/` command menu. No Rust changes are needed — this is purely new skill definition files.
+
+The three skills are:
+- **`/conductor-workflow-create`** — Guided workflow authoring from a plain-English description
+- **`/conductor-workflow-update`** — Plain-English change requests against an existing workflow
+- **`/conductor-workflow-validate`** — Interpret `conductor workflow validate` output and surface actionable fixes
+
+---
+
+## Files to Create
+
+### `.claude/skills/conductor-workflow-create/SKILL.md`
+
+Guides Claude through creating a new workflow from scratch:
+
+1. Ask the user what the workflow should do and what it operates on (`targets`)
+2. Introspect existing repo state:
+   - `ls .conductor/agents/` — available agents to `call`
+   - `ls .conductor/workflows/` — existing workflows for `call workflow` composition (and cycle-avoidance)
+   - `ls .conductor/prompts/` — available prompt snippets for `with =`
+3. Draft a `.wf` structure using the appropriate DSL constructs
+4. Identify any new agent `.md` files that need to be created (with frontmatter stubs)
+5. Write the `.wf` file to `.conductor/workflows/<name>.wf`
+6. Write any new agent stub files to `.conductor/agents/<name>.md`
+7. Run `conductor workflow validate <name>` to confirm clean
+8. Report what was created and any remaining TODOs (e.g., flesh out agent prompts)
+
+**DSL knowledge to embed:** Full grammar, all constructs (`call`, `parallel`, `if`/`unless`/`while`/`do {} while`, `do`, `gate`, `always`), loop options (`max_iterations` required, `stuck_after` optional, `on_max_iter`), gate types (`human_approval`, `human_review`, `pr_approval`, `pr_checks`), agent frontmatter schema, context threading (`{{prior_context}}`, `{{prior_contexts}}`), `CONDUCTOR_OUTPUT` block format, composition via `call workflow`, agent/snippet resolution order.
+
+The skill instructs Claude to read `docs/workflow/engine.md` at the start for the canonical DSL reference.
+
+### `.claude/skills/conductor-workflow-update/SKILL.md`
+
+Applies a plain-English change to an existing workflow:
+
+1. Identify which workflow to update: list `.conductor/workflows/*.wf` and ask the user if not obvious from context
+2. Read the existing `.wf` file
+3. Introspect existing agents and prompts to ensure suggested additions actually exist
+4. Apply the change — explain what DSL construct is being modified and why
+5. Rewrite the `.wf` file (prefer minimal diffs — only change what's needed)
+6. Create any new agent stubs if the change requires a new `call` target
+7. Run `conductor workflow validate <name>`
+8. Summarize what changed and why, referencing DSL semantics (e.g., "Changed `while` to `do {} while` so the review step always runs at least once")
+
+**Example changes to handle:**
+- "Add a human review gate before merging" → insert `gate human_review { ... }` at correct position
+- "Increase the review loop iteration cap" → update `max_iterations` on the loop
+- "Add a performance reviewer to the parallel block" → add `call review-performance` inside `parallel { ... }`, warn if `review-performance.md` doesn't exist
+
+### `.claude/skills/conductor-workflow-validate/SKILL.md`
+
+Interprets `conductor workflow validate` output and surfaces actionable fixes:
+
+1. Determine which workflow(s) to validate: validate all if no name given, or specific workflow if named
+2. Run `conductor workflow validate <name>` (or for all: iterate over `.conductor/workflows/*.wf`)
+3. Parse output and categorize each error:
+   - **Missing agent `.md` files** — show the resolution order that was searched, suggest the correct file path, offer to create a stub
+   - **Unresolved `with` snippets** — show the search paths, suggest `.conductor/prompts/<name>.md`, offer to create a stub
+   - **Cycle errors** — explain the full reference chain (e.g., `a → b → c → a`), explain which workflow to refactor to break the cycle
+   - **Missing `targets` declaration** — explain what `targets` means, show valid values (`worktree`, `repo`)
+   - **`stuck_after` / `max_iterations` misconfiguration** — explain that `max_iterations` is required on `while`/`do {} while`, `stuck_after` must be less than `max_iterations`
+4. For each error, offer to apply the fix directly
+5. Re-run validation after fixes and confirm clean
+
+---
+
+## Design Decisions
+
+### Three separate skills vs one multi-command skill
+
+The ticket proposes a single `conductor-workflow` skill with three sub-commands. Claude Code's `/` menu works best with discrete skills, so this plan uses three separate skills (`conductor-workflow-create`, `conductor-workflow-update`, `conductor-workflow-validate`). Each maps 1:1 to a command, is independently readable, and avoids branching logic in a single large SKILL.md.
+
+### DSL knowledge in skills vs referencing docs
+
+Skills instruct Claude to **read `docs/workflow/engine.md` at the start of each session**. This keeps the SKILL.md files focused on procedure, not DSL documentation, and ensures they stay accurate as the DSL evolves. Key DSL constructs are also summarized inline as a quick reference for the most common patterns.
+
+### Introspection approach
+
+Skills use shell commands (`ls`, `cat`, `conductor workflow validate`) to inspect actual repo state before suggesting anything. This is what the ticket calls "contextually correct suggestions" — the skill won't suggest `call review-security` if that agent doesn't exist.
+
+### No Rust changes
+
+This feature is entirely skill authoring. The `conductor workflow validate` command already exists and surfaces the right error messages. The skills layer intent and explanation on top of existing tooling.
+
+---
+
+## Risks and Unknowns
+
+- **Skill naming convention**: Claude Code's skill menu currently shows `rebase-and-fix-review`. There's no established precedent for multi-word skill groups. Using `conductor-workflow-create` etc. is the safest bet.
+- **`conductor` binary availability**: The validate skill runs `conductor workflow validate`. If the binary isn't built or on PATH, the skill should fall back to `cargo run --bin conductor -- workflow validate` or explain the issue.
+- **Skill args support**: Claude Code's Skill tool accepts `args`, so `/conductor-workflow-create` with no args works, but users may try `/conductor-workflow create` (space-separated). Document the correct invocation in each SKILL.md.
+
+---
+
+## Task List
+
+### task-1: Create conductor-workflow-create skill
+**Files:** `.claude/skills/conductor-workflow-create/SKILL.md`
+
+Full step-by-step skill for guided workflow creation: gather intent, introspect repo, draft DSL, write files, validate.
+
+### task-2: Create conductor-workflow-update skill
+**Files:** `.claude/skills/conductor-workflow-update/SKILL.md`
+
+Step-by-step skill for applying plain-English changes to an existing workflow: read current state, apply change, rewrite, validate.
+
+### task-3: Create conductor-workflow-validate skill
+**Files:** `.claude/skills/conductor-workflow-validate/SKILL.md`
+
+Step-by-step skill for interpreting validate output: categorize errors, explain causes, offer fixes, re-validate.


### PR DESCRIPTION
Add three Claude Code skills that lower the barrier for conductor workflow DSL authoring:

- /conductor-workflow-create: guided .wf file creation from plain-English intent;
  introspects existing agents/prompts/workflows, drafts correct DSL constructs,
  writes files, creates agent stubs, and validates.

- /conductor-workflow-update: applies plain-English changes to existing workflows;
  reads current state, maps the request to the right DSL construct, applies minimal
  edits, and re-validates.

- /conductor-workflow-validate: interprets `conductor workflow validate` output with
  actionable fix guidance for every error type (missing agents, unresolved snippets,
  cycle errors, missing targets, loop misconfiguration).

No Rust changes — pure SKILL.md additions under .claude/skills/.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
