### PR TITLE
fix(workflow): review-aggregator posts as conductor-ai-reviewer

### DIFF
--- a/.conductor/workflows/review-pr.wf
+++ b/.conductor/workflows/review-pr.wf
@@ -18,5 +18,5 @@ workflow review-pr {
     call review-db-migrations   { retries = 1 }
   }
 
-  call review-aggregator { output = "review-aggregator" retries = 1 }
+  call review-aggregator { output = "review-aggregator" retries = 1 as = "conductor-ai-reviewer" }
 }


### PR DESCRIPTION
## Summary

- `review-aggregator` was posting PR comments using `conductor-ai-coder` instead of `conductor-ai-reviewer`
- Root cause: no `as =` override on `call review-aggregator` in `review-pr.wf`, so it inherited `default_bot_name` from the parent `ticket-to-pr` run (which uses the coder identity)
- Fix: add `as = "conductor-ai-reviewer"` to the call, ensuring the aggregator always posts under the reviewer bot regardless of which bot launched the parent workflow

## Test plan
- [ ] Run `review-pr` workflow via `ticket-to-pr` and confirm the aggregated review comment is posted by `conductor-ai-reviewer`
- [ ] Confirm validation passes: `conductor workflow validate --path . review-pr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)