### PR TITLE
fix: make review-aggregator output format deterministic

### DIFF
--- a/.conductor/agents/review-aggregator.md
+++ b/.conductor/agents/review-aggregator.md
@@ -40,7 +40,7 @@ Steps:
 
    If `gh pr review` exits non-zero, note the failure in your CONDUCTOR_OUTPUT context but do not treat it as a blocking error — the comment posted in step 4a already captured the findings.
 
-   Format the review body as:
+   **IMPORTANT: Use EXACTLY the templates below. Do not add extra sections, change headings, add columns to the table, or write narrative prose. The only variation allowed is filling in reviewer names, verdicts, findings, and suggestions.**
 
    **If all reviewers approve:**
    ```
@@ -52,8 +52,11 @@ Steps:
    | security | :white_check_mark: approve |
    | ... | ... |
 
-   All reviewers passed with no blocking findings.
+   ### Suggestions (non-blocking)
+   - **<reviewer>**: <suggestion text>
+   - **<reviewer>**: <suggestion text>
    ```
+   (Omit the `### Suggestions` section entirely if there are no suggestions.)
 
    **If any reviewer has blocking issues:**
    ```
@@ -75,8 +78,9 @@ Steps:
    </details>
 
    ### Suggestions (non-blocking)
-   - ...
+   - **<reviewer>**: <suggestion text>
    ```
+   (Omit the `### Suggestions` section entirely if there are no suggestions.)
 
 5. Collect and file off-diff findings (skip all `gh` calls in this step if `{{dry_run}}` is `true`):
 


### PR DESCRIPTION
## Summary

- Add `### Suggestions (non-blocking)` section to the all-clear template so the agent has a designated place for non-blocking findings
- Add explicit instruction to use the templates exactly as written, with no added sections, columns, or narrative prose

## Root Cause

The all-clear template had no `### Suggestions` section. When all reviewers approved but suggestions existed, the agent had nowhere to put them and improvised a completely different format (wrong title, extra "Notes" table column, narrative prose summary).

## Test plan
- [ ] Run the review swarm on a PR where all reviewers approve but suggestions exist — verify output matches the all-clear template exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)