### PR TITLE
feat: run lint-fix before push-and-pr in ticket-to-pr workflow

### DIFF
--- a/.conductor/workflows/ticket-to-pr.wf
+++ b/.conductor/workflows/ticket-to-pr.wf
@@ -15,6 +15,8 @@ workflow ticket-to-pr {
     retries = 2
   }
 
+  call workflow lint-fix
+
   call push-and-pr
 
   call workflow iterate-pr


### PR DESCRIPTION
## Summary

- Adds `call workflow lint-fix` between `implement` and `push-and-pr` in `ticket-to-pr.wf`
- Fixes CI/format failures on the initial commit by catching `cargo fmt` and clippy issues locally before the PR is opened

## Test plan

- [ ] Run `ticket-to-pr-auto-merge` on a worktree and confirm the initial push passes CI format check
- [ ] Confirm `iterate-pr` still calls `lint-fix` in its loop for issues introduced during review iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)