### PR TITLE
fix(workflow): inject GH_TOKEN from GitHub App into agent subprocess (#530)

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -1683,6 +1683,21 @@ fn run_agent(
         .stderr(Stdio::inherit())
         .current_dir(worktree_path);
 
+    // Inject GH_TOKEN from the GitHub App installation token so all `gh` calls
+    // made by the agent (including `gh pr create`) use the bot identity rather
+    // than the human `gh` CLI user. Fall back gracefully when not configured.
+    match github_app::resolve_app_token(&config, "agent-run") {
+        github_app::TokenResolution::AppToken(token) => {
+            cmd.env("GH_TOKEN", token);
+        }
+        github_app::TokenResolution::Fallback { reason } => {
+            eprintln!(
+                "[conductor] Warning: GitHub App token failed, agents will use gh user identity: {reason}"
+            );
+        }
+        github_app::TokenResolution::NotConfigured => {}
+    }
+
     if let Some(session_id) = resume_session_id {
         cmd.arg("--resume").arg(session_id);
     }

--- a/conductor-core/src/workflow.rs
+++ b/conductor-core/src/workflow.rs
@@ -3545,7 +3545,7 @@ fn execute_gate(state: &mut ExecutionState<'_>, node: &GateNode, iteration: u32)
 
                 // Poll gh pr view for approvals
                 let output = Command::new("gh")
-                    .args(["pr", "view", "--json", "reviews"])
+                    .args(["pr", "view", "--json", "reviews,author"])
                     .current_dir(&state.working_dir)
                     .output();
 
@@ -3553,12 +3553,18 @@ fn execute_gate(state: &mut ExecutionState<'_>, node: &GateNode, iteration: u32)
                     if out.status.success() {
                         let json_str = String::from_utf8_lossy(&out.stdout);
                         if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json_str) {
+                            let pr_author =
+                                val["author"]["login"].as_str().unwrap_or("").to_string();
                             let approvals = val["reviews"]
                                 .as_array()
                                 .map(|reviews| {
                                     reviews
                                         .iter()
-                                        .filter(|r| r["state"].as_str() == Some("APPROVED"))
+                                        .filter(|r| {
+                                            r["state"].as_str() == Some("APPROVED")
+                                                && r["author"]["login"].as_str().unwrap_or("")
+                                                    != pr_author
+                                        })
                                         .count() as u32
                                 })
                                 .unwrap_or(0);


### PR DESCRIPTION
Resolves the pr_approval gate being unsatisfiable by ensuring the agent's
`gh` calls (including `gh pr create`) use the bot identity when a GitHub App
is configured. `run_agent()` in conductor-cli is the single injection point
for all launch paths (TUI, web, workflow engine, orchestrator). Also filters
out self-approvals from the PR approval count in the gate poller as a
defensive measure.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
