### PR TITLE
fix(tui): prune completed workflow threads on each tick

### DIFF
--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -297,6 +297,10 @@ impl App {
         match action {
             Action::None => return false,
             Action::Tick => {
+                // Prune completed workflow threads so the Vec doesn't accumulate
+                // stale handles across the session. Only in-flight threads remain,
+                // making the quit-time join fast in the common case.
+                self.workflow_threads.retain(|h| !h.is_finished());
                 // Poll workflow data asynchronously on every tick so the global
                 // status bar (and workflow views) stay current regardless of which
                 // view is active.


### PR DESCRIPTION
## Summary

Workflow thread handles were pushed to `workflow_threads` on spawn but never removed on completion. The Vec accumulated stale handles across the session, so the quit-time join loop iterated all of them — if any was still mid-execution, the TUI would block for up to 10 seconds before exiting.

## Fix

Prune finished threads on every `Tick` with a one-liner:
```rust
self.workflow_threads.retain(|h| !h.is_finished());
```

By quit time, the Vec only contains genuinely in-flight threads (workflows actively mid-step). The 10-second join timeout remains as a safety net for those.

## Test plan
- [ ] Run several workflows to completion, then quit — TUI should exit immediately
- [ ] Quit while a workflow is actively running — TUI should wait briefly then exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)