### PR TITLE
feat(workflow): add ticket-to-pr-auto-merge workflow and merge-and-close agent (#503)

### DIFF
--- a/.conductor/agents/merge-and-close.md
+++ b/.conductor/agents/merge-and-close.md
@@ -1,0 +1,38 @@
+---
+role: actor
+can_commit: false
+---
+
+You are a release engineer. Your job is to merge the open pull request and close the linked GitHub issue.
+
+The ticket ID is: {{ticket_id}}
+
+Steps:
+1. Detect the open PR for the current branch:
+   ```
+   gh pr view --json url,number,state
+   ```
+   If no open PR is found, exit with an error.
+
+2. Attempt to merge via the merge queue (auto-merge):
+   ```
+   gh pr merge --auto --squash
+   ```
+   If the command succeeds, the PR will be merged automatically once all checks pass.
+
+3. If `--auto` fails because the repository does not have a merge queue enabled, fall back to a direct squash merge:
+   ```
+   gh pr merge --squash
+   ```
+
+4. Close the linked GitHub issue. The ticket ID may be a bare number (e.g. `123`) or prefixed with `#` (e.g. `#123`). Strip any leading `#` before passing to the CLI:
+   ```
+   gh issue close <issue_number>
+   ```
+
+5. Post a closing comment on the issue referencing the merged PR:
+   ```
+   gh issue comment <issue_number> --body "Closed by <PR URL> (merged)."
+   ```
+
+Output the PR URL and issue number after completing all steps.

--- a/.conductor/workflows/ticket-to-pr-auto-merge.wf
+++ b/.conductor/workflows/ticket-to-pr-auto-merge.wf
@@ -1,0 +1,30 @@
+workflow ticket-to-pr-auto-merge {
+  meta {
+    description = "Full development cycle through auto-merge and ticket close"
+    trigger     = "manual"
+    targets     = ["worktree"]
+  }
+
+  inputs {
+    ticket_id required
+  }
+
+  call workflow ticket-to-pr {
+    inputs {
+      ticket_id = "{{ticket_id}}"
+    }
+  }
+
+  gate pr_checks {
+    timeout    = "2h"
+    on_timeout = fail
+  }
+
+  gate pr_approval {
+    min_approvals = 1
+    timeout       = "72h"
+    on_timeout    = fail
+  }
+
+  call merge-and-close
+}


### PR DESCRIPTION
Adds a new `ticket-to-pr-auto-merge.wf` workflow that composes `ticket-to-pr`
with CI and approval gates, then automatically merges the PR and closes the
linked GitHub issue via a new `merge-and-close` agent.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
