### PR TITLE
fix(#974): remove redundant null guards before StepLeaves in WorkflowRunTree

### DIFF
--- a/conductor-web/frontend/src/components/workflows/WorkflowRunTree.tsx
+++ b/conductor-web/frontend/src/components/workflows/WorkflowRunTree.tsx
@@ -225,9 +225,7 @@ export function WorkflowRunTree({ runs, repos, ctxMap }: WorkflowRunTreeProps) {
                       targetRuns.map((run) => (
                         <div key={run.id} className="ml-4">
                           <RunRow run={run} ctxMap={ctxMap} indent={false} />
-                          {run.active_steps && (
-                            <StepLeaves steps={run.active_steps} />
-                          )}
+                          <StepLeaves steps={run.active_steps ?? []} />
                           {childrenMap.get(run.id)?.map((child) => (
                             <div key={child.id}>
                               <RunRow
@@ -235,9 +233,7 @@ export function WorkflowRunTree({ runs, repos, ctxMap }: WorkflowRunTreeProps) {
                                 ctxMap={ctxMap}
                                 indent={true}
                               />
-                              {child.active_steps && (
-                                <StepLeaves steps={child.active_steps} />
-                              )}
+                              <StepLeaves steps={child.active_steps ?? []} />
                             </div>
                           ))}
                         </div>


### PR DESCRIPTION
Replace two `&&`-guarded `<StepLeaves>` renders with `<StepLeaves steps={... ?? []} />`.
StepLeaves already returns null when steps.length === 0, making the outer guards redundant.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
