### PR TITLE
fix: handle already-merged PR in merge-and-close script

### DIFF
--- a/.conductor/scripts/merge-and-close.sh
+++ b/.conductor/scripts/merge-and-close.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Resolve PR number from current branch
+# Resolve PR number and state from current branch
 PR_NUMBER=$(gh pr view --json number -q .number)
+PR_STATE=$(gh pr view --json state -q .state)
 
-# Merge via auto-merge (merge queue); fall back to direct squash if unsupported
-if ! gh pr merge --auto --squash --delete-branch 2>/dev/null; then
-  gh pr merge --squash --delete-branch
+# Merge if not already merged; if already merged (e.g. via auto-merge), skip
+if [ "${PR_STATE}" = "MERGED" ]; then
+  echo "PR #${PR_NUMBER} already merged — skipping merge step"
+else
+  # Attempt auto-merge (merge queue); fall back to direct squash if unsupported
+  if ! gh pr merge --auto --squash --delete-branch 2>/dev/null; then
+    gh pr merge --squash --delete-branch
+  fi
+  echo "Merged PR #${PR_NUMBER}"
 fi
-
-echo "Merged PR #${PR_NUMBER}"
 
 # Close linked issue if TICKET_NUMBER was provided and is a valid number
 if [ -n "${TICKET_NUMBER:-}" ] && [[ "${TICKET_NUMBER}" =~ ^#?[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary
- If GitHub auto-merge fires before the script runs, `gh pr merge --squash` exits non-zero and kills the script (due to `set -euo pipefail`) before reaching the issue-close logic
- Fix: check `gh pr view --json state` first; skip the merge step if the PR is already `MERGED`, so issue close always executes

## Root cause
Observed in the `ticket-to-pr-auto-merge` run for worktree `feat-965` (run `01KKVWEMF70S92BKFFVV65FY53`): PR #992 was already merged by the time the script ran, causing empty output and a failed step.

## Test plan
- [x] Run merge-when-ready on a branch where the PR is already merged — verify issue is still closed
- [x] Run merge-when-ready normally — verify PR is merged and issue is closed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)