### PR TITLE
fix(#1008): exclude shell scripts from dry-abstraction review

### DIFF
--- a/.conductor/agents/review-dry-abstraction.md
+++ b/.conductor/agents/review-dry-abstraction.md
@@ -13,3 +13,6 @@ Focus exclusively on:
 - Missing helper functions that would reduce repetition
 - Repeated error mapping patterns that could be extracted
 - Copy-pasted DB query boilerplate that could be shared
+
+Do NOT flag:
+- Shell scripts (.sh files) — standalone scripts are intentionally self-contained; shared structural patterns (git diff loop, JSON output) are appropriate repetition at that scale


### PR DESCRIPTION
## Summary

- `review-dry-abstraction` was flagging shared scaffolding in `.sh` files (git diff loop, JSON output) as DRY violations
- Standalone shell scripts are intentionally self-contained — that repetition is appropriate at that scale
- Adds a "Do NOT flag" exclusion for `.sh` files

Closes #1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)