### PR TITLE
fix: allow `as =` before `inputs {}` in call workflow blocks

### DIFF
--- a/.conductor/workflows/ticket-to-pr-auto-merge.wf
+++ b/.conductor/workflows/ticket-to-pr-auto-merge.wf
@@ -10,10 +10,10 @@ workflow ticket-to-pr-auto-merge {
   }
 
   call workflow ticket-to-pr {
-    as = "developer"
     inputs {
       ticket_id = "{{ticket_id}}"
     }
+    as = "developer"
   }
 
   gate pr_checks {

--- a/conductor-core/src/workflow_dsl.rs
+++ b/conductor-core/src/workflow_dsl.rs
@@ -925,6 +925,9 @@ impl Parser {
         if self.peek() == &Token::LBrace {
             self.advance();
 
+            // Parse kvs that may appear before inputs { } (e.g. `as = "developer"`)
+            let mut kvs = self.parse_kvs()?;
+
             // Parse optional `inputs { ... }` block inside the braces
             if self.peek() == &Token::Inputs {
                 self.advance();
@@ -936,8 +939,8 @@ impl Parser {
                 }
             }
 
-            // Parse remaining kvs (retries, on_fail, as)
-            let mut kvs = self.parse_kvs()?;
+            // Parse any remaining kvs after inputs { } and merge
+            kvs.extend(self.parse_kvs()?);
             self.expect(&Token::RBrace)?;
 
             if let Some(r) = kvs.get("retries") {
@@ -2512,6 +2515,32 @@ workflow parent {
                     n.on_fail,
                     Some(AgentRef::Name("notify-lint-failure".to_string()))
                 );
+            }
+            _ => panic!("Expected CallWorkflow node"),
+        }
+    }
+
+    #[test]
+    fn test_parse_call_workflow_as_before_inputs() {
+        // Regression: `as =` before `inputs { }` used to silently drop the workflow
+        let input = r#"
+workflow parent {
+    meta { targets = ["worktree"] }
+    call workflow ticket-to-pr {
+        as = "developer"
+        inputs {
+            ticket_id = "{{ticket_id}}"
+        }
+    }
+}
+"#;
+        let def = parse_workflow_str(input, "test.wf").unwrap();
+        assert_eq!(def.body.len(), 1);
+        match &def.body[0] {
+            WorkflowNode::CallWorkflow(n) => {
+                assert_eq!(n.workflow, "ticket-to-pr");
+                assert_eq!(n.inputs.get("ticket_id").unwrap(), "{{ticket_id}}");
+                assert_eq!(n.bot_name.as_deref(), Some("developer"));
             }
             _ => panic!("Expected CallWorkflow node"),
         }


### PR DESCRIPTION
## Summary

- Fixes a parser bug where `as = "..."` appearing **before** `inputs { }` in a `call workflow` block caused the entire workflow to be silently dropped from `load_workflow_defs`
- The symptom was "No worktree-compatible workflows found" in the TUI with no indication of why
- Adds a regression test covering `as =` before `inputs { }`
- Reorders `ticket-to-pr-auto-merge.wf` to use the canonical valid ordering

## Root cause

`parse_call_workflow` checked for `inputs { }` first, then called `parse_kvs()` for remaining keys. With `as =` before `inputs { }`, the parser skipped the inputs check, then hit `inputs {` inside `parse_kvs` which can't handle nested blocks — causing a parse error that was silently swallowed.

## Fix

Parse kvs both **before and after** the optional `inputs { }` block and merge them, so order doesn't matter.

## Test plan

- [x] New regression test `test_parse_call_workflow_as_before_inputs` passes
- [x] All 102 `workflow_dsl` tests pass
- [ ] Verify "No worktree-compatible workflows found" no longer appears with the `ticket-to-pr-auto-merge.wf` containing `as =` before `inputs { }`

## Related

- #649 — follow-on: surface parse errors as warnings instead of silently dropping workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)