### PR TITLE
fix: use developer bot identity for force-push in rebase-worktree

### DIFF
--- a/.conductor/workflows/rebase-worktree.wf
+++ b/.conductor/workflows/rebase-worktree.wf
@@ -19,6 +19,7 @@ workflow rebase-worktree {
     unless sync-with-main.is_up_to_date {
       script push {
         run = ".conductor/scripts/push.sh"
+        as  = "developer"
       }
     }
   }


### PR DESCRIPTION
## Summary

- The `push` script step in `rebase-worktree.wf` force-pushes after conflict resolution but had no bot identity set
- Adding `as = "developer"` injects `GH_TOKEN` for the conductor-ai-coder app, so when `gh` is configured as git's credential helper the HTTPS push is authenticated as the bot
- Makes it clear in GitHub's push activity that the force-push came from automated rebase, not a human

## Test plan

- [ ] Trigger `rebase-worktree` on a branch that needs rebasing — verify the push shows up as conductor-ai-coder in the PR timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)