### PR TITLE
fix: update restart.sh comment to reflect branch-agnostic behavior

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-# Pull latest main, rebuild, and launch the TUI.
+# Pull latest changes on the current branch, rebuild, and launch the TUI.
 set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 
-echo "==> Pulling latest main..."
+echo "==> Pulling latest changes..."
 cd "$REPO_ROOT"
 git pull
 


### PR DESCRIPTION
The script already operates on whatever branch is checked out — no `git checkout main` anywhere. The comment and echo message were just wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)