### PR TITLE
fix: add lint verification loop and post-review lint check

### DIFF
--- a/.conductor/workflows/iterate-pr.wf
+++ b/.conductor/workflows/iterate-pr.wf
@@ -22,6 +22,7 @@ workflow iterate-pr {
 
     if review-pr.has_review_issues {
       call address-reviews
+      call workflow lint-fix
     }
   } while review-pr.has_review_issues
 }

--- a/.conductor/workflows/lint-fix.wf
+++ b/.conductor/workflows/lint-fix.wf
@@ -1,13 +1,18 @@
 workflow lint-fix {
   meta {
-    description = "Analyze lint errors and apply fixes"
+    description = "Analyze lint errors and apply fixes, re-verifying until clean"
     trigger     = "manual"
     targets     = ["worktree"]
   }
 
-  call analyze-lint
+  do {
+    max_iterations = 3
+    on_max_iter    = fail
 
-  if analyze-lint.has_lint_errors {
-    call lint-fix-impl
-  }
+    call analyze-lint
+
+    if analyze-lint.has_lint_errors {
+      call lint-fix-impl
+    }
+  } while analyze-lint.has_lint_errors
 }


### PR DESCRIPTION
## Summary

- **`lint-fix`**: converted to a `do/while` loop (max 3 iterations) so `analyze-lint` re-runs after `lint-fix-impl`. This catches new clippy/fmt errors introduced by the fix itself.
- **`iterate-pr`**: added `call workflow lint-fix` after `address-reviews` so that review-driven code changes are verified clean before the loop exits.

## Motivation

PR #653 produced a commit with an unused variable clippy error — the `analyze-lint` step passed before the fix was applied, but the fix itself introduced the error. The workflow had no re-verification step, so it slipped through to CI.

## Test plan

- [ ] Run `ticket-to-pr` on a worktree and confirm lint errors introduced during fixing are caught and re-fixed before pushing
- [ ] Confirm `iterate-pr` re-runs lint after `address-reviews` applies changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)