### PR TITLE
chore: update Cargo.lock — remove stale tempfile dep from conductor-tui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,6 @@ dependencies = [
  "ratatui",
  "rusqlite",
  "serde_json",
- "tempfile",
  "tracing",
  "tui-textarea",
  "ulid",


### PR DESCRIPTION
## Summary

- Removes the stale `tempfile` entry from `conductor-tui` in `Cargo.lock`, reflecting the dependency removal from a prior PR.

## Test plan

- [ ] CI passes (no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)