### PR TITLE
feat(#626): clean up worktree and ticket row display in Repo Detail view

### DIFF
--- a/conductor-tui/src/ui/common.rs
+++ b/conductor-tui/src/ui/common.rs
@@ -346,24 +346,36 @@ pub fn worktree_list_item(
         ));
     }
 
-    spans.push(Span::styled(
-        wt.slug.clone(),
-        text_style.add_modifier(if is_active {
-            Modifier::BOLD
-        } else {
-            Modifier::DIM
-        }),
-    ));
-
+    // In repo-detail context (show_branch=true): show branch as primary identifier.
+    // In dashboard context (show_branch=false): show slug as before.
     if show_branch {
-        spans.push(Span::styled(format!("  {}", wt.branch), text_style));
+        spans.push(Span::styled(
+            wt.branch.clone(),
+            text_style.add_modifier(if is_active {
+                Modifier::BOLD
+            } else {
+                Modifier::DIM
+            }),
+        ));
+    } else {
+        spans.push(Span::styled(
+            wt.slug.clone(),
+            text_style.add_modifier(if is_active {
+                Modifier::BOLD
+            } else {
+                Modifier::DIM
+            }),
+        ));
     }
 
-    spans.push(Span::raw("  "));
-    spans.push(Span::styled(
-        format!("[{}]", wt.status),
-        Style::default().fg(status_color),
-    ));
+    // Only show status badge for non-active worktrees ([active] is never informative).
+    if !is_active {
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(
+            format!("[{}]", wt.status),
+            Style::default().fg(status_color),
+        ));
+    }
 
     if let Some(ticket) = wt
         .ticket_id
@@ -383,8 +395,10 @@ pub fn worktree_list_item(
         ));
     }
 
