### PR TITLE
feat(agent): add explicit diagnostics for GitHub App token resolution

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -1999,7 +1999,15 @@ fn run_agent(
     };
 
     // Build effective prompt with optional startup context
-    let config = load_config().unwrap_or_default();
+    let config = match load_config() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "[conductor] Warning: failed to load config, GitHub App auth will be skipped: {e}"
+            );
+            conductor_core::config::Config::default()
+        }
+    };
     let effective_prompt = if config.general.inject_startup_context {
         let context =
             build_startup_context(conn, run.worktree_id.as_deref(), run_id, worktree_path);
@@ -2139,6 +2147,9 @@ fn run_agent(
         // than the human `gh` CLI user. Fall back gracefully when not configured.
         match github_app::resolve_named_app_token(&config, bot_name, "agent-run") {
             github_app::TokenResolution::AppToken(token) => {
+                if let Some(name) = bot_name {
+                    eprintln!("[conductor] Using GitHub App token for bot identity: {name}");
+                }
                 cmd.env("GH_TOKEN", token);
             }
             github_app::TokenResolution::Fallback { reason } => {
@@ -2146,7 +2157,13 @@ fn run_agent(
                     "[conductor] Warning: GitHub App token failed, agents will use gh user identity: {reason}"
                 );
             }
-            github_app::TokenResolution::NotConfigured => {}
+            github_app::TokenResolution::NotConfigured => {
+                if let Some(name) = bot_name {
+                    eprintln!(
+                        "[conductor] Warning: bot name '{name}' specified but no matching GitHub App found in config — agents will use gh user identity"
+                    );
+                }
+            }
         }
 
         if let Some(m) = model {


### PR DESCRIPTION
## Summary
- Warn (with error message) when `load_config()` fails in `run_agent`, instead of silently falling back to an empty default config
- Log `[conductor] Using GitHub App token for bot identity: <name>` on success, so the tmux pane confirms the token was obtained
- Warn `[conductor] Warning: bot name '<name>' specified but no matching GitHub App found in config` when `NotConfigured` is returned but a `--bot-name` was requested

## Why
Previously, `TokenResolution::NotConfigured` was completely silent. If the config failed to load or the named app wasn't found, there was zero output — indistinguishable from intentional "no app configured" behavior. This made it impossible to diagnose why reviews were posting as the human user instead of the bot.

## Test plan
- [ ] Run a workflow step with `as = "reviewer"` and confirm `[conductor] Using GitHub App token for bot identity: reviewer` appears in the tmux pane
- [ ] Temporarily rename `[github.apps.reviewer]` → `[github.apps.reviewer2]` in config and confirm the new warning appears
- [ ] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)