### PR TITLE
perf(#1165): skip redundant lint-fix in iterate-pr when rebase pulled no changes

### DIFF
--- a/.conductor/scripts/push-rebased.sh
+++ b/.conductor/scripts/push-rebased.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git push --force-with-lease origin HEAD
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+cat <<EOF
+<<<CONDUCTOR_OUTPUT>>>
+{"markers": ["pulled_new_commits"], "context": "Pushed rebased branch: $branch"}
+<<<END_CONDUCTOR_OUTPUT>>>
+EOF

--- a/.conductor/workflows/iterate-pr.wf
+++ b/.conductor/workflows/iterate-pr.wf
@@ -11,7 +11,9 @@ workflow iterate-pr {
 
     call workflow rebase-worktree
 
-    call workflow lint-fix
+    if rebase-worktree.pulled_new_commits {
+      call workflow lint-fix
+    }
 
     call workflow review-pr
 

--- a/.conductor/workflows/rebase-worktree.wf
+++ b/.conductor/workflows/rebase-worktree.wf
@@ -20,7 +20,7 @@ workflow rebase-worktree {
 
     unless sync-with-main.is_up_to_date {
       script push {
-        run = ".conductor/scripts/push.sh"
+        run = ".conductor/scripts/push-rebased.sh"
         as  = "developer"
       }
     }


### PR DESCRIPTION
- Add push-rebased.sh: like push.sh but emits pulled_new_commits marker
- rebase-worktree.wf: use push-rebased.sh in the push step so the marker propagates to the parent workflow
- iterate-pr.wf: guard the post-rebase lint-fix behind if rebase-worktree.pulled_new_commits

Eliminates ~2 unnecessary analyze-lint agent invocations per clean iterate-pr run when the branch is already up-to-date with main or the PR is already mergeable.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
