### PR TITLE
fix(#969): reference review-aggregator.has_blocking_findings in iterate-pr

### DIFF
--- a/.conductor/workflows/iterate-pr.wf
+++ b/.conductor/workflows/iterate-pr.wf
@@ -15,10 +15,10 @@ workflow iterate-pr {
 
     call workflow review-pr
 
-    if review-pr.has_blocking_findings {
+    if review-aggregator.has_blocking_findings {
       call address-reviews
       call fmt-fix
       call workflow lint-fix
     }
-  } while review-pr.has_blocking_findings
+  } while review-aggregator.has_blocking_findings
 }


### PR DESCRIPTION
## Summary

Fixes #969. The `iterate-pr` loop condition was broken after `submit-review` was added as the last step of `review-pr.wf`.

`fetch_child_completion_data` derives a sub-workflow's bubbled-up markers from the **last completed step by position**. `submit-review` is now last and emits no markers, so `review-pr.has_blocking_findings` was always `false` — iterate-pr exited after one pass even when changes were requested.

Child step results are bubbled up into the parent's `step_results` map, so `review-aggregator` is directly addressable from `iterate-pr`. This fix references it directly.

## Change

```diff
- if review-pr.has_blocking_findings {
+ if review-aggregator.has_blocking_findings {
```
```diff
- } while review-pr.has_blocking_findings  
+ } while review-aggregator.has_blocking_findings
```

## Follow-up

Issue #969 also tracks an engine-level fix (Option A): aggregate the union of all child step markers instead of only the last step's, so this pattern can't regress when workflow steps are reordered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)