### PR TITLE
fix(cli): move name before optional positionals in workflow validate

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -171,14 +171,14 @@ enum WorkflowCommands {
     },
     /// Validate a workflow definition (check all agents exist)
     Validate {
+        /// Workflow name
+        name: String,
         /// Repo slug (required unless --path is given)
         #[arg(required_unless_present = "path")]
         repo: Option<String>,
         /// Worktree slug (required unless --path is given)
         #[arg(required_unless_present = "path")]
         worktree: Option<String>,
-        /// Workflow name
-        name: String,
         /// Path to a repo root directory; skips DB lookup
         #[arg(long, conflicts_with_all = &["repo", "worktree"])]
         path: Option<String>,


### PR DESCRIPTION
## Summary
- `conductor workflow validate` panicked at startup due to clap's positional argument ordering requirement
- Required positional `name` was at a higher index than optional positionals `repo`/`worktree`, violating clap's rule
- Introduced in #570 when `--path` made `repo`/`worktree` optional without repositioning `name`
- Fix: move `name` to be the first positional field

## Test plan
- [x] `conductor workflow validate <name> --path <dir>` no longer panics
- [ ] `conductor workflow validate <name> <repo> <worktree>` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)