### PR TITLE
chore: add PLAN.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 conductor-web/frontend/node_modules/
 conductor-web/frontend/dist/
 *.local.json
+PLAN.md


### PR DESCRIPTION
## Summary
- `PLAN.md` is generated by the `ticket-to-pr` workflow and should not be tracked in version control

🤖 Generated with [Claude Code](https://claude.com/claude-code)