### PR TITLE
fix: use merger app identity for merge-and-close script steps

### DIFF
--- a/.conductor/workflows/merge-when-ready.wf
+++ b/.conductor/workflows/merge-when-ready.wf
@@ -22,7 +22,7 @@ workflow merge-when-ready {
 
   script merge-and-close {
     run = ".conductor/scripts/merge-and-close.sh"
-    as  = "actor"
+    as  = "merger"
     env = { TICKET_NUMBER = "{{ticket_id}}" }
   }
 }

--- a/.conductor/workflows/ticket-to-pr-auto-merge.wf
+++ b/.conductor/workflows/ticket-to-pr-auto-merge.wf
@@ -46,7 +46,7 @@ workflow ticket-to-pr-auto-merge {
 
   script merge-and-close {
     run = ".conductor/scripts/merge-and-close.sh"
-    as  = "actor"
+    as  = "merger"
     env = { TICKET_NUMBER = "{{ticket_id}}" }
   }
 }


### PR DESCRIPTION
## Summary
- Changes `as = "actor"` to `as = "merger"` in both `merge-when-ready.wf` and `ticket-to-pr-auto-merge.wf`
- `merger` is the correct named GitHub app in `config.toml` for merge operations (introduced in #988)

## Test plan
- [x] Verify `merger` app is used when running merge-when-ready workflow
- [x] Verify `merger` app is used when running ticket-to-pr-auto-merge workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)