### PR TITLE
fix(#1221): move count_turns_in_log off TUI main thread

### DIFF
--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -58,6 +58,9 @@ pub struct DataRefreshedPayload {
     pub pending_feedback_requests: Vec<FeedbackRequest>,
     /// All waiting gate steps with their workflow name and optional target label (for cross-process notifications).
     pub waiting_gate_steps: Vec<(WorkflowRunStep, String, Option<String>)>,
+    /// Live turn count for currently running agents, keyed by worktree_id.
+    /// Computed in the background poller to avoid blocking the main thread.
+    pub live_turns_by_worktree: HashMap<String, i64>,
 }
 
 /// Every user intent or background result flows through this enum.

--- a/conductor-tui/src/app/mod.rs
+++ b/conductor-tui/src/app/mod.rs
@@ -716,6 +716,7 @@ impl App {
                 self.state.data.workflow_step_summaries = payload.workflow_step_summaries;
                 self.state.data.active_non_worktree_workflow_runs =
                     payload.active_non_worktree_workflow_runs;
+                self.state.data.live_turns_by_worktree = payload.live_turns_by_worktree;
                 self.refresh_pending_feedback();
                 self.state.data.rebuild_maps();
                 self.reload_agent_events();
@@ -922,9 +923,7 @@ impl App {
     }
 
     fn reload_agent_events(&mut self) {
-        use conductor_core::agent::{
-            count_turns_in_log, parse_agent_log, AgentManager, AgentRunEvent,
-        };
+        use conductor_core::agent::{parse_agent_log, AgentManager, AgentRunEvent};
 
         use crate::state::AgentTotals;
 
@@ -955,11 +954,11 @@ impl App {
             totals.total_output_tokens += run.output_tokens.unwrap_or(0);
         }
 
-        // For running agents, count live turns from the log file
+        // For running agents, use the live turn count from the background poller
         if let Some(run) = runs.last() {
             if run.status == conductor_core::agent::AgentRunStatus::Running {
-                if let Some(ref path) = run.log_file {
-                    totals.live_turns = count_turns_in_log(path);
+                if let Some(turns) = self.state.data.live_turns_by_worktree.get(wt_id) {
+                    totals.live_turns = *turns;
                 }
             }
         }
@@ -1425,6 +1424,7 @@ mod action_handler_tests {
                 active_non_worktree_workflow_runs: vec![],
                 pending_feedback_requests: vec![],
                 waiting_gate_steps: vec![],
+                live_turns_by_worktree: std::collections::HashMap::new(),
             },
         )));
 

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -293,6 +293,20 @@ pub fn poll_data() -> Option<PollResult> {
         })
     });
 
+    // Compute live turn counts for running agents off the main thread.
+    let live_turns_by_worktree = {
+        use conductor_core::agent::{count_turns_in_log, AgentRunStatus};
+        let mut map = std::collections::HashMap::new();
+        for (wt_id, run) in &latest_agent_runs {
+            if run.status == AgentRunStatus::Running {
+                if let Some(ref path) = run.log_file {
+                    map.insert(wt_id.clone(), count_turns_in_log(path));
+                }
+            }
+        }
+        map
+    };
+
     let action = Action::DataRefreshed(Box::new(DataRefreshedPayload {
         repos,
         worktrees,
@@ -305,6 +319,7 @@ pub fn poll_data() -> Option<PollResult> {
         active_non_worktree_workflow_runs,
         pending_feedback_requests,
         waiting_gate_steps,
+        live_turns_by_worktree,
     }));
     Some(PollResult {
         action,

--- a/conductor-tui/src/state.rs
+++ b/conductor-tui/src/state.rs
@@ -782,6 +782,9 @@ pub struct DataCache {
     /// Keyed by run_id; populated when workflow_runs is refreshed to avoid
     /// re-parsing the DSL on every render frame.
     pub workflow_run_declared_inputs: HashMap<String, Vec<InputDecl>>,
+    /// Live turn counts for running agents, keyed by worktree_id.
+    /// Populated by the background poller each tick.
+    pub live_turns_by_worktree: HashMap<String, i64>,
 }
 
 /// Aggregated stats across all agent runs for a worktree.


### PR DESCRIPTION
count_turns_in_log reads and parses an entire JSONL log file, which
blocks the TUI render loop when called on every poll tick. Move the
computation into the background poller thread and pipe results back
via DataRefreshedPayload::live_turns_by_worktree. The main thread
now does a simple HashMap lookup instead of file I/O.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
