### PR TITLE
feat(workflows): add rebase-worktree and rebase-and-fix workflows

### DIFF
--- a/.conductor/workflows/iterate-pr.wf
+++ b/.conductor/workflows/iterate-pr.wf
@@ -9,12 +9,7 @@ workflow iterate-pr {
     max_iterations = 10
     on_max_iter    = fail
 
-    call sync-with-main
-
-    if sync-with-main.has_conflicts {
-      call resolve-conflicts
-      call push
-    }
+    call workflow rebase-worktree
 
     call workflow lint-fix
 

--- a/.conductor/workflows/rebase-and-fix.wf
+++ b/.conductor/workflows/rebase-and-fix.wf
@@ -1,0 +1,11 @@
+workflow rebase-and-fix {
+  meta {
+    description = "Fetch latest main, resolve conflicts, fix lint, and push — leaves the PR CI-green and ready for next steps"
+    trigger     = "manual"
+    targets     = ["worktree"]
+  }
+
+  call workflow rebase-worktree
+
+  call workflow lint-fix
+}

--- a/.conductor/workflows/rebase-worktree.wf
+++ b/.conductor/workflows/rebase-worktree.wf
@@ -1,0 +1,15 @@
+workflow rebase-worktree {
+  meta {
+    description = "Fetch latest main, resolve any conflicts, and force-push the branch"
+    trigger     = "manual"
+    targets     = ["worktree"]
+  }
+
+  call sync-with-main
+
+  if sync-with-main.has_conflicts {
+    call resolve-conflicts
+  }
+
+  call push
+}


### PR DESCRIPTION
## Summary

- **`rebase-worktree`** — fetch latest main, resolve any conflicts, force-push. Pure git op.
- **`rebase-and-fix`** — `rebase-worktree` + `lint-fix`. Leaves the branch CI-green before deciding next steps.
- **`iterate-pr`** — replaced inline `sync-with-main` / `resolve-conflicts` / `push` block with `call workflow rebase-worktree`. Also fixes a latent gap where a conflict-free rebase wasn't being pushed.

## Test plan

- [ ] Run `conductor workflow validate rebase-worktree`
- [ ] Run `conductor workflow validate rebase-and-fix`
- [ ] Run `conductor workflow validate iterate-pr`
- [ ] Run `rebase-worktree` on a worktree with no conflicts — should fetch, rebase cleanly, and push
- [ ] Run `rebase-worktree` on a worktree with conflicts — should resolve and push
- [ ] Run `rebase-and-fix` — should rebase + lint before pushing

🤖 Generated with [Claude Code](https://claude.com/claude-code)