### PR TITLE
fix: change analyze-repo-for-agents target from worktree to repo

### DIFF
--- a/.conductor/workflows/analyze-repo-for-agents.wf
+++ b/.conductor/workflows/analyze-repo-for-agents.wf
@@ -2,7 +2,7 @@ workflow analyze-repo-for-agents {
   meta {
     description = "Analyze a repo for large files and produce AI-optimized refactor recommendations"
     trigger     = "manual"
-    targets     = ["worktree"]
+    targets     = ["repo"]
   }
 
   inputs {


### PR DESCRIPTION
## Summary

- Change `analyze-repo-for-agents.wf` target from `["worktree"]` to `["repo"]`
- This workflow only reads and analyzes the codebase — it doesn't commit or modify code
- Avoids requiring a worktree just to run an analysis
- Consistent with other analysis workflows (`generate-diagrams`, `analyze-ux`) that already target `repo`

## Test plan

- [ ] Run `analyze-repo-for-agents` against a repo without creating a worktree first

🤖 Generated with [Claude Code](https://claude.com/claude-code)