### PR TITLE
feat(tui): show current workflow step and progress in worktree row (#526)

### DIFF
--- a/conductor-core/src/workflow.rs
+++ b/conductor-core/src/workflow.rs
@@ -328,6 +328,17 @@ pub struct WorkflowRunStep {
     pub structured_output: Option<String>,
 }
 
+/// Lightweight summary of the currently-running step for a workflow run.
+/// Used for inline step indicators in the worktrees panel of the TUI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowStepSummary {
+    pub step_name: String,
+    /// 1-indexed current step position (converted from the 0-indexed DB value).
+    pub position: i64,
+    /// Total number of steps in this run.
+    pub total: i64,
+}
+
 /// A single entry in a step's metadata, either a key-value field or a
 /// multi-line section with a heading and body.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -980,6 +991,59 @@ impl<'a> WorkflowManager<'a> {
             .conn
             .query_row(&sql, params_ref.as_slice(), |row| row.get(0))?;
         Ok(count as usize)
+    }
+
+    /// Fetch the currently-running step for each of the given workflow run IDs
+    /// in a single batched query. Returns a map from `workflow_run_id` to a
+    /// `WorkflowStepSummary`. If no active step is found for a run, that run's
+    /// ID is absent from the returned map.
+    ///
+    /// An empty `run_ids` slice returns an empty map without hitting the DB.
+    pub fn get_step_summaries_for_runs(
+        &self,
+        run_ids: &[&str],
+    ) -> Result<HashMap<String, WorkflowStepSummary>> {
+        if run_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let placeholders = (1..=run_ids.len())
+            .map(|i| format!("?{i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT ws.workflow_run_id, ws.step_name, ws.position, \
+             (SELECT COUNT(*) FROM workflow_run_steps t WHERE t.workflow_run_id = ws.workflow_run_id) AS total \
+             FROM workflow_run_steps ws \
+             WHERE ws.workflow_run_id IN ({placeholders}) \
+               AND ws.status = 'running' \
+             ORDER BY ws.position ASC"
+        );
+        let run_id_strings: Vec<String> = run_ids.iter().map(|s| s.to_string()).collect();
+        let params_ref: Vec<&dyn rusqlite::ToSql> = run_id_strings
+            .iter()
+            .map(|s| s as &dyn rusqlite::ToSql)
+            .collect();
+        let mut stmt = self.conn.prepare_cached(&sql)?;
+        let mut rows = stmt.query(params_ref.as_slice())?;
+        let mut map: HashMap<String, WorkflowStepSummary> = HashMap::new();
+        while let Some(row) = rows.next()? {
+            let run_id: String = row.get(0)?;
+            // Take only the first (lowest position) running step per run.
+            if map.contains_key(&run_id) {
+                continue;
+            }
+            let db_position: i64 = row.get(2)?;
+            let total: i64 = row.get(3)?;
+            map.insert(
+                run_id,
+                WorkflowStepSummary {
+                    step_name: row.get(1)?,
+                    position: db_position + 1, // convert 0-indexed to 1-indexed
+                    total,
+                },
+            );
+        }
+        Ok(map)
     }
 }
 

--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -4,7 +4,7 @@ use conductor_core::agent::{AgentRun, AgentRunEvent, TicketAgentTotals};
 use conductor_core::github::DiscoveredRepo;
 use conductor_core::repo::Repo;
 use conductor_core::tickets::Ticket;
-use conductor_core::workflow::{WorkflowDef, WorkflowRun, WorkflowRunStep};
+use conductor_core::workflow::{WorkflowDef, WorkflowRun, WorkflowRunStep, WorkflowStepSummary};
 use conductor_core::worktree::Worktree;
 use crossterm::event::KeyEvent;
 