-    if let Some(run) = state.data.latest_agent_runs.get(&wt.id) {
-        use conductor_core::agent::AgentRunStatus;
+    use conductor_core::agent::AgentRunStatus;
+    let agent_run = state.data.latest_agent_runs.get(&wt.id);
+
+    if let Some(run) = agent_run {
         let (symbol, color) = match run.status {
             AgentRunStatus::Running => ("● running", Color::Yellow),
             AgentRunStatus::WaitingForFeedback => ("⏸ waiting for feedback", Color::Magenta),
@@ -396,6 +410,13 @@ pub fn worktree_list_item(
         spans.push(Span::styled(symbol, Style::default().fg(color)));
     }
 
+    let has_active_agent = agent_run.is_some_and(|r| {
+        matches!(
+            r.status,
+            AgentRunStatus::Running | AgentRunStatus::WaitingForFeedback
+        )
+    });
+
     if let Some(wf_run) = state.data.latest_workflow_runs_by_worktree.get(&wt.id) {
         use conductor_core::workflow::WorkflowRunStatus;
         let (symbol, color) = match wf_run.status {
@@ -406,11 +427,20 @@ pub fn worktree_list_item(
             WorkflowRunStatus::Pending | WorkflowRunStatus::Cancelled => ("", Color::DarkGray),
         };
         if !symbol.is_empty() {
-            // For running/waiting runs, append step progress if available.
-            let label = if matches!(
+            let is_wf_active = matches!(
                 wf_run.status,
                 WorkflowRunStatus::Running | WorkflowRunStatus::Waiting
-            ) {
+            );
+            // When both an agent and workflow are active, suppress the ⚙ symbol —
+            // the agent's ● already covers status. Build a compact "name › step" label.
+            let label = if is_wf_active && has_active_agent {
+                state
+                    .data
+                    .workflow_step_summaries
+                    .get(&wf_run.id)
+                    .map(|s| format!("{} › {}", wf_run.workflow_name, s.step_name))
+                    .unwrap_or_else(|| wf_run.workflow_name.clone())
+            } else if is_wf_active {
                 state
                     .data
                     .workflow_step_summaries
@@ -431,6 +461,21 @@ pub fn worktree_list_item(
             };
             spans.push(Span::raw("  "));
             spans.push(Span::styled(label, Style::default().fg(color)));
+        }
+    }
+
+    // Append token counts at end for active agent runs.
+    if let Some(run) = agent_run {
+        if matches!(
+            run.status,
+            AgentRunStatus::Running | AgentRunStatus::WaitingForFeedback
+        ) {
+            if let (Some(input), Some(output)) = (run.input_tokens, run.output_tokens) {
+                spans.push(Span::styled(
+                    format!("  ↑{} ↓{}", fmt_tokens_k(input), fmt_tokens_k(output)),
+                    Style::default().fg(Color::Magenta),
+                ));
+            }
         }
     }
 
@@ -562,10 +607,13 @@ pub fn build_workflow_breadcrumb(
 ///
 /// Pass `leading_space` to control the whitespace before the indicator
 /// (single space for the padded Tickets view, double for compact views).
+///
+/// When `compact=true`, returns only the indicator dot with no slug text.
 pub fn ticket_worktree_spans(
     state: &AppState,
     ticket_id: &str,
     leading: &str,
+    compact: bool,
 ) -> Vec<Span<'static>> {
     let Some(wts) = state.data.ticket_worktrees.get(ticket_id) else {
         return Vec::new();
@@ -579,7 +627,9 @@ pub fn ticket_worktree_spans(
     } else {
         ("○", Color::DarkGray)
     };
-    let label = if wts.len() > 1 {
+    let label = if compact {
+        indicator.to_string()
+    } else if wts.len() > 1 {
         format!("{indicator} {} worktrees", wts.len())
     } else {
         format!("{indicator} {}", best.slug)

--- a/conductor-tui/src/ui/dashboard.rs
+++ b/conductor-tui/src/ui/dashboard.rs
@@ -172,7 +172,9 @@ fn render_tickets(frame: &mut Frame, area: Rect, state: &AppState) {
                 .map(|v| v.as_slice())
                 .unwrap_or(&[]);
             spans.extend(super::common::ticket_label_spans_compact(labels));
-            spans.extend(super::common::ticket_worktree_spans(state, &t.id, "  "));
+            spans.extend(super::common::ticket_worktree_spans(
+                state, &t.id, "  ", false,
+            ));
             spans.extend(super::common::ticket_agent_total_spans(
                 state, &t.id, "  ", false,
             ));

--- a/conductor-tui/src/ui/repo_detail.rs
+++ b/conductor-tui/src/ui/repo_detail.rs
@@ -156,20 +156,12 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
         .filtered_detail_tickets
         .iter()
         .map(|t| {
-            let state_color = match t.state.as_str() {
-                "open" => Color::Green,
-                "closed" => Color::Red,
-                "in_progress" => Color::Yellow,
-                _ => Color::White,
-            };
             let mut spans = vec![
                 Span::styled(
                     format!("#{} ", t.source_id),
                     Style::default().fg(Color::Yellow),
                 ),
                 Span::raw(&t.title),
-                Span::raw("  "),
-                Span::styled(format!("[{}]", t.state), Style::default().fg(state_color)),
             ];
             let labels = state
                 .data
@@ -178,7 +170,9 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                 .map(|v| v.as_slice())
                 .unwrap_or(&[]);
             spans.extend(super::common::ticket_label_spans_compact(labels));
-            spans.extend(super::common::ticket_worktree_spans(state, &t.id, "  "));
+            spans.extend(super::common::ticket_worktree_spans(
+                state, &t.id, "  ", true,
+            ));
             spans.extend(super::common::ticket_agent_total_spans(
                 state, &t.id, "  ", false,
             ));

--- a/conductor-tui/src/ui/tickets.rs
+++ b/conductor-tui/src/ui/tickets.rs
@@ -79,7 +79,9 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
                 }
             }
 
-            spans.extend(super::common::ticket_worktree_spans(state, &t.id, " "));
+            spans.extend(super::common::ticket_worktree_spans(
+                state, &t.id, " ", false,
+            ));
             spans.extend(super::common::ticket_agent_total_spans(
                 state, &t.id, " ", true,
             ));


### PR DESCRIPTION
- worktree rows: show branch as primary identifier (not slug) in repo-detail context
- worktree rows: suppress [active] badge; only show [merged]/[abandoned]
- worktree rows: collapse ⚙ symbol when agent + workflow both active, show plain "name › step"
- worktree rows: append ↑Xk ↓Yk token counts for active agent runs
- ticket rows (repo-detail): remove redundant [state] tag; show compact ● dot instead of full slug
- ticket_worktree_spans: add compact param (true=dot only, false=existing behaviour)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
