### PR TITLE
refactor(#1251): extract model resolution chain to conductor-core

### DIFF
--- a/conductor-cli/src/main.rs
+++ b/conductor-cli/src/main.rs
@@ -740,11 +740,12 @@ fn main() -> Result<()> {
                                     let repo_mgr = RepoManager::new(&conn, &config);
                                     let repo_model =
                                         repo_mgr.get_by_slug(&repo).ok().and_then(|r| r.model);
-                                    let model = wt
-                                        .model
-                                        .as_deref()
-                                        .or(repo_model.as_deref())
-                                        .or(config.general.model.as_deref());
+                                    let resolved_model = conductor_core::models::resolve_model(
+                                        wt.model.as_deref(),
+                                        repo_model.as_deref(),
+                                        config.general.model.as_deref(),
+                                    );
+                                    let model = resolved_model.as_deref();
                                     let agent_mgr = AgentManager::new(&conn);
                                     let run = agent_mgr.create_run(
                                         Some(&wt.id),

--- a/conductor-core/src/models.rs
+++ b/conductor-core/src/models.rs
@@ -66,6 +66,23 @@ pub const KNOWN_MODELS: &[KnownModel] = &[
     },
 ];
 
+/// Resolve the effective model using the per-worktree → per-repo → global config
+/// precedence chain. All inputs are optional; returns `None` if nothing is set.
+///
+/// This is a pure function — callers supply already-loaded values so it works
+/// in both the CLI (loads from DB before calling) and the TUI (reads from
+/// cached in-memory state without blocking the render thread).
+pub fn resolve_model(
+    worktree_model: Option<&str>,
+    repo_model: Option<&str>,
+    global_model: Option<&str>,
+) -> Option<String> {
+    worktree_model
+        .or(repo_model)
+        .or(global_model)
+        .map(|s| s.to_string())
+}
+
 /// Look up a known model by its ID or alias. Returns `None` for custom model strings.
 pub fn find_known_model(id_or_alias: &str) -> Option<&'static KnownModel> {
     KNOWN_MODELS
@@ -129,6 +146,35 @@ pub fn suggest_model(prompt: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_model_worktree_wins() {
+        assert_eq!(
+            resolve_model(Some("opus"), Some("sonnet"), Some("haiku")),
+            Some("opus".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_model_repo_wins_when_no_worktree() {
+        assert_eq!(
+            resolve_model(None, Some("sonnet"), Some("haiku")),
+            Some("sonnet".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_model_global_wins_when_no_worktree_or_repo() {
+        assert_eq!(
+            resolve_model(None, None, Some("haiku")),
+            Some("haiku".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_model_none_when_nothing_set() {
+        assert_eq!(resolve_model(None, None, None), None);
+    }
 
     #[test]
     fn test_known_models_count() {

--- a/conductor-tui/src/app/input_handling.rs
+++ b/conductor-tui/src/app/input_handling.rs
@@ -421,24 +421,21 @@ impl App {
                     return;
                 }
                 // Resolve the default model: per-worktree → per-repo → global config
-                let wt_model = self
+                let wt = self
                     .state
                     .data
                     .worktrees
                     .iter()
-                    .find(|w| w.id == worktree_id)
-                    .and_then(|w| w.model.clone());
-                let repo_model = self
-                    .state
-                    .data
-                    .worktrees
-                    .iter()
-                    .find(|w| w.id == worktree_id)
+                    .find(|w| w.id == worktree_id);
+                let wt_model = wt.and_then(|w| w.model.as_deref());
+                let repo_model = wt
                     .and_then(|w| self.state.data.repos.iter().find(|r| r.id == w.repo_id))
-                    .and_then(|r| r.model.clone());
-                let resolved_default = wt_model
-                    .or(repo_model)
-                    .or_else(|| self.config.general.model.clone());
+                    .and_then(|r| r.model.as_deref());
+                let resolved_default = conductor_core::models::resolve_model(
+                    wt_model,
+                    repo_model,
+                    self.config.general.model.as_deref(),
+                );
 
                 // Suggest a model based on the prompt text
                 let suggested = conductor_core::models::suggest_model(&value);
@@ -451,27 +448,9 @@ impl App {
 
                 let (effective_default, effective_source) = match &resolved_default {
                     Some(m) => {
-                        // Determine source
-                        let source = if self
-                            .state
-                            .data
-                            .worktrees
-                            .iter()
-                            .find(|w| w.id == worktree_id)
-                            .and_then(|w| w.model.as_ref())
-                            .is_some()
-                        {
+                        let source = if wt_model.is_some() {
                             "worktree"
-                        } else if self
-                            .state
-                            .data
-                            .worktrees
-                            .iter()
-                            .find(|w| w.id == worktree_id)
-                            .and_then(|w| self.state.data.repos.iter().find(|r| r.id == w.repo_id))
-                            .and_then(|r| r.model.as_ref())
-                            .is_some()
-                        {
+                        } else if repo_model.is_some() {
                             "repo"
                         } else {
                             "global config"

--- a/conductor-tui/src/app/workflow_management.rs
+++ b/conductor-tui/src/app/workflow_management.rs
@@ -1420,10 +1420,12 @@ impl App {
             .and_then(|r| r.model.clone());
         let is_wt = wt_model.is_some();
         let is_repo = !is_wt && repo_model.is_some();
-        match wt_model
-            .or(repo_model)
-            .or_else(|| self.config.general.model.clone())
-        {
+        let model = conductor_core::models::resolve_model(
+            wt_model.as_deref(),
+            repo_model.as_deref(),
+            self.config.general.model.as_deref(),
+        );
+        match model {
             Some(m) => {
                 let source = if is_wt {
                     "worktree"


### PR DESCRIPTION
Add `resolve_model(worktree_model, repo_model, global_model) -> Option<String>`
to `conductor-core/src/models.rs` as a pure free function covering the
per-worktree → per-repo → global config precedence chain.

Update all four callsites to delegate to it:
- conductor-cli/src/main.rs (was inline `.or()` chain)
- conductor-tui/src/app/workflow_management.rs (`resolve_model_for_worktree` now delegates, source-label logic kept in TUI layer)
- conductor-tui/src/app/input_handling.rs (was duplicated inline block with repeated iterator walks)

Unit tests for the four resolution cases added in conductor-core.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
