### PR TITLE
fix(#1234): move column-existence probes inside version guards in migrations

### DIFF
--- a/conductor-core/src/db/migrations.rs
+++ b/conductor-core/src/db/migrations.rs
@@ -68,13 +68,13 @@ pub fn run(conn: &Connection) -> Result<()> {
     // Migration 002: add completed_at to worktrees.
     // Check column existence rather than version number to handle DBs that jumped
     // past version 1 via other feature branches.
-    let has_completed_at: bool = conn
-        .prepare("SELECT completed_at FROM worktrees LIMIT 0")
-        .is_ok();
-    if !has_completed_at {
-        conn.execute_batch(include_str!("migrations/002_worktree_completed_at.sql"))?;
-    }
     if version < 2 {
+        let has_completed_at: bool = conn
+            .prepare("SELECT completed_at FROM worktrees LIMIT 0")
+            .is_ok();
+        if !has_completed_at {
+            conn.execute_batch(include_str!("migrations/002_worktree_completed_at.sql"))?;
+        }
         bump_version(conn, 2)?;
     }
 
@@ -85,24 +85,24 @@ pub fn run(conn: &Connection) -> Result<()> {
 
     // Migration 004: add tmux_window to agent_runs.
     // Check column existence to handle DBs that already have it from feature branches.
-    let has_tmux_window: bool = conn
-        .prepare("SELECT tmux_window FROM agent_runs LIMIT 0")
-        .is_ok();
-    if !has_tmux_window {
-        conn.execute_batch(include_str!("migrations/004_agent_tmux.sql"))?;
-    }
     if version < 4 {
+        let has_tmux_window: bool = conn
+            .prepare("SELECT tmux_window FROM agent_runs LIMIT 0")
+            .is_ok();
+        if !has_tmux_window {
+            conn.execute_batch(include_str!("migrations/004_agent_tmux.sql"))?;
+        }
         bump_version(conn, 4)?;
     }
 
     // Migration 005: add log_file to agent_runs.
-    let has_log_file: bool = conn
-        .prepare("SELECT log_file FROM agent_runs LIMIT 0")
-        .is_ok();
-    if !has_log_file {
-        conn.execute_batch(include_str!("migrations/005_agent_log_file.sql"))?;
-    }
     if version < 5 {
+        let has_log_file: bool = conn
+            .prepare("SELECT log_file FROM agent_runs LIMIT 0")
+            .is_ok();
+        if !has_log_file {
+            conn.execute_batch(include_str!("migrations/005_agent_log_file.sql"))?;
+        }
         bump_version(conn, 5)?;
     }
 
@@ -113,125 +113,126 @@ pub fn run(conn: &Connection) -> Result<()> {
     }
 
     // Migration 007: add agent_run_events table (trace/span model).
-    let has_agent_run_events: bool = conn
-        .prepare("SELECT id FROM agent_run_events LIMIT 0")
-        .is_ok();
-    if !has_agent_run_events {
-        conn.execute_batch(include_str!("migrations/007_agent_run_events.sql"))?;
-    }
     if version < 7 {
+        let has_agent_run_events: bool = conn
+            .prepare("SELECT id FROM agent_run_events LIMIT 0")
+            .is_ok();
+        if !has_agent_run_events {
+            conn.execute_batch(include_str!("migrations/007_agent_run_events.sql"))?;
+        }
         bump_version(conn, 7)?;
     }
 
     // Migration 008: add model column to worktrees.
-    let has_worktree_model: bool = conn.prepare("SELECT model FROM worktrees LIMIT 0").is_ok();
-    if !has_worktree_model {
-        conn.execute_batch(include_str!("migrations/008_worktree_model.sql"))?;
-    }
     if version < 8 {
+        let has_worktree_model: bool = conn.prepare("SELECT model FROM worktrees LIMIT 0").is_ok();
+        if !has_worktree_model {
+            conn.execute_batch(include_str!("migrations/008_worktree_model.sql"))?;
+        }
         bump_version(conn, 8)?;
     }
 
     // Migration 009: add model column to agent_runs.
-    let has_agent_run_model: bool = conn.prepare("SELECT model FROM agent_runs LIMIT 0").is_ok();
-    if !has_agent_run_model {
-        conn.execute_batch(include_str!("migrations/009_agent_run_model.sql"))?;
-    }
     if version < 9 {
+        let has_agent_run_model: bool =
+            conn.prepare("SELECT model FROM agent_runs LIMIT 0").is_ok();
+        if !has_agent_run_model {
+            conn.execute_batch(include_str!("migrations/009_agent_run_model.sql"))?;
+        }
         bump_version(conn, 9)?;
     }
 
     // Migration 010: add model column to repos.
-    let has_repo_model: bool = conn.prepare("SELECT model FROM repos LIMIT 0").is_ok();
-    if !has_repo_model {
-        conn.execute_batch(include_str!("migrations/010_repo_model.sql"))?;
-    }
     if version < 10 {
+        let has_repo_model: bool = conn.prepare("SELECT model FROM repos LIMIT 0").is_ok();
+        if !has_repo_model {
+            conn.execute_batch(include_str!("migrations/010_repo_model.sql"))?;
+        }
         bump_version(conn, 10)?;
     }
 
     // Migration 011: add plan column to agent_runs.
-    let has_plan: bool = conn.prepare("SELECT plan FROM agent_runs LIMIT 0").is_ok();
-    if !has_plan {
-        conn.execute_batch(include_str!("migrations/011_agent_plan.sql"))?;
-    }
     if version < 11 {
+        let has_plan: bool = conn.prepare("SELECT plan FROM agent_runs LIMIT 0").is_ok();
+        if !has_plan {
+            conn.execute_batch(include_str!("migrations/011_agent_plan.sql"))?;
+        }
         bump_version(conn, 11)?;
     }
 
     // Migration 012: add parent_run_id to agent_runs for parent/child relationships.
-    let has_parent_run_id: bool = conn
-        .prepare("SELECT parent_run_id FROM agent_runs LIMIT 0")
-        .is_ok();
-    if !has_parent_run_id {
-        conn.execute_batch(include_str!("migrations/012_parent_run_id.sql"))?;
-    }
     if version < 12 {
+        let has_parent_run_id: bool = conn
+            .prepare("SELECT parent_run_id FROM agent_runs LIMIT 0")
+            .is_ok();
+        if !has_parent_run_id {
+            conn.execute_batch(include_str!("migrations/012_parent_run_id.sql"))?;
+        }
         bump_version(conn, 12)?;
     }
 
     // Migration 013: add agent_created_issues table.
-    let has_agent_created_issues: bool = conn
-        .prepare("SELECT id FROM agent_created_issues LIMIT 0")
-        .is_ok();
-    if !has_agent_created_issues {
-        conn.execute_batch(include_str!("migrations/007_agent_created_issues.sql"))?;
-    }
     if version < 13 {
+        let has_agent_created_issues: bool = conn
+            .prepare("SELECT id FROM agent_created_issues LIMIT 0")
+            .is_ok();
+        if !has_agent_created_issues {
+            conn.execute_batch(include_str!("migrations/007_agent_created_issues.sql"))?;
+        }
         bump_version(conn, 13)?;
     }
 
     // Migration 014: add allow_agent_issue_creation to repos.
-    let has_allow_agent_issue_creation: bool = conn
-        .prepare("SELECT allow_agent_issue_creation FROM repos LIMIT 0")
-        .is_ok();
-    if !has_allow_agent_issue_creation {
-        conn.execute_batch(include_str!("migrations/008_repo_allow_agent_issues.sql"))?;
-    }
     if version < 14 {
+        let has_allow_agent_issue_creation: bool = conn
+            .prepare("SELECT allow_agent_issue_creation FROM repos LIMIT 0")
+            .is_ok();
+        if !has_allow_agent_issue_creation {
+            conn.execute_batch(include_str!("migrations/008_repo_allow_agent_issues.sql"))?;
+        }
         bump_version(conn, 14)?;
     }
 
     // Migration 015: create agent_run_steps table and migrate JSON plan data.
-    let has_agent_run_steps: bool = conn
-        .prepare("SELECT id FROM agent_run_steps LIMIT 0")
-        .is_ok();
-    if !has_agent_run_steps {
-        conn.execute_batch(include_str!("migrations/015_agent_run_steps.sql"))?;
+    if version < 15 {
+        let has_agent_run_steps: bool = conn
+            .prepare("SELECT id FROM agent_run_steps LIMIT 0")
+            .is_ok();
+        if !has_agent_run_steps {
+            conn.execute_batch(include_str!("migrations/015_agent_run_steps.sql"))?;
 
-        // Migrate existing JSON plan data from agent_runs.plan into the new table.
-        let mut read_stmt =
-            conn.prepare("SELECT id, plan FROM agent_runs WHERE plan IS NOT NULL")?;
-        let rows: Vec<(String, String)> = read_stmt
-            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
-            .filter_map(|r| r.ok())
-            .collect();
-        for (run_id, plan_json) in &rows {
-            if let Ok(steps) = serde_json::from_str::<Vec<LegacyPlanStep>>(plan_json) {
-                for (i, step) in steps.iter().enumerate() {
-                    let step_id = crate::new_id();
-                    let status = if step.done { "completed" } else { "pending" };
-                    conn.execute(
-                        "INSERT INTO agent_run_steps (id, run_id, position, description, status) \
-                         VALUES (?1, ?2, ?3, ?4, ?5)",
-                        params![step_id, run_id, i as i64, step.description, status],
-                    )?;
+            // Migrate existing JSON plan data from agent_runs.plan into the new table.
+            let mut read_stmt =
+                conn.prepare("SELECT id, plan FROM agent_runs WHERE plan IS NOT NULL")?;
+            let rows: Vec<(String, String)> = read_stmt
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+                .filter_map(|r| r.ok())
+                .collect();
+            for (run_id, plan_json) in &rows {
+                if let Ok(steps) = serde_json::from_str::<Vec<LegacyPlanStep>>(plan_json) {
+                    for (i, step) in steps.iter().enumerate() {
+                        let step_id = crate::new_id();
+                        let status = if step.done { "completed" } else { "pending" };
+                        conn.execute(
+                            "INSERT INTO agent_run_steps (id, run_id, position, description, status) \
+                             VALUES (?1, ?2, ?3, ?4, ?5)",
+                            params![step_id, run_id, i as i64, step.description, status],
+                        )?;
+                    }
                 }
             }
         }
-    }
-    if version < 15 {
         bump_version(conn, 15)?;
     }
 
     // Migration 017: create review_configs table for multi-agent PR review swarms.
-    let has_review_configs: bool = conn
-        .prepare("SELECT id FROM review_configs LIMIT 0")
-        .is_ok();
-    if !has_review_configs {
-        conn.execute_batch(include_str!("migrations/017_review_configs.sql"))?;
-    }
     if version < 17 {
+        let has_review_configs: bool = conn
+            .prepare("SELECT id FROM review_configs LIMIT 0")
+            .is_ok();
+        if !has_review_configs {
+            conn.execute_batch(include_str!("migrations/017_review_configs.sql"))?;
+        }
         bump_version(conn, 17)?;
     }
 
@@ -239,46 +240,46 @@ pub fn run(conn: &Connection) -> Result<()> {
     // The agent_runs table must be recreated to add 'waiting_for_feedback' to the
     // status CHECK constraint. PRAGMA foreign_keys = OFF must be set outside a
     // transaction, so we handle the table swap in Rust code.
-    let has_feedback_requests: bool = conn
-        .prepare("SELECT id FROM feedback_requests LIMIT 0")
-        .is_ok();
-    if !has_feedback_requests {
-        with_foreign_keys_off(conn, || {
-            conn.execute_batch(
-                "CREATE TABLE agent_runs_new (
-                id                TEXT PRIMARY KEY,
-                worktree_id       TEXT NOT NULL REFERENCES worktrees(id) ON DELETE CASCADE,
-                claude_session_id TEXT,
-                prompt            TEXT NOT NULL,
-                status            TEXT NOT NULL DEFAULT 'running'
-                                  CHECK (status IN ('running','completed','failed','cancelled','waiting_for_feedback')),
-                result_text       TEXT,
-                cost_usd          REAL,
-                num_turns         INTEGER,
-                duration_ms       INTEGER,
-                started_at        TEXT NOT NULL,
-                ended_at          TEXT,
-                tmux_window       TEXT,
-                log_file          TEXT,
-                model             TEXT,
-                plan              TEXT,
-                parent_run_id     TEXT REFERENCES agent_runs_new(id) ON DELETE SET NULL
-            );
-            INSERT INTO agent_runs_new SELECT id, worktree_id, claude_session_id, prompt, status,
-                result_text, cost_usd, num_turns, duration_ms, started_at, ended_at,
-                tmux_window, log_file, model, plan, parent_run_id FROM agent_runs;
-            DROP TABLE agent_runs;
-            ALTER TABLE agent_runs_new RENAME TO agent_runs;
-            CREATE INDEX IF NOT EXISTS idx_agent_runs_parent ON agent_runs(parent_run_id);
-            CREATE INDEX IF NOT EXISTS idx_agent_runs_worktree ON agent_runs(worktree_id);",
-            )?;
-            Ok(())
-        })?;
-
-        // Now create the feedback_requests table
-        conn.execute_batch(include_str!("migrations/018_feedback_requests.sql"))?;
-    }
     if version < 18 {
+        let has_feedback_requests: bool = conn
+            .prepare("SELECT id FROM feedback_requests LIMIT 0")
+            .is_ok();
+        if !has_feedback_requests {
+            with_foreign_keys_off(conn, || {
+                conn.execute_batch(
+                    "CREATE TABLE agent_runs_new (
+                    id                TEXT PRIMARY KEY,
+                    worktree_id       TEXT NOT NULL REFERENCES worktrees(id) ON DELETE CASCADE,
+                    claude_session_id TEXT,
+                    prompt            TEXT NOT NULL,
+                    status            TEXT NOT NULL DEFAULT 'running'
+                                      CHECK (status IN ('running','completed','failed','cancelled','waiting_for_feedback')),
+                    result_text       TEXT,
+                    cost_usd          REAL,
+                    num_turns         INTEGER,
+                    duration_ms       INTEGER,
+                    started_at        TEXT NOT NULL,
+                    ended_at          TEXT,
+                    tmux_window       TEXT,
+                    log_file          TEXT,
+                    model             TEXT,
+                    plan              TEXT,
+                    parent_run_id     TEXT REFERENCES agent_runs_new(id) ON DELETE SET NULL
+                );
+                INSERT INTO agent_runs_new SELECT id, worktree_id, claude_session_id, prompt, status,
+                    result_text, cost_usd, num_turns, duration_ms, started_at, ended_at,
+                    tmux_window, log_file, model, plan, parent_run_id FROM agent_runs;
+                DROP TABLE agent_runs;
+                ALTER TABLE agent_runs_new RENAME TO agent_runs;
+                CREATE INDEX IF NOT EXISTS idx_agent_runs_parent ON agent_runs(parent_run_id);
+                CREATE INDEX IF NOT EXISTS idx_agent_runs_worktree ON agent_runs(worktree_id);",
+                )?;
+                Ok(())
+            })?;
+
+            // Now create the feedback_requests table
+            conn.execute_batch(include_str!("migrations/018_feedback_requests.sql"))?;
+        }
         bump_version(conn, 18)?;
     }
 
@@ -289,23 +290,23 @@ pub fn run(conn: &Connection) -> Result<()> {
     }
 
     // Migration 020: workflow_runs and workflow_run_steps tables.
-    let has_workflow_runs: bool = conn.prepare("SELECT id FROM workflow_runs LIMIT 0").is_ok();
-    if !has_workflow_runs {
-        conn.execute_batch(include_str!("migrations/020_workflow_runs.sql"))?;
-    }
     if version < 20 {
+        let has_workflow_runs: bool = conn.prepare("SELECT id FROM workflow_runs LIMIT 0").is_ok();
+        if !has_workflow_runs {
+            conn.execute_batch(include_str!("migrations/020_workflow_runs.sql"))?;
+        }
         bump_version(conn, 20)?;
     }
 
     // Migration 021: workflow redesign — add structured output, iteration,
     // parallel, retry, gate, and snapshot columns.
-    let has_definition_snapshot: bool = conn
-        .prepare("SELECT definition_snapshot FROM workflow_runs LIMIT 0")
-        .is_ok();
-    if !has_definition_snapshot {
-        conn.execute_batch(include_str!("migrations/021_workflow_redesign.sql"))?;
-    }
     if version < 21 {
+        let has_definition_snapshot: bool = conn
+            .prepare("SELECT definition_snapshot FROM workflow_runs LIMIT 0")
+            .is_ok();
+        if !has_definition_snapshot {
+            conn.execute_batch(include_str!("migrations/021_workflow_redesign.sql"))?;
+        }
         // Recreate tables to update CHECK constraints (add 'waiting' status).
         with_foreign_keys_off(conn, || {
             conn.execute_batch(
@@ -491,13 +492,13 @@ pub fn run(conn: &Connection) -> Result<()> {
     }
 
     // Migration 026: add inputs column to workflow_runs for resume support.
-    let has_workflow_run_inputs: bool = conn
-        .prepare("SELECT inputs FROM workflow_runs LIMIT 0")
-        .is_ok();
-    if !has_workflow_run_inputs {
-        conn.execute_batch(include_str!("migrations/026_workflow_run_inputs.sql"))?;
-    }
     if version < 26 {
+        let has_workflow_run_inputs: bool = conn
+            .prepare("SELECT inputs FROM workflow_runs LIMIT 0")
+            .is_ok();
+        if !has_workflow_run_inputs {
+            conn.execute_batch(include_str!("migrations/026_workflow_run_inputs.sql"))?;
+        }
         bump_version(conn, 26)?;
     }
 
@@ -589,48 +590,48 @@ pub fn run(conn: &Connection) -> Result<()> {
     }
 
     // Migration 032: add token count columns to agent_runs.
-    let has_input_tokens: bool = conn
-        .prepare("SELECT input_tokens FROM agent_runs LIMIT 0")
-        .is_ok();
-    if !has_input_tokens {
-        conn.execute_batch(include_str!("migrations/032_agent_run_token_counts.sql"))?;
-    }
     if version < 32 {
+        let has_input_tokens: bool = conn
+            .prepare("SELECT input_tokens FROM agent_runs LIMIT 0")
+            .is_ok();
+        if !has_input_tokens {
+            conn.execute_batch(include_str!("migrations/032_agent_run_token_counts.sql"))?;
+        }
         bump_version(conn, 32)?;
     }
 
     // Migration 033: add target_label column to workflow_runs.
-    let has_target_label: bool = conn
-        .prepare("SELECT target_label FROM workflow_runs LIMIT 0")
-        .is_ok();
-    if !has_target_label {
-        conn.execute_batch(include_str!("migrations/033_workflow_target_label.sql"))?;
-    }
     if version < 33 {
+        let has_target_label: bool = conn
+            .prepare("SELECT target_label FROM workflow_runs LIMIT 0")
+            .is_ok();
+        if !has_target_label {
+            conn.execute_batch(include_str!("migrations/033_workflow_target_label.sql"))?;
+        }
         bump_version(conn, 33)?;
     }
 
     // Migration 034: add bot_name column to agent_runs.
-    let has_bot_name: bool = conn
-        .prepare("SELECT bot_name FROM agent_runs LIMIT 0")
-        .is_ok();
-    if !has_bot_name {
-        conn.execute_batch(include_str!("migrations/034_agent_run_bot_name.sql"))?;
-    }
     if version < 34 {
+        let has_bot_name: bool = conn
+            .prepare("SELECT bot_name FROM agent_runs LIMIT 0")
+            .is_ok();
+        if !has_bot_name {
+            conn.execute_batch(include_str!("migrations/034_agent_run_bot_name.sql"))?;
+        }
         bump_version(conn, 34)?;
     }
 
     // Migration 035: add default_bot_name column to workflow_runs.
-    let has_wf_default_bot_name: bool = conn
-        .prepare("SELECT default_bot_name FROM workflow_runs LIMIT 0")
-        .is_ok();
-    if !has_wf_default_bot_name {
-        conn.execute_batch(include_str!(
-            "migrations/035_workflow_run_default_bot_name.sql"
-        ))?;
-    }
     if version < 35 {
+        let has_wf_default_bot_name: bool = conn
+            .prepare("SELECT default_bot_name FROM workflow_runs LIMIT 0")
+            .is_ok();
+        if !has_wf_default_bot_name {
+            conn.execute_batch(include_str!(
+                "migrations/035_workflow_run_default_bot_name.sql"
+            ))?;
+        }
         bump_version(conn, 35)?;
     }
 
@@ -648,10 +649,10 @@ pub fn run(conn: &Connection) -> Result<()> {
     // Migration 037: add 'script' to the role CHECK constraint and add output_file column.
     // Requires a table swap (FK constraint). Guarded by output_file column existence
     // to be idempotent and to skip gracefully on partial test schemas.
-    let has_output_file: bool = conn
-        .prepare("SELECT output_file FROM workflow_run_steps LIMIT 0")
-        .is_ok();
     if version < 37 {
+        let has_output_file: bool = conn
+            .prepare("SELECT output_file FROM workflow_run_steps LIMIT 0")
+            .is_ok();
         if !has_output_file {
             let steps_table_exists = conn
                 .prepare("SELECT 1 FROM workflow_run_steps LIMIT 0")


### PR DESCRIPTION
Column/table-existence probes (conn.prepare("SELECT ... LIMIT 0")) for
22 migrations were running outside their `if version < N` guards, causing
~22 unnecessary PREPARE statements on every startup for fully-upgraded
databases. Move each probe inside its corresponding version guard so it
only executes when the migration hasn't been applied yet.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
