### PR TITLE
fix(review): remove suggestion severity from reviewer prompts and schemas

### DIFF
--- a/.conductor/agents/review-aggregator.md
+++ b/.conductor/agents/review-aggregator.md
@@ -24,7 +24,7 @@ Steps:
    - For each reviewer entry, extract off-diff findings as follows:
      - **Primary path**: If `entry.structured_output` is present (non-null), parse it as JSON and read `.off_diff_findings[]` from it. The reviewer schema uses `body` for the finding description — map `body` → `message` in your output.
      - **Fallback path**: If `entry.structured_output` is null or absent, attempt to parse the `context` string as JSON and extract the `off_diff_findings` array (if present).
-   - Collect all off-diff findings across all reviewers into a single deduplicated list (deduplicate by `(file, line)`, keeping highest severity: `critical > warning > suggestion`).
+   - Collect all off-diff findings across all reviewers into a single deduplicated list (deduplicate by `(file, line)`, keeping highest severity: `critical > warning`).
 
 2. Get the PR number:
    - If `{{pr_number}}` is set and does not contain `{{` (i.e. it was substituted), use it directly.
@@ -46,13 +46,8 @@ Steps:
    | security | :white_check_mark: approve |
    | ... | ... |
 
-   ### Suggestions (non-blocking)
-   - **<reviewer>**: <suggestion text>
-   - **<reviewer>**: <suggestion text>
-
    <!-- conductor-review -->
    ```
-   (Omit the `### Suggestions` section entirely if there are no suggestions.)
 
    **If any reviewer has blocking issues:**
    ```
@@ -73,12 +68,8 @@ Steps:
    - **warning** `src/bar.rs:10` — Hardcoded API token ...
    </details>
 
-   ### Suggestions (non-blocking)
-   - **<reviewer>**: <suggestion text>
-
    <!-- conductor-review -->
    ```
-   (Omit the `### Suggestions` section entirely if there are no suggestions.)
 
    Do NOT include the off-diff section in the review body — the script step will append it after filing issues.
 

--- a/.conductor/prompts/review-diff-scope.md
+++ b/.conductor/prompts/review-diff-scope.md
@@ -21,7 +21,8 @@ If the diff exceeds ~50KB, focus on files most relevant to your review area.
 Severity guide:
 - **critical**: Bugs, security holes, data loss — blocks merge
 - **warning**: Design or correctness concern — should be addressed
-- **suggestion**: Style, minor improvement — non-blocking
+
+Only flag `critical` or `warning` issues. Do not emit suggestion-level or style findings.
 
 Your `CONDUCTOR_OUTPUT` `context` field must be a **JSON object** (not plain text) so the aggregator can parse it. Use this structure:
 
@@ -51,8 +52,8 @@ Your `CONDUCTOR_OUTPUT` `context` field must be a **JSON object** (not plain tex
 ```
 
 - `findings`: issues in code **added or modified by this PR** — set `approved: false` if any are `critical` or `warning`
-- `off_diff_findings`: issues in **unchanged/removed code** — never affect `approved`, filed as separate GitHub issues; only include `critical` or `warning` severity (omit `suggestion`-level off-diff findings entirely)
+- `off_diff_findings`: issues in **unchanged/removed code** — never affect `approved`, filed as separate GitHub issues; only include `critical` or `warning` severity
 - Omit `off_diff_findings` entirely if there are none
 
 If you find **critical** or **warning** `findings`, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
-If you find only `suggestion` findings or no findings, do NOT include that marker.
+If you find no findings, do NOT include that marker.

--- a/.conductor/schemas/review-aggregator.yaml
+++ b/.conductor/schemas/review-aggregator.yaml
@@ -14,7 +14,6 @@ fields:
       line: number
       severity: enum(critical, warning)
       message: string
-  suggestion_count: number
   overall_approved: boolean
   summary: string
   review_body: string
@@ -23,7 +22,7 @@ fields:
     items:
       file: string
       line: number
-      severity: enum(critical, warning, suggestion)
+      severity: enum(critical, warning)
       title: string
       message: string
       reviewer: string

--- a/.conductor/schemas/review-findings.yaml
+++ b/.conductor/schemas/review-findings.yaml
@@ -4,7 +4,7 @@ fields:
     items:
       file: string
       line: number
-      severity: enum(critical, warning, suggestion)
+      severity: enum(critical, warning)
       message: string
       suggestion?:
         type: string
@@ -16,7 +16,7 @@ fields:
       title: string
       file: string
       line: number
-      severity: enum(critical, warning, suggestion)
+      severity: enum(critical, warning)
       body: string
   approved: boolean
   summary: string


### PR DESCRIPTION
## Summary

- Removes `suggestion` severity from reviewer output — reviewers now only emit `critical` and `warning` findings
- Drops `suggestion_count` field and `suggestion` enum values from aggregator and findings schemas
- Removes `### Suggestions` template sections from the aggregator review body templates

## Why

Suggestion-level findings added unnecessary output tokens across all 6 parallel reviewers on every PR review run. The `off_diff_findings` section already excluded suggestions; this makes the in-diff findings consistent.

## Test plan

- [ ] Run a PR review and verify no suggestion-level findings appear in reviewer output
- [ ] Verify aggregator formats review body without a Suggestions section
- [ ] Verify approve/reject behavior is unchanged for critical/warning findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)