### PR TITLE
feat(workflow): skip rebase when PR merges cleanly into main

### DIFF
--- a/.conductor/agents/check-mergeability.md
+++ b/.conductor/agents/check-mergeability.md
@@ -1,0 +1,19 @@
+---
+role: reviewer
+can_commit: false
+model: claude-haiku-4-5-20251001
+---
+
+You are a pre-rebase check agent. Your task is to determine whether the current PR can merge cleanly into main using GitHub's computed mergeability.
+
+Steps:
+1. Run `gh pr view --json mergeable,mergeStateStatus` to get the PR's merge status.
+2. If the `mergeable` field is `UNKNOWN`, GitHub is still computing. Wait 5 seconds and retry up to 2 times. If still `UNKNOWN` after retries, treat it as `MERGEABLE` (skip the rebase) and note the uncertainty in context.
+3. Emit markers based on the result:
+   - `mergeable == "CONFLICTING"` → emit `has_conflicts`
+   - `mergeable == "MERGEABLE"` → emit no markers
+   - `mergeable == "UNKNOWN"` after retries → emit no markers
+
+Output the `mergeable` and `mergeStateStatus` values in your structured output.
+
+Prior step context: {{prior_context}}

--- a/.conductor/schemas/merge-check.yaml
+++ b/.conductor/schemas/merge-check.yaml
@@ -1,0 +1,10 @@
+fields:
+  mergeable:
+    type: enum(MERGEABLE, CONFLICTING, UNKNOWN)
+    desc: "GitHub's computed mergeability for this PR"
+  merge_state_status:
+    type: string
+    desc: "GitHub mergeStateStatus (CLEAN, DIRTY, BLOCKED, UNSTABLE, etc.)"
+
+markers:
+  has_conflicts: "mergeable == CONFLICTING"

--- a/.conductor/workflows/rebase-worktree.wf
+++ b/.conductor/workflows/rebase-worktree.wf
@@ -5,11 +5,15 @@ workflow rebase-worktree {
     targets     = ["worktree"]
   }
 
-  call sync-with-main
+  call check-mergeability { output = "merge-check" }
 
-  if sync-with-main.has_conflicts {
-    call resolve-conflicts
+  if check-mergeability.has_conflicts {
+    call sync-with-main
+
+    if sync-with-main.has_conflicts {
+      call resolve-conflicts
+    }
+
+    call push
   }
-
-  call push
 }


### PR DESCRIPTION
## Summary
- Adds a `check-mergeability` pre-check that queries `gh pr view --json mergeable,mergeStateStatus` before touching the branch
- The rebase, conflict resolution, and push now only run when GitHub reports the PR as `CONFLICTING`
- Clean PRs (`MERGEABLE`) exit immediately after the check — no unnecessary rebase or force-push
- `UNKNOWN` (GitHub still computing) is retried up to 2 times, then treated as clean

## New files
- `.conductor/agents/check-mergeability.md` — mergeability check agent
- `.conductor/schemas/merge-check.yaml` — structured output schema, derives `has_conflicts` from `mergeable == CONFLICTING`

## Execution paths
| GitHub says | Result |
|---|---|
| `MERGEABLE` | Check runs, workflow exits. Branch untouched. |
| `CONFLICTING` | Rebase → optionally resolve conflicts → push |
| `UNKNOWN` after retries | Treated as clean, skip rebase |

## Test plan
- [ ] Run `rebase-worktree` on a PR with no conflicts — verify only `check-mergeability` runs
- [ ] Run `rebase-worktree` on a PR with conflicts — verify full rebase + resolve + push path runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)