### PR TITLE
perf(#1166): replace analyze-lint agent with shell script

### DIFF
--- a/.conductor/scripts/analyze-lint.sh
+++ b/.conductor/scripts/analyze-lint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ERRORS=0
+
+cargo clippy --workspace --all-targets -- -D warnings 2>&1 || ERRORS=1
+cargo fmt --all --check 2>&1 || ERRORS=1
+
+# Validate changed or new .wf files
+for f in $(git diff --name-only HEAD -- '*.wf') $(git ls-files --others --exclude-standard -- '*.wf'); do
+  [ -f "$f" ] || continue
+  name=$(basename "$f" .wf)
+  conductor workflow validate "$name" --path . 2>&1 \
+    || cargo run --bin conductor -- workflow validate "$name" --path . 2>&1 \
+    || ERRORS=1
+done
+
+if [ "$ERRORS" -eq 1 ]; then
+  cat <<'EOF'
+<<<CONDUCTOR_OUTPUT>>>
+{"markers": ["has_lint_errors"], "context": "Lint errors found"}
+<<<END_CONDUCTOR_OUTPUT>>>
+EOF
+else
+  cat <<'EOF'
+<<<CONDUCTOR_OUTPUT>>>
+{"markers": [], "context": "All lint checks passed"}
+<<<END_CONDUCTOR_OUTPUT>>>
+EOF
+fi

--- a/.conductor/workflows/lint-fix.wf
+++ b/.conductor/workflows/lint-fix.wf
@@ -9,7 +9,9 @@ workflow lint-fix {
     max_iterations = 3
     on_max_iter    = fail
 
-    call analyze-lint
+    script analyze-lint {
+      run = ".conductor/scripts/analyze-lint.sh"
+    }
 
     if analyze-lint.has_lint_errors {
       call lint-fix-impl

--- a/conductor-core/src/workflow_dsl.rs
+++ b/conductor-core/src/workflow_dsl.rs
@@ -2724,7 +2724,9 @@ workflow lint-fix {
     targets     = ["worktree"]
   }
 
-  call analyze-lint
+  script analyze-lint {
+    run = ".conductor/scripts/analyze-lint.sh"
+  }
 
   if analyze-lint.has_lint_errors {
     call lint-fix-impl
@@ -2736,10 +2738,11 @@ workflow lint-fix {
         assert_eq!(def.body.len(), 2);
 
         match &def.body[0] {
-            WorkflowNode::Call(c) => {
-                assert_eq!(c.agent, AgentRef::Name("analyze-lint".to_string()))
+            WorkflowNode::Script(s) => {
+                assert_eq!(s.name, "analyze-lint");
+                assert_eq!(s.run, ".conductor/scripts/analyze-lint.sh");
             }
-            _ => panic!("Expected Call node"),
+            _ => panic!("Expected Script node"),
         }
     }
 


### PR DESCRIPTION
Replace the analyze-lint Claude agent call in lint-fix.wf with a deterministic shell script that runs clippy, fmt check, and .wf validation. This eliminates 4-6 agent token costs per typical ticket-to-pr run for purely mechanical detection work.