### PR TITLE
fix(#1196): prevent APPROVE submission when blocking findings exist

### DIFF
--- a/.conductor/agents/review-aggregator.md
+++ b/.conductor/agents/review-aggregator.md
@@ -18,9 +18,11 @@ Steps:
 
 1. Parse all reviewer outputs from prior_contexts:
    - Each entry in `prior_contexts` has `step`, `iteration`, `context` (string), `markers` (array of strings), and `structured_output` (string or null).
-   - Classify the overall result using **markers first** (authoritative), then context strings as fallback:
-     - **Blocking**: Any entry whose `markers` array contains `"has_review_issues"` → that reviewer requested changes.
-     - **Clean**: No entry has `"has_review_issues"` in markers AND no context string clearly signals blocking issues.
+   - Classify the overall result using **markers and findings** (both authoritative), then context strings as fallback:
+     - **Blocking**: Any entry that meets **either** condition:
+       (a) its `markers` array contains `"has_review_issues"`, OR
+       (b) its `structured_output` (parsed as JSON) contains a `.findings[]` entry with `severity` of `"critical"` or `"warning"`.
+     - **Clean**: No entry is blocking AND no context string clearly signals blocking issues.
    - For each reviewer entry, extract off-diff findings as follows:
      - **Primary path**: If `entry.structured_output` is present (non-null), parse it as JSON and read `.off_diff_findings[]` from it. The reviewer schema uses `body` for the finding description — map `body` → `message` in your output.
      - **Fallback path**: If `entry.structured_output` is null or absent, attempt to parse the `context` string as JSON and extract the `off_diff_findings` array (if present).
@@ -77,7 +79,7 @@ Steps:
 
 4. Produce your CONDUCTOR_OUTPUT with the correct structured fields so the workflow engine can derive outcome markers automatically from the schema:
 
-   - Set `overall_approved: true` if **all** reviewers approved (no critical or warning findings). Set `overall_approved: false` if **any** reviewer reported a critical or warning finding.
+   - Set `overall_approved: false` if **any** reviewer is classified as blocking in Phase 1 (i.e. has `has_review_issues` marker OR has critical/warning findings in `structured_output`). Set `overall_approved: true` only if no reviewer is blocking.
    - Populate `blocking_findings` with every critical and warning finding collected across all reviewers. Include warnings here — use `severity: "warning"` for warning-level items and `severity: "critical"` for critical items. Leave the array empty if there are no blocking findings.
    - Set `review_body` to the full formatted markdown string produced in Phase 2 (without the off-diff section).
    - Set `off_diff_findings` to the deduplicated list of off-diff findings collected in Phase 1 (each with `file`, `line`, `severity`, `title`, `message`, `reviewer` fields). Leave the array empty if there are none.

--- a/.conductor/scripts/submit-review.sh
+++ b/.conductor/scripts/submit-review.sh
@@ -140,6 +140,15 @@ echo "${REVIEW_BODY}" > "${REVIEW_BODY_FILE}"
 # ---------------------------------------------------------------------------
 OVERALL_APPROVED=$(echo "${PRIOR_OUTPUT}" | jq -r 'if .overall_approved == false then "false" else "true" end')
 
+# Safety net: if blocking_findings is non-empty, override to REQUEST CHANGES
+# regardless of overall_approved (guards against prompt inconsistency producing
+# overall_approved:true with non-empty blocking_findings)
+HAS_BLOCKING=$(echo "${PRIOR_OUTPUT}" | jq -r 'if (.blocking_findings // [] | length) > 0 then "true" else "false" end')
+if [ "${OVERALL_APPROVED}" = "true" ] && [ "${HAS_BLOCKING}" = "true" ]; then
+  echo "WARNING: overall_approved=true but blocking_findings is non-empty — overriding to REQUEST CHANGES."
+  OVERALL_APPROVED="false"
+fi
+
 if [ "${OVERALL_APPROVED}" = "true" ]; then
   echo "Submitting APPROVE review for PR #${PR_NUMBER}…"
   gh pr review "${PR_NUMBER}" --approve --body-file "${REVIEW_BODY_FILE}"


### PR DESCRIPTION
Two-layer fix for review-aggregator submitting APPROVE despite blocking
findings:

1. Update Phase 1 classification in review-aggregator.md to detect
   blocking reviewers by findings (critical/warning in structured_output)
   in addition to the has_review_issues marker. Anchor Phase 3's
   overall_approved rule to Phase 1's classification to eliminate the
   contradiction between the two phases.

2. Add safety-net guard in submit-review.sh that overrides
   OVERALL_APPROVED=false when blocking_findings is non-empty, preventing
   an APPROVE submission even if the aggregator output is inconsistent.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
