### PR TITLE
fix: declare ticket_id input in merge-when-ready so issue close works

### DIFF
--- a/.conductor/workflows/merge-when-ready.wf
+++ b/.conductor/workflows/merge-when-ready.wf
@@ -6,7 +6,8 @@ workflow merge-when-ready {
   }
 
   inputs {
-    pr_url required
+    pr_url    required
+    ticket_id
   }
 
   gate pr_checks {


### PR DESCRIPTION
## Summary
- `merge-when-ready.wf` was missing `ticket_id` as an optional input
- `{{ticket_id}}` substituted to empty string at runtime, so the `merge-and-close.sh` guard failed and silently skipped closing the linked issue
- Root cause of issue #958 not being closed after PR #990 merged

## Test plan
- [ ] Run merge-when-ready with `--input ticket_id=<number>` and verify the linked issue is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)