### PR TITLE
fix(#981): replace redundant length guard with proper type narrowing

### DIFF
--- a/conductor-web/frontend/src/components/workflows/WorkflowRunTree.tsx
+++ b/conductor-web/frontend/src/components/workflows/WorkflowRunTree.tsx
@@ -225,7 +225,7 @@ export function WorkflowRunTree({ runs, repos, ctxMap }: WorkflowRunTreeProps) {
                       targetRuns.map((run) => (
                         <div key={run.id} className="ml-4">
                           <RunRow run={run} ctxMap={ctxMap} indent={false} />
-                          {!!run.active_steps?.length && (
+                          {run.active_steps && (
                             <StepLeaves steps={run.active_steps} />
                           )}
                           {childrenMap.get(run.id)?.map((child) => (
@@ -235,7 +235,7 @@ export function WorkflowRunTree({ runs, repos, ctxMap }: WorkflowRunTreeProps) {
                                 ctxMap={ctxMap}
                                 indent={true}
                               />
-                              {!!child.active_steps?.length && (
+                              {child.active_steps && (
                                 <StepLeaves steps={child.active_steps} />
                               )}
                             </div>


### PR DESCRIPTION
Replace \`!!run.active_steps?.length\` with \`run.active_steps &&\` in
WorkflowRunTree.tsx. The optional-chain length check does not narrow the
TypeScript type, forcing an unsafe non-null assertion when passing to
StepLeaves. The simpler \`&&\` check properly narrows active_steps from
WorkflowRunStep[] | undefined to WorkflowRunStep[], and the length check
is redundant since StepLeaves already returns null for empty arrays.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
