### PR TITLE
fix: exclude conductor-web from analyze-lint clippy check

### DIFF
--- a/.conductor/scripts/analyze-lint.sh
+++ b/.conductor/scripts/analyze-lint.sh
@@ -3,7 +3,7 @@ set -uo pipefail
 
 ERRORS=0
 
-cargo clippy --workspace --all-targets -- -D warnings 2>&1 || ERRORS=1
+cargo clippy --workspace --all-targets --exclude conductor-web -- -D warnings 2>&1 || ERRORS=1
 cargo fmt --all --check 2>&1 || ERRORS=1
 
 # Validate changed or new .wf files


### PR DESCRIPTION
## Summary
- `analyze-lint.sh` was running `cargo clippy --workspace` which includes `conductor-web`
- `conductor-web` requires a built frontend (`frontend/dist/`) that is never present in worktrees
- This caused `has_lint_errors` to be emitted every iteration, exhausting `max_iterations` (3) in the `lint-fix` workflow on a pre-existing, unresolvable error

## Fix
Add `--exclude conductor-web` to the clippy invocation. The web crate is already excluded from CI lint checks when the frontend hasn't been built.

## Test plan
- [ ] Run `lint-fix` workflow on a worktree — should complete without hitting max_iterations on conductor-web errors
- [ ] Verify real lint errors in other crates are still caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)