### PR TITLE
feat(workflows): add merge-when-ready workflow

### DIFF
--- a/.conductor/agents/summarize-unresolved.md
+++ b/.conductor/agents/summarize-unresolved.md
@@ -1,0 +1,35 @@
+---
+role: reviewer
+can_commit: false
+---
+
+You are a PR review summarizer. Your job is to clearly present the unresolved review comment threads on a pull request so a human can decide whether to proceed with the merge.
+
+The PR URL is: {{pr_url}}
+
+Prior step context (from verify-review-comments): {{prior_context}}
+
+Steps:
+
+1. Fetch the unresolved review threads:
+   ```
+   gh pr view "{{pr_url}}" --json reviewThreads
+   ```
+
+2. Filter to threads where `isResolved` is `false`.
+
+3. For each unresolved thread, show:
+   - The file and line number (if available)
+   - The reviewer's name
+   - The comment body
+   - The number of replies in the thread
+
+4. Present a concise summary suitable for a human gate decision. Be clear about what each unresolved comment is asking for.
+
+Emit a `CONDUCTOR_OUTPUT` block with your summary:
+
+```
+<<<CONDUCTOR_OUTPUT>>>
+{"markers": [], "context": "N unresolved thread(s): <brief summary of each>"}
+<<<END_CONDUCTOR_OUTPUT>>>
+```

--- a/.conductor/agents/verify-review-comments.md
+++ b/.conductor/agents/verify-review-comments.md
@@ -1,0 +1,39 @@
+---
+role: reviewer
+can_commit: false
+---
+
+You are a PR review status agent. Your job is to check whether a pull request has any unresolved review comment threads.
+
+The PR URL is: {{pr_url}}
+
+Steps:
+
+1. Fetch the review threads for the PR:
+   ```
+   gh pr view "{{pr_url}}" --json reviewThreads
+   ```
+
+2. Parse the JSON output. Each entry in `reviewThreads` has an `isResolved` field.
+
+3. Count the number of threads where `isResolved` is `false`.
+
+4. Report the count and list any unresolved threads (include the comment body and author for each).
+
+If there are unresolved threads, emit the `has_unresolved_comments` marker. If all threads are resolved (or there are no threads at all), emit no markers.
+
+Emit a `CONDUCTOR_OUTPUT` block when done:
+
+If unresolved comments exist:
+```
+<<<CONDUCTOR_OUTPUT>>>
+{"markers": ["has_unresolved_comments"], "context": "Found N unresolved review thread(s) on {{pr_url}}"}
+<<<END_CONDUCTOR_OUTPUT>>>
+```
+
+If all clear:
+```
+<<<CONDUCTOR_OUTPUT>>>
+{"markers": [], "context": "All review threads resolved (or no review threads) on {{pr_url}}"}
+<<<END_CONDUCTOR_OUTPUT>>>
+```

--- a/.conductor/workflows/merge-when-ready.wf
+++ b/.conductor/workflows/merge-when-ready.wf
@@ -1,0 +1,35 @@
+workflow merge-when-ready {
+  meta {
+    description = "Verify CI, approvals, and review comments are clear, then merge and close"
+    trigger     = "manual"
+    targets     = ["worktree"] // not "pr": merge-and-close runs `gh pr merge` from the branch checkout; the ephemeral --pr shallow clone has no push remote configured so the merge step would fail
+  }
+
+  inputs {
+    pr_url required
+  }
+
+  gate pr_checks {
+    timeout    = "2h"
+    on_timeout = fail
+  }
+
+  gate pr_approval {
+    min_approvals = 1
+    timeout       = "72h"
+    on_timeout    = fail
+  }
+
+  call verify-review-comments
+
+  if verify-review-comments.has_unresolved_comments {
+    call summarize-unresolved
+    gate human_review {
+      prompt     = "There are unresolved review comments on this PR. See the summarize-unresolved step for details. Approve to merge anyway or reject to abort."
+      timeout    = "24h"
+      on_timeout = fail
+    }
+  }
+
+  call merge-and-close
+}


### PR DESCRIPTION
## Summary
- Adds `merge-when-ready.wf` — gates on CI checks and PR approval, verifies all review comment threads are resolved, then merges and closes
- Adds `verify-review-comments` agent — checks `gh pr view --json reviewThreads` for unresolved threads, emits `has_unresolved_comments` marker if any found
- Adds `summarize-unresolved` agent — presents unresolved threads clearly for the `human_review` gate decision
- Reuses existing `merge-and-close` agent

## Flow
1. `gate pr_checks` — waits for CI to pass (2h timeout)
2. `gate pr_approval` — waits for ≥1 approval (72h timeout)
3. `call verify-review-comments` — checks for unresolved threads
4. If unresolved: `call summarize-unresolved` → `gate human_review` (merge anyway or abort)
5. `call merge-and-close` — squash merges and closes the linked issue

## Test plan
- [ ] `conductor workflow validate merge-when-ready` passes ✅
- [ ] Dry run: `conductor workflow run merge-when-ready <repo> <worktree> --input pr_url=<url> --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)