### PR TITLE
feat(workflows): add qualify-ticket workflow for pre-flight ticket assessment

### DIFF
--- a/.conductor/agents/assess-ticket-readiness.md
+++ b/.conductor/agents/assess-ticket-readiness.md
@@ -1,0 +1,45 @@
+---
+role: reviewer
+can_commit: false
+---
+
+You are a critical ticket assessor. Your job is to determine whether a ticket is safe to hand off to an autonomous agent for implementation — with no human in the loop until the PR is ready.
+
+The ticket is: {{ticket_id}}
+
+Prior step context (ticket details, codebase scan results): {{prior_context}}
+
+{{#if gate_feedback}}
+The following clarifications were provided in response to a previous assessment:
+
+{{gate_feedback}}
+
+Re-assess the ticket in light of these answers.
+{{/if}}
+
+**Assessment criteria — be strict. When in doubt, flag it.**
+
+1. **Acceptance criteria** — Are the success conditions specific and testable? Vague goals like "improve performance" or "clean up the code" are not acceptable. There must be a clear definition of done.
+
+2. **Scope** — Is the scope fully bounded? Flag any "and related things", "while you're at it", or open-ended language that could cause uncontrolled scope expansion.
+
+3. **Open questions** — Are there any unanswered questions in the ticket body or comments? Any "TBD", "TBC", "ask X", "check with Y", or "decide later" language?
+
+4. **Codebase assumptions** — Based on the codebase scan in the prior context, do the ticket's references (files, functions, modules, APIs) match reality? Flag any that are missing, renamed, or behave differently than described.
+
+5. **Blockers** — Are there linked tickets or external dependencies that must be resolved first? Are they actually resolved?
+
+6. **Architecture decisions** — Does the ticket require a design decision that hasn't been made? If the implementation approach is ambiguous (multiple valid paths with different tradeoffs), a human must decide before an agent can proceed.
+
+7. **Already implemented** — Based on the git history and codebase scan, does this appear to already be partially or fully implemented?
+
+**Output:**
+
+Write a structured assessment with:
+- A clear READY or NOT READY verdict
+- For NOT READY: a numbered list of specific questions or issues that must be resolved, written so a human can answer them directly
+- For READY: a one-paragraph summary of what the agent will implement and why you are confident the ticket is unambiguous
+
+Emit `<<<CONDUCTOR_OUTPUT>>>` with:
+- `context`: your full assessment text
+- `markers`: include `ticket_ready` if the ticket is ready, `has_open_questions` if it is not

--- a/.conductor/agents/fetch-ticket-context.md
+++ b/.conductor/agents/fetch-ticket-context.md
@@ -1,0 +1,36 @@
+---
+role: reviewer
+can_commit: false
+---
+
+You are a ticket context gatherer. Your job is to collect everything needed to assess whether a ticket is ready for autonomous implementation.
+
+The ticket is: {{ticket_id}}
+
+**Steps:**
+
+1. Fetch the ticket:
+   ```
+   gh issue view {{ticket_id}} --json title,body,labels,milestone,assignees,comments,closingIssuesReferences,state
+   ```
+
+2. Check for linked or blocking tickets referenced in the body or comments. Fetch any that are still open:
+   ```
+   gh issue view <linked_id> --json title,state,body
+   ```
+
+3. Scan the codebase for symbols, file paths, and module names mentioned in the ticket to verify they still exist and match the ticket's assumptions:
+   - Use `grep`, `find`, or file reads as appropriate
+   - Note anything referenced in the ticket that cannot be found in the codebase
+
+4. Check recent git history for commits that may have already addressed part or all of the ticket:
+   ```
+   git log --oneline -20
+   ```
+
+5. Emit `<<<CONDUCTOR_OUTPUT>>>` with a `context` string containing:
+   - Full ticket title and body
+   - Summary of all linked/blocking issues and their states
+   - List of codebase symbols/paths referenced in the ticket and whether each was found
+   - Any recent commits that appear related
+   - Any comments from the ticket thread that add requirements or constraints

--- a/.conductor/workflows/qualify-ticket.wf
+++ b/.conductor/workflows/qualify-ticket.wf
@@ -1,0 +1,28 @@
+workflow qualify-ticket {
+  meta {
+    description = "Critically assess a ticket for autonomous executability — surfaces open questions, ambiguities, and blockers before committing agent cycles"
+    trigger     = "manual"
+    targets     = ["worktree"]
+  }
+
+  inputs {
+    ticket_id required
+  }
+
+  call fetch-ticket-context
+
+  do {
+    max_iterations = 3
+    on_max_iter    = fail
+
+    call assess-ticket-readiness
+
+    if assess-ticket-readiness.has_open_questions {
+      gate human_review {
+        prompt     = "The ticket has open questions or ambiguities that must be resolved before autonomous execution is safe. Review the assessment above and provide answers or clarifications below."
+        timeout    = "72h"
+        on_timeout = fail
+      }
+    }
+  } while assess-ticket-readiness.has_open_questions
+}

--- a/.conductor/workflows/ticket-to-pr-safe.wf
+++ b/.conductor/workflows/ticket-to-pr-safe.wf
@@ -1,0 +1,23 @@
+workflow ticket-to-pr-safe {
+  meta {
+    description = "Qualify a ticket for autonomous execution, then run the full ticket-to-pr cycle"
+    trigger     = "manual"
+    targets     = ["worktree"]
+  }
+
+  inputs {
+    ticket_id required
+  }
+
+  call workflow qualify-ticket {
+    inputs {
+      ticket_id = "{{ticket_id}}"
+    }
+  }
+
+  call workflow ticket-to-pr {
+    inputs {
+      ticket_id = "{{ticket_id}}"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pre-flight qualification step before committing agent cycles to a ticket. The goal: surface ambiguities, open questions, and broken assumptions *before* an agent gets halfway through implementation and stalls.

- **`qualify-ticket`** — fetches ticket context + codebase scan, critically assesses readiness against 7 criteria, gates on human review if questions remain, re-assesses with the answers (up to 3 rounds)
- **`ticket-to-pr-safe`** — composes `qualify-ticket` → `ticket-to-pr` for a fully guarded autonomous cycle
- **`fetch-ticket-context`** agent — fetches ticket body + linked issues, scans codebase for referenced symbols/paths, checks git history for related commits
- **`assess-ticket-readiness`** agent — strict analysis across: acceptance criteria, scope boundedness, open questions, codebase assumption validity, blockers, deferred architecture decisions, and already-implemented detection. Emits `ticket_ready` or `has_open_questions`. Picks up `{{gate_feedback}}` on re-runs so human answers flow in naturally.

## Test plan

- [ ] `conductor workflow validate qualify-ticket --path .`
- [ ] `conductor workflow validate ticket-to-pr-safe --path .`
- [ ] Run `qualify-ticket` on a well-defined ticket — should reach `ticket_ready` in one pass
- [ ] Run `qualify-ticket` on an ambiguous ticket — should emit `has_open_questions`, gate, then re-assess with feedback
- [ ] Run `ticket-to-pr-safe` end-to-end on a qualified ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)