### PR TITLE
fix(#1141): show workflow inputs modal for 'r' key and post-create paths

### DIFF
--- a/conductor-tui/src/app.rs
+++ b/conductor-tui/src/app.rs
@@ -3131,8 +3131,7 @@ impl App {
                     .unwrap_or_default();
                 // Fall back to inputs["ticket_id"] when the worktree's in-memory state
                 // hasn't been refreshed yet (e.g. post-create flow).
-                let ticket_id = wt_ticket_id
-                    .or_else(|| inputs.get("ticket_id").cloned());
+                let ticket_id = wt_ticket_id.or_else(|| inputs.get("ticket_id").cloned());
                 self.spawn_workflow_in_background(
                     def,
                     worktree_id,


### PR DESCRIPTION
Two TUI paths bypassed show_workflow_inputs_or_run() and called
spawn_workflow_in_background() directly, silently launching workflows
with empty/partial inputs instead of showing the form modal.

- Add `prefill: HashMap<String, String>` param to show_workflow_inputs_or_run
  so callers can pre-populate fields (e.g. ticket_id) with runtime values
- Fix handle_run_workflow ('r' key) to use worktree_picker_target +
  show_workflow_inputs_or_run instead of spawn_workflow_in_background
- Fix PostCreateChoice::RunWorkflow ('c' key post-create) to use
  show_workflow_inputs_or_run with ticket_id pre-filled

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
