### PR TITLE
feat(tui): confirmation modal before quitting (#523)

### DIFF
--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -283,7 +283,13 @@ impl App {
                 // so this is cheap).
                 return true;
             }
-            Action::Quit => self.state.should_quit = true,
+            Action::Quit => {
+                if matches!(self.state.modal, Modal::None) {
+                    self.show_confirm_quit();
+                } else {
+                    self.state.should_quit = true;
+                }
+            }
 
             // Navigation
             Action::Back => self.go_back(),
@@ -890,7 +896,7 @@ impl App {
 
     fn go_back(&mut self) {
         match self.state.view {
-            View::Dashboard => self.state.should_quit = true,
+            View::Dashboard => self.show_confirm_quit(),
             View::RepoDetail => {
                 self.state.view = View::Dashboard;
                 self.state.selected_repo_id = None;
@@ -1720,7 +1726,33 @@ impl App {
                     }
                 }
             }
+            ConfirmAction::Quit => {
+                self.state.should_quit = true;
+            }
         }
+    }
+
+    fn show_confirm_quit(&mut self) {
+        let running = self
+            .state
+            .data
+            .latest_agent_runs
+            .values()
+            .filter(|r| r.status == conductor_core::agent::AgentRunStatus::Running)
+            .count();
+        let message = if running == 0 {
+            "Quit conductor?".to_string()
+        } else {
+            format!(
+                "{running} agent{} running. Quit anyway?",
+                if running == 1 { " is" } else { "s are" }
+            )
+        };
+        self.state.modal = Modal::Confirm {
+            title: "Confirm Quit".to_string(),
+            message,
+            on_confirm: ConfirmAction::Quit,
+        };
     }
 
     fn handle_input_submit(&mut self) {

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -453,6 +453,7 @@ pub enum ConfirmAction {
     ResumeWorkflow {
         workflow_run_id: String,
     },
+    Quit,
 }
 
 #[derive(Debug, Clone)]

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -26,7 +26,7 @@ pub fn render_confirm(frame: &mut Frame, area: Rect, title: &str, message: &str)
                     .fg(Color::Green)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::raw(" = confirm    "),
+            Span::raw("/Enter = confirm    "),
             Span::styled(
                 "n",
                 Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),


### PR DESCRIPTION
Intercept all three quit paths (q, Ctrl+C, Esc on Dashboard) with a
ConfirmQuit modal. The modal shows the count of running agents when
non-zero. y/Enter confirms quit; n/Esc dismisses. Ctrl+C while any
modal is already open force-quits without a second confirmation.

Reuses existing Modal::Confirm + ConfirmAction infrastructure — no new
renderer needed. Adds ConfirmAction::Quit variant and show_confirm_quit()
helper. Updates render_confirm hint to show y/Enter = confirm.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
