### PR TITLE
fix: write large prompts to file to avoid tmux command-length limit

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -2756,7 +2756,10 @@ mod tests {
         std::fs::write(&path, "hello").unwrap();
         let content = read_and_maybe_cleanup_prompt_file(path.to_str().unwrap()).unwrap();
         assert_eq!(content, "hello");
-        assert!(!path.exists(), "internal temp file should have been deleted");
+        assert!(
+            !path.exists(),
+            "internal temp file should have been deleted"
+        );
     }
 
     #[test]
@@ -2766,7 +2769,10 @@ mod tests {
         std::fs::write(&path, "custom prompt").unwrap();
         let content = read_and_maybe_cleanup_prompt_file(path.to_str().unwrap()).unwrap();
         assert_eq!(content, "custom prompt");
-        assert!(path.exists(), "user-provided prompt file should not be deleted");
+        assert!(
+            path.exists(),
+            "user-provided prompt file should not be deleted"
+        );
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/conductor-core/src/agent_runtime.rs
+++ b/conductor-core/src/agent_runtime.rs
@@ -258,9 +258,15 @@ mod tests {
         let prompt = "short prompt";
         assert!(prompt.len() <= 512);
         let args = super::build_agent_args("run-1", "/tmp/wt", prompt, None, None).unwrap();
-        let prompt_idx = args.iter().position(|a| a == "--prompt").expect("--prompt flag missing");
+        let prompt_idx = args
+            .iter()
+            .position(|a| a == "--prompt")
+            .expect("--prompt flag missing");
         assert_eq!(args[prompt_idx + 1], prompt);
-        assert!(!args.iter().any(|a| a == "--prompt-file"), "--prompt-file should not appear");
+        assert!(
+            !args.iter().any(|a| a == "--prompt-file"),
+            "--prompt-file should not appear"
+        );
     }
 
     #[test]
@@ -273,11 +279,20 @@ mod tests {
         let prompt = "x".repeat(513);
         let args = super::build_agent_args(run_id, worktree, &prompt, None, None).unwrap();
 
-        let file_idx = args.iter().position(|a| a == "--prompt-file").expect("--prompt-file flag missing");
+        let file_idx = args
+            .iter()
+            .position(|a| a == "--prompt-file")
+            .expect("--prompt-file flag missing");
         let file_path = &args[file_idx + 1];
-        assert!(std::path::Path::new(file_path).exists(), "prompt file should have been written");
+        assert!(
+            std::path::Path::new(file_path).exists(),
+            "prompt file should have been written"
+        );
         assert_eq!(std::fs::read_to_string(file_path).unwrap(), prompt);
-        assert!(!args.iter().any(|a| a == "--prompt"), "--prompt should not appear");
+        assert!(
+            !args.iter().any(|a| a == "--prompt"),
+            "--prompt should not appear"
+        );
 
         // cleanup
         let _ = std::fs::remove_file(file_path);


### PR DESCRIPTION
## Summary

- tmux rejects `new-window`/`new-session` commands over ~2 KB with "command too long"
- `spawn_child_tmux` always passed the full prompt as a `--prompt` CLI arg, no matter how large
- Review-pr workflow prompts embed PR diffs and can easily exceed this limit
- `--prompt-file` already existed in `conductor agent run` for exactly this case — it was just never used

Fix: when the prompt exceeds 512 bytes, write it to `.conductor-prompt-<run-id>.txt` in the worktree directory and pass `--prompt-file` instead. Short prompts continue using `--prompt` inline.

## Test plan

- [ ] Trigger review-pr on a large PR (many changed files) and verify agents spawn successfully
- [ ] Verify short prompts still work (no regression for normal workflows)
- [ ] Verify prompt file is created in the worktree dir for large prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)