### PR TITLE
docs: update roadmap and add ideas parking lot

### DIFF
--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -1,0 +1,29 @@
+# Ideas Parking Lot
+
+Half-formed ideas that aren't ready for a ticket or RFC. Promote to a GitHub issue when the design questions are resolved.
+
+---
+
+## Tool version / update warnings
+
+Surface a warning when required external tools (`gh`, `git`, `tmux`, package managers) are missing or outdated.
+
+**Open questions:**
+- When to check? Startup adds latency (subprocess calls). Background check with a dismissable footer warning may be better.
+- Proactive (define minimum versions, check on startup) vs reactive (catch version-specific failures at the call site with a helpful hint like "consider upgrading `gh`")?
+- Proactive version pinning for all tools could become maintenance whack-a-mole — reactive with better error messages may be the right default.
+- How to surface it? Dismissable footer message, not a hard block.
+
+---
+
+## CI status in TUI
+
+Show PR check status (passing/failing/pending) without leaving the TUI.
+
+**Open questions:**
+- Where first? Options in priority order: (1) dashboard worktree list as a small indicator, (2) worktree detail view, (3) persistent workflow column from #662.
+- Data source: `gh pr view --json statusCheckRollup` for list/summary view; `gh pr checks` for per-check breakdown in detail view.
+- Fetch strategy: on-demand (manual refresh key) first, background polling later. CI status is volatile (checks run for minutes) so auto-refresh adds meaningful load.
+- Only relevant for worktrees with an open PR.
+
+---

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Conductor Roadmap
 
-Priority order as of 2026-03-08. See linked GitHub issues for full details.
+Priority order as of 2026-03-12. See linked GitHub issues for full details.
 
 ## Tier 1 — Near-term, High Value
 
@@ -16,8 +16,9 @@ Mostly independent, high signal-to-effort ratio.
 
 | Priority | Issue | Title | Notes |
 |----------|-------|-------|-------|
-| 2 | [#218](https://github.com/devinrosen/conductor-ai/issues/218) | Run a workflow against a GitHub PR URL without a local clone | Ephemeral shallow clone; `review-pr` is the natural first use case |
-| 3 | [#140](https://github.com/devinrosen/conductor-ai/issues/140) | Role-based tool profiles for scoped agent MCP access | Important as parallel agent usage scales |
+| 2 | [#662](https://github.com/devinrosen/conductor-ai/issues/662) | TUI redesign: persistent workflow column, footer status bar, simplified navigation | Remove tickets view, replace dynamic header with 1-line footer, add always-visible workflow column (right ~35%), directional column switching (`Ctrl+h`/`Ctrl+l`) |
+| 3 | [#667](https://github.com/devinrosen/conductor-ai/issues/667) | In-TUI theme picker with immediate preview | Modal picker, live preview, persists to config.toml on confirm |
+| 5 | [#140](https://github.com/devinrosen/conductor-ai/issues/140) | Role-based tool profiles for scoped agent MCP access | Important as parallel agent usage scales |
 
 ## Tier 3 — Larger Investments
 
@@ -25,10 +26,10 @@ High value but require more design and implementation work.
 
 | Priority | Issue | Title | Notes |
 |----------|-------|-------|-------|
-| 4 | [#274](https://github.com/devinrosen/conductor-ai/issues/274) | Dependency graph, impact analysis, and conflict-aware scheduling | Phased: dependency edges → impact analysis → DAG-aware scheduling. Absorbs cost-awareness from #142 as a scheduling signal. |
-| 5 | [#137](https://github.com/devinrosen/conductor-ai/issues/137) | Agent-to-human notifications from agent runs | |
-| 6 | [#144](https://github.com/devinrosen/conductor-ai/issues/144) | Cost analytics dashboard — spend over time by repo | Feeds into #274's cost-aware scheduling |
-| 7 | [#142](https://github.com/devinrosen/conductor-ai/issues/142) | Cost budgeting and spending limits per run, workflow, and repo | Deferred — smart scheduling (#274) is higher priority; hard spend caps remain useful as a safety net |
+| 6 | [#274](https://github.com/devinrosen/conductor-ai/issues/274) | Dependency graph, impact analysis, and conflict-aware scheduling | Phased: dependency edges → impact analysis → DAG-aware scheduling. Absorbs cost-awareness from #142 as a scheduling signal. |
+| 7 | [#137](https://github.com/devinrosen/conductor-ai/issues/137) | Agent-to-human notifications from agent runs | |
+| 8 | [#144](https://github.com/devinrosen/conductor-ai/issues/144) | Cost analytics dashboard — spend over time by repo | Feeds into #274's cost-aware scheduling |
+| 9 | [#142](https://github.com/devinrosen/conductor-ai/issues/142) | Cost budgeting and spending limits per run, workflow, and repo | Deferred — smart scheduling (#274) is higher priority; hard spend caps remain useful as a safety net |
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary

- Add `#662` (TUI redesign) and `#667` (theme picker) to the roadmap
- Remove closed issue `#218` (run workflow against GitHub PR URL — done)
- Renumber priorities and update date to 2026-03-12
- Add `docs/IDEAS.md` as a lightweight parking lot for half-formed ideas not yet ready for tickets: CI status in TUI and tool version/update warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)