### PR TITLE
feat(tui): show ticket labels in Dashboard and RepoDetail panes (#539)

### DIFF
--- a/conductor-tui/src/ui/common.rs
+++ b/conductor-tui/src/ui/common.rs
@@ -1,4 +1,5 @@
 use conductor_core::agent::AgentRunStatus;
+use conductor_core::tickets::TicketLabel;
 use conductor_core::workflow::WorkflowRunStatus;
 use conductor_core::worktree::{Worktree, WorktreeStatus};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
@@ -8,6 +9,75 @@ use ratatui::widgets::{ListItem, Paragraph};
 use ratatui::Frame;
 
 use crate::state::{AppState, GlobalStatusItem, View};
+
+/// Parse a 6-digit hex color string (with or without `#`) into `Color::Rgb`.
+/// Falls back to `Color::DarkGray` on any parse error.
+pub fn hex_to_color(hex: &str) -> Color {
+    let h = hex.trim_start_matches('#');
+    // Support 3-digit shorthand
+    let full = if h.len() == 3 {
+        format!(
+            "{}{}{}{}{}{}",
+            &h[0..1],
+            &h[0..1],
+            &h[1..2],
+            &h[1..2],
+            &h[2..3],
+            &h[2..3]
+        )
+    } else {
+        h.to_string()
+    };
+    if full.len() != 6 {
+        return Color::DarkGray;
+    }
+    let r = u8::from_str_radix(&full[0..2], 16).unwrap_or(128);
+    let g = u8::from_str_radix(&full[2..4], 16).unwrap_or(128);
+    let b = u8::from_str_radix(&full[4..6], 16).unwrap_or(128);
+    Color::Rgb(r, g, b)
+}
+
+/// Choose black or white foreground for maximum contrast against a colored background.
+pub fn label_fg(bg: Color) -> Color {
+    match bg {
+        Color::Rgb(r, g, b) => {
+            let luminance = 0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32;
+            if luminance > 128.0 {
+                Color::Black
+            } else {
+                Color::White
+            }
+        }
+        _ => Color::White,
+    }
+}
+
+/// Build compact fg-only label spans for a ticket row (up to 3 labels + `+N` overflow).
+pub fn ticket_label_spans_compact(labels: &[TicketLabel]) -> Vec<Span<'static>> {
+    if labels.is_empty() {
+        return Vec::new();
+    }
+    let mut spans = Vec::new();
+    let mut shown = 0usize;
+    for lbl in labels.iter().take(3) {
+        let color = lbl
+            .color
+            .as_deref()
+            .map(hex_to_color)
+            .unwrap_or(Color::DarkGray);
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(lbl.label.clone(), Style::default().fg(color)));
+        shown += 1;
+    }
+    let remaining = labels.len().saturating_sub(shown);
+    if remaining > 0 {
+        spans.push(Span::styled(
+            format!(" +{remaining}"),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+    spans
+}
 
 pub fn render_header(
     frame: &mut Frame,

--- a/conductor-tui/src/ui/dashboard.rs
+++ b/conductor-tui/src/ui/dashboard.rs
@@ -165,6 +165,13 @@ fn render_tickets(frame: &mut Frame, area: Rect, state: &AppState) {
                 Span::raw("  "),
                 Span::styled(format!("[{}]", t.state), Style::default().fg(state_color)),
             ];
+            let labels = state
+                .data
+                .ticket_labels
+                .get(&t.id)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            spans.extend(super::common::ticket_label_spans_compact(labels));
             spans.extend(super::common::ticket_worktree_spans(state, &t.id, "  "));
             spans.extend(super::common::ticket_agent_total_spans(
                 state, &t.id, "  ", false,

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -84,7 +84,12 @@ pub fn render(frame: &mut Frame, state: &AppState) {
         Modal::TicketInfo { ticket } => {
             let agent_totals = state.data.ticket_agent_totals.get(&ticket.id);
             let worktrees = state.data.ticket_worktrees.get(&ticket.id);
-            modal::render_ticket_info(frame, area, ticket, agent_totals, worktrees);
+            let labels = state
+                .data
+                .ticket_labels
+                .get(&ticket.id)
+                .map(|v| v.as_slice());
+            modal::render_ticket_info(frame, area, ticket, agent_totals, worktrees, labels);
         }
         Modal::PostCreatePicker {
             items,

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -8,7 +8,7 @@ use tui_textarea::TextArea;
 use conductor_core::agent::TicketAgentTotals;
 use conductor_core::github::DiscoveredRepo;
 use conductor_core::issue_source::IssueSource;
-use conductor_core::tickets::Ticket;
+use conductor_core::tickets::{Ticket, TicketLabel};
 use conductor_core::worktree::Worktree;
 
 pub fn render_confirm(frame: &mut Frame, area: Rect, title: &str, message: &str) {
@@ -181,6 +181,7 @@ pub fn render_ticket_info(
     ticket: &Ticket,
     agent_totals: Option<&TicketAgentTotals>,
     worktrees: Option<&Vec<Worktree>>,
+    labels: Option<&[TicketLabel]>,
 ) {
     let popup = centered_rect(60, 70, area);
     frame.render_widget(Clear, popup);
@@ -208,10 +209,42 @@ pub fn render_ticket_info(
 
     let assignee_text = ticket.assignee.as_deref().unwrap_or("unassigned");
 
-    let labels_text = if ticket.labels.is_empty() {
-        "none".to_string()
-    } else {
-        ticket.labels.clone()
+    // Build the labels line — colored badge chips if rich label data is available,
+    // otherwise fall back to the raw comma-separated string.
+    let labels_line = {
+        let mut spans: Vec<Span<'static>> = vec![Span::styled("  Labels:    ", label_style)];
+        let rich = labels.unwrap_or(&[]);
+        if rich.is_empty() && ticket.labels.is_empty() {
+            spans.push(Span::styled("none", value_style));
+        } else if !rich.is_empty() {
+            let mut shown = 0usize;
+            for lbl in rich.iter().take(5) {
+                let bg = lbl
+                    .color
+                    .as_deref()
+                    .map(super::common::hex_to_color)
+                    .unwrap_or(Color::DarkGray);
+                let fg = super::common::label_fg(bg);
+                if shown > 0 {
+                    spans.push(Span::raw(" "));
+                }
+                spans.push(Span::styled(
+                    format!(" {} ", lbl.label.clone()),
+                    Style::default().fg(fg).bg(bg),
+                ));
+                shown += 1;
+            }
+            let remaining = rich.len().saturating_sub(shown);
+            if remaining > 0 {
+                spans.push(Span::styled(
+                    format!(" +{remaining}"),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+        } else {
+            spans.push(Span::styled(ticket.labels.clone(), value_style));
+        }
+        Line::from(spans)
     };
 
     let mut lines = vec![
@@ -236,10 +269,7 @@ pub fn render_ticket_info(
             Span::styled("  Assignee:  ", label_style),
             Span::styled(assignee_text, value_style),
         ]),
-        Line::from(vec![
-            Span::styled("  Labels:    ", label_style),
-            Span::styled(&labels_text, value_style),
-        ]),
+        labels_line,
         Line::from(vec![
             Span::styled("  URL:       ", label_style),
             Span::styled(&ticket.url, Style::default().fg(Color::Blue)),

--- a/conductor-tui/src/ui/repo_detail.rs
+++ b/conductor-tui/src/ui/repo_detail.rs
@@ -171,6 +171,13 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                 Span::raw("  "),
                 Span::styled(format!("[{}]", t.state), Style::default().fg(state_color)),
             ];
+            let labels = state
+                .data
+                .ticket_labels
+                .get(&t.id)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]);
+            spans.extend(super::common::ticket_label_spans_compact(labels));
             spans.extend(super::common::ticket_worktree_spans(state, &t.id, "  "));
             spans.extend(super::common::ticket_agent_total_spans(
                 state, &t.id, "  ", false,

--- a/conductor-tui/src/ui/tickets.rs
+++ b/conductor-tui/src/ui/tickets.rs
@@ -7,48 +7,6 @@ use ratatui::Frame;
 use super::common::truncate;
 use crate::state::AppState;
 
-/// Parse a 6-digit hex color string (with or without `#`) into `Color::Rgb`.
-/// Falls back to `Color::DarkGray` on any parse error.
-fn hex_to_color(hex: &str) -> Color {
-    let h = hex.trim_start_matches('#');
-    // Support 3-digit shorthand
-    let full = if h.len() == 3 {
-        format!(
-            "{}{}{}{}{}{}",
-            &h[0..1],
-            &h[0..1],
-            &h[1..2],
-            &h[1..2],
-            &h[2..3],
-            &h[2..3]
-        )
-    } else {
-        h.to_string()
-    };
-    if full.len() != 6 {
-        return Color::DarkGray;
-    }
-    let r = u8::from_str_radix(&full[0..2], 16).unwrap_or(128);
-    let g = u8::from_str_radix(&full[2..4], 16).unwrap_or(128);
-    let b = u8::from_str_radix(&full[4..6], 16).unwrap_or(128);
-    Color::Rgb(r, g, b)
-}
-
-/// Choose black or white foreground for maximum contrast against a colored background.
-fn label_fg(bg: Color) -> Color {
-    match bg {
-        Color::Rgb(r, g, b) => {
-            let luminance = 0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32;
-            if luminance > 128.0 {
-                Color::Black
-            } else {
-                Color::White
-            }
-        }
-        _ => Color::White,
-    }
-}
-
 pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
     let filter = state.filter.as_query();
     let label_filter = state.label_filter.as_query();
@@ -102,9 +60,9 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                     let bg = lbl
                         .color
                         .as_deref()
-                        .map(hex_to_color)
+                        .map(super::common::hex_to_color)
                         .unwrap_or(Color::DarkGray);
-                    let fg = label_fg(bg);
+                    let fg = super::common::label_fg(bg);
                     spans.push(Span::raw(" "));
                     spans.push(Span::styled(
                         format!(" {name} "),


### PR DESCRIPTION
Move hex_to_color and label_fg helpers to common.rs and add a new
ticket_label_spans_compact() helper (fg-only, up to 3 + +N overflow).
Extend Dashboard and RepoDetail ticket rows with compact label spans.
Update render_ticket_info modal to render colored badge chips using the
rich TicketLabel data from AppState.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
