### PR TITLE
fix(#1159): push after fmt-fix in iterate-pr to avoid unformatted CI commits

### DIFF
--- a/.conductor/agents/address-reviews.md
+++ b/.conductor/agents/address-reviews.md
@@ -20,6 +20,5 @@ Steps:
 4. After all changes are made, run the build and tests to confirm nothing is broken:
    - Rust: `cargo build && cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings`
 5. Commit all changes with a message like: `fix: address PR review feedback`
-6. Push the branch: `git push`
 
 Work through all comments in a single pass before committing.

--- a/.conductor/workflows/iterate-pr.wf
+++ b/.conductor/workflows/iterate-pr.wf
@@ -20,6 +20,9 @@ workflow iterate-pr {
       script fmt-fix {
         run = ".conductor/scripts/fmt-fix.sh"
       }
+      script push {
+        run = ".conductor/scripts/push.sh"
+      }
       call workflow lint-fix
     }
   } while review-aggregator.has_blocking_findings


### PR DESCRIPTION
Remove `git push` from address-reviews agent step 6 (agent now commits only).
Add explicit `script push` step in iterate-pr.wf after fmt-fix and before
lint-fix, so CI always sees fully-formatted code.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
