### PR TITLE
feat(workflow): add db-check schema for detect-db-migrations output

### DIFF
--- a/.conductor/schemas/db-check.yaml
+++ b/.conductor/schemas/db-check.yaml
@@ -1,0 +1,10 @@
+fields:
+  context:
+    type: string
+    desc: "Summary of migration detection result (e.g. 'Found 2 migration file(s) in diff')"
+  markers?:
+    type: array
+    desc: "Active markers emitted by the agent (has_db_migrations when migrations found)"
+
+markers:
+  has_db_migrations: "markers.length > 0"


### PR DESCRIPTION
## Summary
- Adds the missing `.conductor/schemas/db-check.yaml` that was supposed to ship with #774
- Schema validates the `detect-db-migrations` agent output and derives the `has_db_migrations` marker from the agent's `markers` array
- No changes to the agent or workflow — the schema matches the existing output format exactly

## Test plan
- [ ] Run `review-pr` workflow on a PR with migration files — `review-db-migrations` step should execute
- [ ] Run `review-pr` workflow on a PR without migration files — `review-db-migrations` step should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)