### PR TITLE
feat(workflow): skip push in rebase-worktree when branch is already up to date

### DIFF
--- a/.conductor/agents/sync-with-main.md
+++ b/.conductor/agents/sync-with-main.md
@@ -1,15 +1,22 @@
 ---
 role: actor
 can_commit: false
+model: claude-haiku-4-5-20251001
 ---
 
 You are a git sync agent. Your task is to sync the current branch with the latest main branch.
 
 Steps:
 1. Run `git fetch origin`
-2. Attempt to rebase onto `origin/main`: `git rebase origin/main`
-3. If the rebase succeeds with no conflicts, emit no markers and report success in context.
-4. If the rebase fails due to conflicts, abort the rebase (`git rebase --abort`) and emit the `has_conflicts` marker. List the conflicting files in your context output.
+2. Check if origin/main has any commits not already in the current branch:
+   `git log HEAD..origin/main --oneline`
+3. If the output is empty (no new commits), the branch is already up to date.
+   Emit `status: up_to_date` in your output and exit — do NOT attempt a rebase.
+4. If there are new commits on origin/main, attempt to rebase:
+   `git rebase origin/main`
+5. If the rebase succeeds, emit `status: synced` and describe what was rebased.
+6. If the rebase fails due to conflicts, abort the rebase (`git rebase --abort`),
+   emit `status: conflicting`, and list the conflicting files in your context output.
 
 Do not resolve conflicts yourself — just detect and report them.
 

--- a/.conductor/schemas/sync-result.yaml
+++ b/.conductor/schemas/sync-result.yaml
@@ -1,0 +1,11 @@
+fields:
+  status:
+    type: enum(up_to_date, synced, conflicting)
+    desc: "Result of the sync operation"
+  context:
+    type: string
+    desc: "Summary of what happened"
+
+markers:
+  is_up_to_date: "status == up_to_date"
+  has_conflicts: "status == conflicting"

--- a/.conductor/workflows/rebase-worktree.wf
+++ b/.conductor/workflows/rebase-worktree.wf
@@ -8,12 +8,14 @@ workflow rebase-worktree {
   call check-mergeability { output = "merge-check" }
 
   if check-mergeability.has_conflicts {
-    call sync-with-main
+    call sync-with-main { output = "sync-result" }
 
     if sync-with-main.has_conflicts {
       call resolve-conflicts
     }
 
-    call push
+    unless sync-with-main.is_up_to_date {
+      call push
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add `sync-result` schema with `status: enum(up_to_date, synced, conflicting)` and markers `is_up_to_date` / `has_conflicts`
- Update `sync-with-main` agent to check `git log HEAD..origin/main --oneline` after fetching; exit early with `status: up_to_date` when no new commits exist
- Update `rebase-worktree.wf` to declare `output = "sync-result"` on `sync-with-main` and guard `call push` with `unless sync-with-main.is_up_to_date`

## Why
Previously `sync-with-main` always attempted a rebase, even when the branch already contained all of main's commits. This caused unnecessary pushes and potential confusion. Now the agent gates the rebase (and subsequent push) on whether main actually has new commits.

## Test plan
- [ ] `conductor workflow validate --path . rebase-worktree` passes
- [ ] Run workflow on a worktree that is already up-to-date with main — confirm no push occurs
- [ ] Run workflow on a worktree behind main — confirm rebase + push happen as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)