### PR TITLE
fix(workflows): rebase + conditional re-review after approval in ticket-to-pr-auto-merge

### DIFF
--- a/.conductor/workflows/ticket-to-pr-auto-merge.wf
+++ b/.conductor/workflows/ticket-to-pr-auto-merge.wf
@@ -29,10 +29,16 @@ workflow ticket-to-pr-auto-merge {
   }
 
   // Rebase onto latest main after approval to resolve any conflicts that
-  // accumulated during the review window, and fix lint
-  call workflow rebase-and-fix
+  // accumulated during the review window
+  call workflow rebase-worktree
 
-  // Wait for CI to pass on the rebased branch before merging
+  // If conflicts were resolved, code changed — re-run lint and full review
+  // cycle to verify the fix before merging
+  if rebase-worktree.has_conflicts {
+    call workflow iterate-pr
+  }
+
+  // CI must pass on the final state before merging
   gate pr_checks {
     timeout    = "2h"
     on_timeout = fail


### PR DESCRIPTION
## Problem
During the 72h `pr_approval` gate, other PRs can merge and leave the branch behind `main` with conflicts. When `merge-and-close` runs, the merge fails or GitHub blocks it.

Additionally, if conflicts were resolved (code was changed), the original approval is stale — a re-review is warranted before merging.

Example: #734

## Fix

Replace the naive `rebase-and-fix` call with conditional logic using the `has_conflicts` marker from `rebase-worktree`:

1. After approval, run `rebase-worktree` directly (not via `rebase-and-fix`) so the parent can read its `has_conflicts` marker
2. **If conflicts were resolved** → run `iterate-pr` (lint-fix + review swarm + iterate loop) since code changed
3. **If no conflicts** → skip review, proceed directly to CI gate
4. Wait for CI to pass on the final state
5. Merge

## Why `rebase-worktree` directly instead of `rebase-and-fix`

Shallow workflow composition only bubbles up the *final* step's markers to the parent. `rebase-and-fix` ends with `lint-fix`, so `has_conflicts` from `rebase-worktree` would be invisible to the parent. Calling `rebase-worktree` directly makes the marker available for branching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)