### PR TITLE
docs(rfc): close RFC 004 — conductor Claude Code experience implemented

### DIFF
--- a/docs/rfc/closed/004-conductor-claude-code-experience.md
+++ b/docs/rfc/closed/004-conductor-claude-code-experience.md
@@ -1,6 +1,6 @@
 # RFC 004: Conductor as a Native Claude Code Experience
 
-**Status:** Draft / Exploring
+**Status:** Implemented
 **Created:** 2026-03-12
 
 ---


### PR DESCRIPTION
## Summary

Moves RFC 004 from `docs/rfc/open/` to `docs/rfc/closed/` and updates status to `Implemented`.

## What shipped

- **Phase 1** — Status line (`conductor statusline install`, #599 closed) + conductor Claude Code plugin (#588 closed, published to [LivelyVideo/claude-plugin-marketplace](https://github.com/LivelyVideo/claude-plugin-marketplace))
- **Phase 2** — `conductor mcp serve` fully implemented (`conductor-cli/src/mcp.rs`, 24 tools, 9 resources)
- **Phase 3** — Conversational use enabled by the MCP tools; no additional work needed

Issue #600 (status line auto-install via plugin) closed as won't fix — standalone `conductor statusline install` covers the use case and `/conductor:status` handles the Claude Code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)