### PR TITLE
chore: ignore .conductor/postmortems/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ conductor-web/frontend/node_modules/
 conductor-web/frontend/dist/
 *.local.json
 PLAN.md
+.conductor/postmortems/


### PR DESCRIPTION
Adds `.conductor/postmortems/` to `.gitignore` so local postmortem files aren't accidentally staged. Also fixes the missing newline at end of file.