### PR TITLE
feat/983 missing test for empty input edge

### DIFF
--- a/conductor-core/src/workflow/manager.rs
+++ b/conductor-core/src/workflow/manager.rs
@@ -1941,7 +1941,10 @@ mod tests {
         let conn = setup_db();
         let mgr = WorkflowManager::new(&conn);
         let result = mgr.get_workflow_run_ids_for_agent_runs(&[]).unwrap();
-        assert!(result.is_empty(), "empty agent_run_ids must yield an empty map");
+        assert!(
+            result.is_empty(),
+            "empty agent_run_ids must yield an empty map"
+        );
     }
 
     #[test]


### PR DESCRIPTION
- **test(#983): add empty-slice tests for get_workflow_run_ids_for_agent_runs and get_step_summaries_for_runs**
- **style(#983): fix rustfmt formatting in empty-slice test assertion**
