### PR TITLE
feat(agent): auto-start tmux session when no server is running

### DIFF
--- a/conductor-core/src/agent.rs
+++ b/conductor-core/src/agent.rs
@@ -916,6 +916,13 @@ impl<'a> AgentManager<'a> {
             Err(ConductorError::Agent(
                 "tmux select-window failed".to_string(),
             ))
+        } else if stderr.contains("No such file or directory")
+            || stderr.contains("error connecting to")
+        {
+            Err(ConductorError::Agent(
+                "tmux is not running — start a tmux session first, then relaunch conductor"
+                    .to_string(),
+            ))
         } else {
             Err(ConductorError::Agent(format!(
                 "tmux select-window failed: {stderr}"

--- a/conductor-core/src/agent_runtime.rs
+++ b/conductor-core/src/agent_runtime.rs
@@ -32,6 +32,9 @@ fn resolve_conductor_bin() -> String {
 /// `args` are the arguments passed to the `conductor` binary (e.g.
 /// `["agent", "run", "--run-id", …]`).  `window_name` is used as the tmux
 /// window name (`-n`) and for post-spawn verification.
+///
+/// If no tmux server is running, a detached session named `conductor` is
+/// created automatically so agents can run without a pre-existing tmux session.
 pub fn spawn_tmux_window(args: &[String], window_name: &str) -> std::result::Result<(), String> {
     let conductor_bin = resolve_conductor_bin();
 
@@ -41,7 +44,7 @@ pub fn spawn_tmux_window(args: &[String], window_name: &str) -> std::result::Res
         "-n".to_string(),
         window_name.to_string(),
         "--".to_string(),
-        conductor_bin,
+        conductor_bin.clone(),
     ];
     tmux_args.extend_from_slice(args);
 
@@ -51,11 +54,37 @@ pub fn spawn_tmux_window(args: &[String], window_name: &str) -> std::result::Res
         .map_err(|e| format!("Failed to spawn tmux: {e}"))?;
 
     if result.status.success() {
-        verify_tmux_window(window_name)
-    } else {
-        let stderr = String::from_utf8_lossy(&result.stderr);
-        Err(format!("tmux failed: {stderr}"))
+        return verify_tmux_window(window_name);
     }
+
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    // No tmux server running — create a detached session and retry.
+    if stderr.contains("No such file or directory") || stderr.contains("error connecting to") {
+        let mut session_args = vec![
+            "new-session".to_string(),
+            "-d".to_string(),
+            "-s".to_string(),
+            "conductor".to_string(),
+            "-n".to_string(),
+            window_name.to_string(),
+            "--".to_string(),
+            conductor_bin,
+        ];
+        session_args.extend_from_slice(args);
+
+        let retry = Command::new("tmux")
+            .args(&session_args)
+            .output()
+            .map_err(|e| format!("Failed to start tmux session: {e}"))?;
+
+        if retry.status.success() {
+            return verify_tmux_window(window_name);
+        }
+        let retry_stderr = String::from_utf8_lossy(&retry.stderr);
+        return Err(format!("Failed to start tmux session: {retry_stderr}"));
+    }
+
+    Err(format!("tmux failed: {stderr}"))
 }
 
 /// After a successful `tmux new-window`, wait briefly and verify the window


### PR DESCRIPTION
## Summary

- When launching an agent and no tmux server is running, `spawn_tmux_window` now falls back to `tmux new-session -d -s conductor -n <window>` automatically instead of failing
- Improves `attach_agent_window` error message from raw socket path error to a human-readable "tmux is not running" message

## Test plan

- [x] Launch `conductor-tui` outside of any tmux session
- [x] Start an agent — it should launch successfully (tmux session `conductor` created in background)
- [x] Launch a second agent — should use `new-window` into the existing session
- [x] Confirm agent status updates in TUI as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)