### PR TITLE
fix(#1228): remove misleading ANTHROPIC_API_KEY prerequisite check

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,7 @@ A local-first orchestration tool for managing multiple git repos, worktrees, tic
 - [Node.js](https://nodejs.org/) (for the web UI frontend)
 - [GitHub CLI (`gh`)](https://cli.github.com/) — installed and authenticated (for GitHub issue sync)
 - [tmux](https://github.com/tmux/tmux) (for AI agent sessions)
-- `ANTHROPIC_API_KEY` — set in your shell environment (get a key at https://console.anthropic.com)
-
-```bash
-export ANTHROPIC_API_KEY="sk-ant-..."  # add to ~/.zshrc or ~/.bashrc
-```
+- [Claude Code CLI (`claude`)](https://docs.anthropic.com/en/docs/claude-code) — installed and authenticated
 
 ## Build
 

--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -481,8 +481,9 @@ fn check_prerequisites() {
     if Command::new("tmux").arg("-V").output().is_err() {
         missing.push("  - tmux: https://github.com/tmux/tmux");
     }
-    if std::env::var("ANTHROPIC_API_KEY").is_err() {
-        missing.push("  - ANTHROPIC_API_KEY (get a key at https://console.anthropic.com)");
+    if Command::new("claude").arg("--version").output().is_err() {
+        missing
+            .push("  - claude (Claude Code CLI): https://docs.anthropic.com/en/docs/claude-code");
     }
     if !missing.is_empty() {
         eprintln!("conductor: missing prerequisites:\n{}", missing.join("\n"));

--- a/docs/getting-started-cli.md
+++ b/docs/getting-started-cli.md
@@ -7,7 +7,7 @@ This guide is for teams that want to use `conductor` as a standalone command-lin
 - **macOS or Linux**
 - **[`gh` CLI](https://cli.github.com/)** — authenticated (`gh auth login`)
 - **[`tmux`](https://github.com/tmux/tmux)** — agents run in tmux windows
-- **Claude API key** — set as `ANTHROPIC_API_KEY` in your environment
+- **[Claude Code CLI (`claude`)](https://docs.anthropic.com/en/docs/claude-code)** — installed and authenticated
 - **Git**
 
 ## Installation


### PR DESCRIPTION
The CLI's check_prerequisites() warned about a missing ANTHROPIC_API_KEY,
but Conductor never uses it — agents authenticate via the Claude Code CLI's
own OAuth flow. Replace with a `claude --version` check so users get an
actionable warning if the Claude CLI isn't installed. Update README and
getting-started docs to match.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
