### PR TITLE
feat(workflows): add iterate-pr workflow for retrying failed ticket-to-pr runs

### DIFF
--- a/.conductor/agents/push.md
+++ b/.conductor/agents/push.md
@@ -1,0 +1,15 @@
+---
+role: actor
+can_commit: false
+---
+
+You are a push agent. The PR already exists — your only task is to push the current branch to the remote.
+
+Steps:
+1. Run `git push --force-with-lease origin HEAD` to push the current branch.
+2. If the push succeeds, report the branch name and remote in your context output.
+3. If the push fails, report the error clearly. Do not retry — let the workflow fail.
+
+Do not create or update the PR description. Do not run any other git commands.
+
+Prior step context: {{prior_context}}

--- a/.conductor/agents/resolve-conflicts.md
+++ b/.conductor/agents/resolve-conflicts.md
@@ -1,0 +1,18 @@
+---
+role: actor
+can_commit: true
+---
+
+You are a merge conflict resolution agent. The current branch has conflicts with main that need to be resolved before the PR can proceed.
+
+Steps:
+1. Run `git fetch origin && git rebase origin/main` to begin the rebase.
+2. For each conflicting file, open it and resolve the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`). Use your best judgement to produce a correct, coherent result that preserves the intent of both sides.
+3. After resolving each file, stage it with `git add <file>`.
+4. Continue the rebase with `git rebase --continue`. Repeat for any further conflicts.
+5. If a conflict is too complex or ambiguous to resolve safely, abort with `git rebase --abort` and emit the `failed` marker with a clear explanation of which files could not be resolved and why.
+6. If all conflicts are resolved and the rebase completes successfully, emit no markers and summarise what was resolved in your context output.
+
+Do not emit the `failed` marker unless you genuinely cannot resolve the conflicts. Prefer resolving over aborting.
+
+Prior step context: {{prior_context}}

--- a/.conductor/agents/sync-with-main.md
+++ b/.conductor/agents/sync-with-main.md
@@ -1,0 +1,16 @@
+---
+role: actor
+can_commit: false
+---
+
+You are a git sync agent. Your task is to sync the current branch with the latest main branch.
+
+Steps:
+1. Run `git fetch origin`
+2. Attempt to rebase onto `origin/main`: `git rebase origin/main`
+3. If the rebase succeeds with no conflicts, emit no markers and report success in context.
+4. If the rebase fails due to conflicts, abort the rebase (`git rebase --abort`) and emit the `has_conflicts` marker. List the conflicting files in your context output.
+
+Do not resolve conflicts yourself — just detect and report them.
+
+Prior step context: {{prior_context}}

--- a/.conductor/workflows/iterate-pr.wf
+++ b/.conductor/workflows/iterate-pr.wf
@@ -1,0 +1,27 @@
+workflow iterate-pr {
+  meta {
+    description = "Sync with main, resolve conflicts, lint, then iterate review until clean"
+    trigger     = "manual"
+    targets     = ["worktree"]
+  }
+
+  do {
+    max_iterations = 10
+    on_max_iter    = fail
+
+    call sync-with-main
+
+    if sync-with-main.has_conflicts {
+      call resolve-conflicts
+      call push
+    }
+
+    call workflow lint-fix
+
+    call workflow review-pr
+
+    if review-pr.has_review_issues {
+      call address-reviews
+    }
+  } while review-pr.has_review_issues
+}

--- a/.conductor/workflows/ticket-to-pr.wf
+++ b/.conductor/workflows/ticket-to-pr.wf
@@ -15,18 +15,7 @@ workflow ticket-to-pr {
     retries = 2
   }
 
-  call workflow lint-fix
-
   call push-and-pr
 
-  do {
-    max_iterations = 10
-    on_max_iter    = fail
-
-    call workflow review-pr
-
-    if review-aggregator.has_review_issues {
-      call address-reviews
-    }
-  } while review-aggregator.has_review_issues
+  call workflow iterate-pr
 }


### PR DESCRIPTION
## Summary

- Adds `iterate-pr.wf` — a standalone workflow for cases where `ticket-to-pr` has already created a PR but failed mid-run. Syncs with main, resolves merge conflicts, lints, then iterates the review swarm until clean.
- Refactors `ticket-to-pr.wf` to delegate the entire post-push review loop to `call workflow iterate-pr`, eliminating duplication.
- Adds three new agent stubs: `sync-with-main`, `resolve-conflicts`, `push`.

## New workflow: `iterate-pr`

```
do (max 10 iterations):
  1. sync-with-main          — fetch + rebase onto origin/main
  2. if has_conflicts:
       resolve-conflicts     — resolve conflict markers and commit
       push                  — force-push branch
  3. workflow lint-fix
  4. workflow review-pr
  5. if has_review_issues:
       address-reviews
while has_review_issues
```

## New agents

| Agent | Role | Purpose |
|---|---|---|
| `sync-with-main` | actor | `git fetch` + `git rebase origin/main`; emits `has_conflicts` if rebase fails |
| `resolve-conflicts` | actor | Resolves conflict markers and commits; emits `failed` if unresolvable |
| `push` | actor | `git push --force-with-lease`; no PR description update |

## Test plan

- [ ] `conductor workflow validate <repo> <worktree> iterate-pr` passes
- [ ] `conductor workflow validate <repo> <worktree> ticket-to-pr` passes
- [ ] `iterate-pr` can be triggered via `w` on an active worktree in the TUI
- [ ] `ticket-to-pr` behaviour is unchanged end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)