@@ -40,6 +40,8 @@ pub struct DataRefreshedPayload {
     pub ticket_agent_totals: HashMap<String, TicketAgentTotals>,
     /// Most recent workflow run per worktree (for inline indicators in the Worktrees panel).
     pub latest_workflow_runs_by_worktree: HashMap<String, WorkflowRun>,
+    /// Currently-running step summary per workflow_run_id (for inline step indicators).
+    pub workflow_step_summaries: HashMap<String, WorkflowStepSummary>,
 }
 
 /// Every user intent or background result flows through this enum.

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -651,6 +651,7 @@ impl App {
                 self.state.data.ticket_agent_totals = payload.ticket_agent_totals;
                 self.state.data.latest_workflow_runs_by_worktree =
                     payload.latest_workflow_runs_by_worktree;
+                self.state.data.workflow_step_summaries = payload.workflow_step_summaries;
                 self.refresh_pending_feedback();
                 self.state.data.rebuild_maps();
                 self.reload_agent_events();

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -69,7 +69,7 @@ pub fn poll_data() -> Option<Action> {
     let latest_agent_runs = agent_mgr.latest_runs_by_worktree().unwrap_or_default();
     let ticket_agent_totals = agent_mgr.totals_by_ticket_all().unwrap_or_default();
 
-    use conductor_core::workflow::WorkflowManager;
+    use conductor_core::workflow::{WorkflowManager, WorkflowRunStatus};
     let wf_mgr = WorkflowManager::new(&conn);
     // Build a per-worktree map of the most recent run (any status) for inline indicators.
     // Fetch recent runs sorted DESC; the first entry per worktree_id wins.
@@ -84,6 +84,22 @@ pub fn poll_data() -> Option<Action> {
         }
     }
 
+    // Collect IDs of active runs to fetch current step summaries in a single batch query.
+    let active_run_ids: Vec<String> = latest_workflow_runs_by_worktree
+        .values()
+        .filter(|r| {
+            matches!(
+                r.status,
+                WorkflowRunStatus::Running | WorkflowRunStatus::Waiting
+            )
+        })
+        .map(|r| r.id.clone())
+        .collect();
+    let active_run_id_refs: Vec<&str> = active_run_ids.iter().map(|s| s.as_str()).collect();
+    let workflow_step_summaries = wf_mgr
+        .get_step_summaries_for_runs(&active_run_id_refs)
+        .unwrap_or_default();
+
     Some(Action::DataRefreshed(Box::new(DataRefreshedPayload {
         repos,
         worktrees,
@@ -91,6 +107,7 @@ pub fn poll_data() -> Option<Action> {
         latest_agent_runs,
         ticket_agent_totals,
         latest_workflow_runs_by_worktree,
+        workflow_step_summaries,
     })))
 }
 

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -39,7 +39,9 @@ use conductor_core::github::{DiscoveredRepo, GithubPr};
 use conductor_core::issue_source::IssueSource;
 use conductor_core::repo::Repo;
 use conductor_core::tickets::Ticket;
-use conductor_core::workflow::{WorkflowDef, WorkflowRun, WorkflowRunStatus, WorkflowRunStep};
+use conductor_core::workflow::{
+    WorkflowDef, WorkflowRun, WorkflowRunStatus, WorkflowRunStep, WorkflowStepSummary,
+};
 
 /// A single active item for the global status bar detail line.
 #[derive(Debug, Clone)]
@@ -554,6 +556,8 @@ pub struct DataCache {
     pub pending_feedback: Option<FeedbackRequest>,
     /// Most recent workflow run per worktree (worktree_id → run), for inline indicators.
     pub latest_workflow_runs_by_worktree: HashMap<String, WorkflowRun>,
+    /// Currently-running step summary per workflow_run_id, for inline step indicators.
+    pub workflow_step_summaries: HashMap<String, WorkflowStepSummary>,
     /// Workflow definitions for the currently viewed worktree
     pub workflow_defs: Vec<WorkflowDef>,
     /// Workflow runs for the currently viewed worktree (or all worktrees in global mode)

--- a/conductor-tui/src/ui/common.rs
+++ b/conductor-tui/src/ui/common.rs
@@ -318,7 +318,33 @@ pub fn worktree_list_item(
             WorkflowRunStatus::Pending | WorkflowRunStatus::Cancelled => ("", Color::DarkGray),
         };
         if !symbol.is_empty() {
-            let label = format!("{symbol} {}", wf_run.workflow_name);
+            // For running/waiting runs, append step progress if available.
+            let step_suffix = if matches!(
+                wf_run.status,
+                WorkflowRunStatus::Running | WorkflowRunStatus::Waiting
+            ) {
+                state.data.workflow_step_summaries.get(&wf_run.id).map(|s| {
+                    let base = format!(
+                        "{symbol} {} ({}/{}) > ",
+                        wf_run.workflow_name, s.position, s.total
+                    );
+                    // Truncate step name if it would overflow a reasonable column width.
+                    // We use a heuristic max of 80 chars for the full label.
+                    const MAX_LABEL: usize = 80;
+                    let base_chars = base.chars().count();
+                    let step_chars = s.step_name.chars().count();
+                    if base_chars + step_chars <= MAX_LABEL {
+                        format!("{base}{}", s.step_name)
+                    } else {
+                        let available = MAX_LABEL.saturating_sub(base_chars + 1); // +1 for ellipsis
+                        let truncated: String = s.step_name.chars().take(available).collect();
+                        format!("{base}{truncated}…")
+                    }
+                })
+            } else {
+                None
+            };
+            let label = step_suffix.unwrap_or_else(|| format!("{symbol} {}", wf_run.workflow_name));
             spans.push(Span::raw("  "));
             spans.push(Span::styled(label, Style::default().fg(color)));
         }


### PR DESCRIPTION
Worktree rows now display the currently-running step name and progress
fraction when a workflow is active, e.g. `⚙ running ticket-to-pr (4/7) > push-and-pr`.
Step names are truncated with `…` if they exceed 80 chars total.

- conductor-core: add `WorkflowStepSummary` struct and
  `WorkflowManager::get_step_summaries_for_runs()` — a single batched
  SQL query that fetches the running step per workflow run, avoiding
  N+1 queries on each background poll tick
- conductor-tui/action.rs: extend `DataRefreshedPayload` with
  `workflow_step_summaries: HashMap<String, WorkflowStepSummary>`
- conductor-tui/state.rs: extend `DataCache` with `workflow_step_summaries`
- conductor-tui/background.rs: collect active run IDs after building the
  per-worktree run map and populate `workflow_step_summaries` via the
  new batch query
- conductor-tui/app.rs: propagate `workflow_step_summaries` from the
  `DataRefreshed` payload into `state.data`
- conductor-tui/ui/common.rs: update `worktree_list_item()` to look up
  step info and render `(<current>/<total>) > <step_name>` with truncation

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
