### PR TITLE
feat(workflows): add label-ticket and label-all-tickets workflows

### DIFF
--- a/.conductor/agents/label-all-tickets.md
+++ b/.conductor/agents/label-all-tickets.md
@@ -1,0 +1,54 @@
+---
+role: actor
+---
+
+You are a GitHub issue curator. Your task is to review all open, unlabeled issues in a repository and add appropriate labels to each one.
+
+**Repository details:**
+- Internal ID: {{repo_id}}
+- Local path: {{repo_path}}
+- Name: {{repo_name}}
+
+Prior step context: {{prior_context}}
+Gate feedback (if provided): {{gate_feedback}}
+
+**Steps:**
+
+1. Determine the GitHub remote `<owner>/<repo>` for this repo:
+   ```
+   git -C {{repo_path}} remote get-url origin
+   ```
+   Parse `<owner>/<repo>` from the URL (handles both HTTPS and SSH formats).
+
+2. List all available labels with their descriptions:
+   ```
+   gh label list --repo <owner>/<repo> --limit 100
+   ```
+
+3. List all open issues, then filter for those with no labels:
+   ```
+   gh issue list --repo <owner>/<repo> --state open --limit 200 --json number,title,body,labels
+   ```
+   Process only items where the `labels` array is empty.
+
+   If `{{prior_context}}` lists specific issue numbers that were unresolved in a previous run,
+   focus on those issues rather than re-scanning everything.
+
+4. For each unlabeled issue (or each previously-unresolved issue on a second pass):
+   a. Read the issue title and body.
+   b. Select the most appropriate existing label(s) from the list in step 2.
+      If `{{gate_feedback}}` contains guidance about specific labels or label names to create,
+      use that guidance when assigning labels.
+   c. Apply the labels:
+      ```
+      gh issue edit <number> --repo <owner>/<repo> --add-label "label1,label2"
+      ```
+   d. If no existing label is a good fit, record the issue number and a brief note
+      about what label type would be appropriate. Do not apply any label to that issue.
+
+5. After processing all issues, summarize the results:
+   - How many issues were labeled and a brief summary of labels applied.
+   - If any issues could not be labeled with existing labels, list them with your suggested
+     label names/descriptions.
+   - If there were unresolvable issues, emit the marker `needs_new_labels`.
+   - If all issues were labeled (or there were no unlabeled issues), emit no markers.

--- a/.conductor/agents/label-ticket.md
+++ b/.conductor/agents/label-ticket.md
@@ -1,0 +1,45 @@
+---
+role: actor
+---
+
+You are a GitHub issue curator. Your task is to review a single GitHub issue and add appropriate labels if it has none.
+
+**Ticket details:**
+- Internal ID: {{ticket_id}}
+- Title: {{ticket_title}}
+- URL: {{ticket_url}}
+
+Prior step context: {{prior_context}}
+Gate feedback (if provided): {{gate_feedback}}
+
+**Steps:**
+
+1. Parse the repo owner/name and issue number from `{{ticket_url}}`.
+   The URL format is: `https://github.com/<owner>/<repo>/issues/<number>`
+
+2. View the issue to get its current labels and full body:
+   ```
+   gh issue view <number> --repo <owner>/<repo>
+   ```
+   If the issue already has one or more labels, stop here — do nothing and exit successfully.
+
+3. List all available labels in the repo with their descriptions:
+   ```
+   gh label list --repo <owner>/<repo> --limit 100
+   ```
+
+4. Based on the issue title and body, select the most appropriate existing label(s).
+   Use each label's description (if present) to guide your choice.
+   If `{{gate_feedback}}` is non-empty, treat it as authoritative guidance from a human reviewer —
+   follow it to select or create a label as instructed.
+
+5a. If one or more existing labels are a good fit, apply them:
+    ```
+    gh issue edit <number> --repo <owner>/<repo> --add-label "label1,label2"
+    ```
+    Emit no markers.
+
+5b. If no existing label is a suitable fit and no gate feedback was provided:
+    - Do NOT apply any labels.
+    - In your output, explain what type of label would be appropriate and why.
+    - Emit the marker `needs_new_label`.

--- a/.conductor/workflows/label-all-tickets.wf
+++ b/.conductor/workflows/label-all-tickets.wf
@@ -1,0 +1,18 @@
+workflow label-all-tickets {
+  meta {
+    description = "Add appropriate labels to all unlabeled open GitHub issues in a repo"
+    trigger     = "manual"
+    targets     = ["repo"]
+  }
+
+  call label-all-tickets
+
+  if label-all-tickets.needs_new_labels {
+    gate human_review {
+      prompt     = "Some issues could not be labeled using existing labels. Review the agent's suggestions and provide feedback — e.g. which existing labels to use anyway, or names for new labels to create first. The agent will re-process only the unresolved issues."
+      timeout    = "48h"
+      on_timeout = continue
+    }
+    call label-all-tickets
+  }
+}

--- a/.conductor/workflows/label-ticket.wf
+++ b/.conductor/workflows/label-ticket.wf
@@ -1,0 +1,18 @@
+workflow label-ticket {
+  meta {
+    description = "Add appropriate labels to a single GitHub issue if it is missing labels"
+    trigger     = "manual"
+    targets     = ["ticket"]
+  }
+
+  call label-ticket
+
+  if label-ticket.needs_new_label {
+    gate human_review {
+      prompt     = "No existing label fits this ticket. Review the agent's suggestion and provide feedback — e.g. use an existing label anyway, or name a new label to create first. The agent will then apply labels based on your guidance."
+      timeout    = "24h"
+      on_timeout = fail
+    }
+    call label-ticket
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `label-ticket` workflow (targets `ticket`) — labels a single GitHub issue using existing repo labels; gates on human review if no label fits
- Adds `label-all-tickets` workflow (targets `repo`) — batch-labels all open unlabeled issues; gates on human review (continue on timeout) for any unresolvable issues
- Both workflows use the GitHub App token (requires `issues: write` permission on the App installation)

## Test plan

- [ ] Run `label-ticket` on a ticket with no labels — verify correct label applied via `gh`
- [ ] Run `label-ticket` on a ticket where no existing label fits — verify `needs_new_label` gate fires, human feedback is accepted, label applied on second pass
- [ ] Run `label-all-tickets` on a repo — verify all unlabeled open issues receive labels
- [ ] Confirm workflows validate cleanly: `conductor workflow validate <repo> <worktree> label-ticket`

🤖 Generated with [Claude Code](https://claude.com/claude-code)