### PR TITLE
fix: pass worktree ticket_id to workflow engine so ticket_source_id is injected

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -1443,7 +1443,7 @@ fn main() -> Result<()> {
                             worktree_id: Some(&wt.id),
                             working_dir: &wt.path,
                             repo_path: &r.local_path,
-                            ticket_id: None,
+                            ticket_id: wt.ticket_id.as_deref(),
                             repo_id: None,
                             model: model.as_deref(),
                             exec_config: &exec_config,

--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -3418,7 +3418,7 @@ impl App {
             }
             PostCreateChoice::RunWorkflow { def, .. } => {
                 let mut inputs = std::collections::HashMap::new();
-                inputs.insert("ticket_id".to_string(), ticket_id);
+                inputs.insert("ticket_id".to_string(), ticket_id.clone());
                 let post_create_target_label = self
                     .state
                     .data
@@ -3439,6 +3439,7 @@ impl App {
                     worktree_id,
                     worktree_path,
                     repo_path,
+                    Some(ticket_id),
                     inputs,
                     post_create_target_label,
                 );
@@ -5407,7 +5408,7 @@ impl App {
                     }
                 }
 
-                let wt_target_label = self
+                let (wt_target_label, wt_ticket_id) = self
                     .state
                     .data
                     .worktrees
@@ -5419,7 +5420,7 @@ impl App {
                             .repos
                             .iter()
                             .find(|r| r.id == w.repo_id)
-                            .map(|r| format!("{}/{}", r.slug, w.slug))
+                            .map(|r| (format!("{}/{}", r.slug, w.slug), w.ticket_id.clone()))
                     })
                     .unwrap_or_default();
                 self.spawn_workflow_in_background(
@@ -5427,6 +5428,7 @@ impl App {
                     worktree_id,
                     worktree_path,
                     repo_path,
+                    wt_ticket_id,
                     std::collections::HashMap::new(),
                     wt_target_label,
                 );
@@ -5507,6 +5509,7 @@ impl App {
                         wt_id,
                         working_dir,
                         repo_path,
+                        None,
                         inputs,
                         workflow_run_id,
                     );
@@ -5585,18 +5588,21 @@ impl App {
             wt.id,
             wt.path,
             repo_path,
+            wt.ticket_id,
             std::collections::HashMap::new(),
             wt_target_label,
         );
     }
 
     /// Spawn a workflow execution in a background thread, reporting result via bg_tx.
+    #[allow(clippy::too_many_arguments)]
     fn spawn_workflow_in_background(
         &mut self,
         def: conductor_core::workflow::WorkflowDef,
         worktree_id: String,
         worktree_path: String,
         repo_path: String,
+        ticket_id: Option<String>,
         inputs: std::collections::HashMap<String, String>,
         target_label: String,
     ) {
@@ -5616,7 +5622,7 @@ impl App {
                 worktree_id: Some(worktree_id),
                 working_dir: worktree_path,
                 repo_path,
-                ticket_id: None,
+                ticket_id,
                 repo_id: None,
                 model: None,
                 exec_config: WorkflowExecConfig {

--- a/conductor-web/src/routes/workflows.rs
+++ b/conductor-web/src/routes/workflows.rs
@@ -107,7 +107,7 @@ pub async fn run_workflow(
     Json(req): Json<RunWorkflowRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
     // Validate inputs while holding the lock
-    let (wt_path, wt_slug, repo_path, repo_slug, model) = {
+    let (wt_path, wt_slug, wt_ticket_id, repo_path, repo_slug, model) = {
         let db = state.db.lock().await;
         let config = state.config.read().await;
         let wt_mgr = WorktreeManager::new(&db, &config);
@@ -138,6 +138,7 @@ pub async fn run_workflow(
         (
             wt.path.clone(),
             wt.slug.clone(),
+            wt.ticket_id.clone(),
             repo.local_path.clone(),
             repo.slug.clone(),
             model,
@@ -184,7 +185,7 @@ pub async fn run_workflow(
                 worktree_id: Some(&wt_id),
                 working_dir: &wt_path,
                 repo_path: &repo_path,
-                ticket_id: None,
+                ticket_id: wt_ticket_id.as_deref(),
                 repo_id: None,
                 model: model.as_deref(),
                 exec_config: &exec_config,


### PR DESCRIPTION
## Summary

- TUI, CLI, and web all hardcoded `ticket_id: None` when launching a workflow on a worktree
- This meant the engine never looked up the ticket record, never injected `ticket_source_id` into `state.inputs`, so `{{ticket_source_id}}` in `merge-and-close.sh` resolved to `""` — silently skipping `gh issue close`
- Fix: extract `wt.ticket_id` from the worktree struct and pass it to `WorkflowExecInput`/`WorkflowExecStandalone` in all three callers

## Test plan

- [ ] Run `merge-when-ready` on a worktree that has a linked ticket — verify the GitHub issue is closed after merge
- [ ] Run `ticket-to-pr-auto-merge` — verify linked issue closes on merge
- [ ] Verify workflow still works when worktree has no linked ticket (ticket_id = None)

Fixes #908, #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)