### PR TITLE
fix(workflow): align review-aggregator bot identity with config key

### DIFF
--- a/.conductor/workflows/review-pr.wf
+++ b/.conductor/workflows/review-pr.wf
@@ -20,5 +20,5 @@ workflow review-pr {
     call review-db-migrations   { retries = 1 if = "detect-db-migrations.has_db_migrations" }
   }
 
-  call review-aggregator { output = "review-aggregator" retries = 1 as = "conductor-ai-reviewer" }
+  call review-aggregator { output = "review-aggregator" retries = 1 as = "reviewer" }
 }


### PR DESCRIPTION
## Summary
- Fixes `as = "conductor-ai-reviewer"` → `as = "reviewer"` in `review-pr.wf` to match the key name in `config.toml` (`[github.apps.reviewer]`)
- The mismatch caused `resolve_named_app_token` to silently fall through to `NotConfigured`, so no `GH_TOKEN` was injected and the agent posted reviews under the human `gh` identity instead of the bot

## Root cause
`resolve_named_app_token` looks up the `as =` value in `config.github.apps`. When the key isn't found it warns and falls back to the singleton `[github.app]`, which is also not configured — resulting in `NotConfigured` with no error surfaced to the user.

## Test plan
- [ ] Run `review-pr` and verify the PR review/comment is posted by `conductor-ai-reviewer[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)