### PR TITLE
docs: update ROADMAP.md for current priorities

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,8 @@
 # Conductor Roadmap
 
-Priority order as of 2026-03-15. See linked GitHub issues for full details.
+Priority order as of 2026-03-19. See linked GitHub issues for full details.
+
+> **Note:** This file tracks upcoming work only. Completed items should be removed, not moved to a "recently completed" section — git history and closed issues are the source of truth for what's done.
 
 ## Tier 1 — Near-term, High Value
 
@@ -8,8 +10,8 @@ Small scope, immediately useful. Start here.
 
 | Priority | Issue | Title | Notes |
 |----------|-------|-------|-------|
-| 1 | [#146](https://github.com/devinrosen/conductor-ai/issues/146) | Plugin system for custom ticket sources via CLI adapter | Enables teams to integrate non-GitHub/Jira ticket sources |
-| 2 | [#493](https://github.com/devinrosen/conductor-ai/issues/493) | Parameterize review-pr scope: full diff vs incremental | High-value workflow improvement; low implementation cost |
+| 1 | [#1311](https://github.com/devinrosen/conductor-ai/issues/1311) | Per-repo .conductor/config.toml for repo-level settings | Active — PR [#1314](https://github.com/devinrosen/conductor-ai/pull/1314) in review |
+| 2 | [#140](https://github.com/devinrosen/conductor-ai/issues/140) | Role-based tool profiles for scoped agent MCP access | Important as parallel agent usage scales |
 
 ---
 
@@ -19,7 +21,7 @@ Mostly independent, high signal-to-effort ratio.
 
 | Priority | Issue | Title | Notes |
 |----------|-------|-------|-------|
-| 3 | [#140](https://github.com/devinrosen/conductor-ai/issues/140) | Role-based tool profiles for scoped agent MCP access | Important as parallel agent usage scales |
+| 3 | [#1312](https://github.com/devinrosen/conductor-ai/issues/1312) | Workflow hooks — auto-trigger workflows on lifecycle events | |
 | 4 | [#794](https://github.com/devinrosen/conductor-ai/issues/794) | Surface workflow-produced store files in TUI/web | Depends on #793 design landing first |
 
 ---
@@ -30,15 +32,13 @@ High value but require more design and implementation work.
 
 | Priority | Issue | Title | Notes |
 |----------|-------|-------|-------|
-| 7 | [#793](https://github.com/devinrosen/conductor-ai/issues/793) | Workflow-produced data storage (extensible KV layer) | RFC phase — design must land before #794 |
-| 8 | [#274](https://github.com/devinrosen/conductor-ai/issues/274) | Dependency graph, impact analysis, and conflict-aware scheduling | Phased delivery via #432–436; absorbs cost-awareness from #142 |
-| 9 | [#484](https://github.com/devinrosen/conductor-ai/issues/484) | Workflow-postmortem phase 2: multi-run pattern analysis | Builds on phase 1 |
-| 10 | [#485](https://github.com/devinrosen/conductor-ai/issues/485) | Workflow-postmortem phase 3: suggest .wf diff with gate | Builds on phase 2 |
-| 11 | [#486](https://github.com/devinrosen/conductor-ai/issues/486) | Workflow-postmortem phase 4: open PR for .wf improvements | Builds on phase 3 |
-| 12 | [#137](https://github.com/devinrosen/conductor-ai/issues/137) | Agent-to-human notifications from agent runs | |
-| 13 | [#144](https://github.com/devinrosen/conductor-ai/issues/144) | Cost analytics dashboard — spend over time by repo | Feeds into #274's cost-aware scheduling |
-| 14 | [#142](https://github.com/devinrosen/conductor-ai/issues/142) | Cost budgeting and spending limits per run, workflow, and repo | Hard spend caps as safety net; smart scheduling (#274) higher priority |
-| 15 | [#618](https://github.com/devinrosen/conductor-ai/issues/618) | Agent credential management — capability-based identity | RFC phase |
+| 5 | [#793](https://github.com/devinrosen/conductor-ai/issues/793) | Workflow-produced data storage (extensible KV layer) | RFC phase — design must land before #794 |
+| 6 | [#274](https://github.com/devinrosen/conductor-ai/issues/274) | Dependency graph, impact analysis, and conflict-aware scheduling | Phased delivery via #432–436; absorbs cost-awareness from #142 |
+| 7 | [#484](https://github.com/devinrosen/conductor-ai/issues/484) | Workflow-postmortem phase 2: multi-run pattern analysis | Builds on phase 1 |
+| 8 | [#137](https://github.com/devinrosen/conductor-ai/issues/137) | Agent-to-human notifications from agent runs | |
+| 9 | [#144](https://github.com/devinrosen/conductor-ai/issues/144) | Cost analytics dashboard — spend over time by repo | Feeds into #274's cost-aware scheduling |
+| 10 | [#142](https://github.com/devinrosen/conductor-ai/issues/142) | Cost budgeting and spending limits per run, workflow, and repo | Hard spend caps as safety net; smart scheduling (#274) higher priority |
+| 11 | [#618](https://github.com/devinrosen/conductor-ai/issues/618) | Agent credential management — capability-based identity | RFC phase |
 
 ---
 
@@ -47,7 +47,6 @@ High value but require more design and implementation work.
 | Area | Limitation | Details |
 |------|-----------|---------|
 | GitHub sync | Sub-issues not supported | Ticket sync uses `gh issue list` which returns a flat list. GitHub sub-issues require the GraphQL API and are not yet pulled in. |
-
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove completed issues (#493, #146, #485, #486, #1320, #1323) from roadmap
- Add new open issues (#1311, #1312) to appropriate tiers
- Renumber priorities sequentially across all tiers (1–11)
- Add note that this file tracks upcoming work only — no "recently completed" sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)