### PR TITLE
fix(#1252): pre-fill ticket_id when running workflow from worktree

### DIFF
--- a/conductor-tui/src/app/workflow_management.rs
+++ b/conductor-tui/src/app/workflow_management.rs
@@ -460,7 +460,24 @@ impl App {
 
         self.state.modal = Modal::None;
 
-        self.show_workflow_inputs_or_run(target, def, std::collections::HashMap::new());
+        let mut prefill = std::collections::HashMap::new();
+        if let crate::state::WorkflowPickerTarget::Worktree {
+            ref worktree_id, ..
+        } = target
+        {
+            if let Some(wt) = self
+                .state
+                .data
+                .worktrees
+                .iter()
+                .find(|w| &w.id == worktree_id)
+            {
+                if let Some(tid) = &wt.ticket_id {
+                    prefill.insert("ticket_id".to_string(), tid.clone());
+                }
+            }
+        }
+        self.show_workflow_inputs_or_run(target, def, prefill);
     }
 
     pub(super) fn handle_run_workflow(&mut self) {
@@ -515,7 +532,11 @@ impl App {
             self.state.status_message = Some("Repo not found for worktree".to_string());
             return;
         };
-        self.show_workflow_inputs_or_run(target, def, std::collections::HashMap::new());
+        let mut prefill = std::collections::HashMap::new();
+        if let Some(tid) = &wt.ticket_id {
+            prefill.insert("ticket_id".to_string(), tid.clone());
+        }
+        self.show_workflow_inputs_or_run(target, def, prefill);
     }
 
     /// Show the input form if the workflow declares inputs, otherwise dispatch immediately.


### PR DESCRIPTION
Two call sites in workflow_management.rs passed an empty prefill map to
show_workflow_inputs_or_run, so ticket_id was never pre-populated even
when the worktree had a linked ticket.

- handle_run_workflow: build prefill from wt.ticket_id (already in scope)
- handle_workflow_picker_confirm: look up worktree from WorkflowPickerTarget
  and build prefill when target is a Worktree variant

ENGINE_INJECTED_KEYS already includes "ticket_id", so the field is
automatically marked readonly once the prefill value is non-empty.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
