### PR TITLE
fix: inject ticket_source_id so merge-and-close closes the correct GitHub issue

### DIFF
--- a/.conductor/workflows/merge-when-ready.wf
+++ b/.conductor/workflows/merge-when-ready.wf
@@ -7,7 +7,7 @@ workflow merge-when-ready {
 
   inputs {
     pr_url    required
-    ticket_id
+    ticket_source_id
   }
 
   gate pr_checks {
@@ -24,6 +24,6 @@ workflow merge-when-ready {
   script merge-and-close {
     run = ".conductor/scripts/merge-and-close.sh"
     as  = "merger"
-    env = { TICKET_NUMBER = "{{ticket_id}}" }
+    env = { TICKET_NUMBER = "{{ticket_source_id}}" }
   }
 }

--- a/.conductor/workflows/ticket-to-pr-auto-merge.wf
+++ b/.conductor/workflows/ticket-to-pr-auto-merge.wf
@@ -47,6 +47,6 @@ workflow ticket-to-pr-auto-merge {
   script merge-and-close {
     run = ".conductor/scripts/merge-and-close.sh"
     as  = "merger"
-    env = { TICKET_NUMBER = "{{ticket_id}}" }
+    env = { TICKET_NUMBER = "{{ticket_source_id}}" }
   }
 }

--- a/conductor-core/src/workflow/engine.rs
+++ b/conductor-core/src/workflow/engine.rs
@@ -239,6 +239,9 @@ pub fn execute_workflow(input: &WorkflowExecInput<'_>) -> Result<WorkflowResult>
             .entry("ticket_id".to_string())
             .or_insert_with(|| ticket.id.clone());
         merged_inputs
+            .entry("ticket_source_id".to_string())
+            .or_insert_with(|| ticket.source_id.clone());
+        merged_inputs
             .entry("ticket_title".to_string())
             .or_insert_with(|| ticket.title.clone());
         merged_inputs


### PR DESCRIPTION
## Summary
- `{{ticket_id}}` in the workflow variable map was the conductor internal ULID (e.g. `01KKVX64FNW4CDGSJNMSMQBZ0D`), not the GitHub issue number
- The merge-and-close script guards with `^#?[0-9]+$` which never matches a ULID, so issue close was silently skipped on every run
- Root cause: the engine injects `ticket_id = ticket.id` (ULID) as an implicit variable; there was no way for scripts to get the actual GitHub issue number

## Fix
- Inject `ticket_source_id` (= `ticket.source_id`, the GitHub issue number) as a new implicit workflow variable alongside the existing `ticket_id`
- Switch `ticket-to-pr-auto-merge.wf` and `merge-when-ready.wf` to pass `{{ticket_source_id}}` as `TICKET_NUMBER`

## Test plan
- [ ] Run `ticket-to-pr-auto-merge` — verify the linked GitHub issue is closed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)