### PR TITLE
fix(#1358): strip unresolved {{…}} placeholders in substitute_variables

### DIFF
--- a/conductor-core/src/workflow/prompt_builder.rs
+++ b/conductor-core/src/workflow/prompt_builder.rs
@@ -12,6 +12,15 @@ pub(super) fn substitute_variables(prompt: &str, vars: &HashMap<&str, String>) -
         let pattern = format!("{{{{{key}}}}}");
         result = result.replace(&pattern, value);
     }
+    // Strip any remaining unresolved {{…}} placeholders so they don't
+    // leak as literal text into prompts, env vars, or script paths.
+    while let Some(start) = result.find("{{") {
+        if let Some(end) = result[start..].find("}}") {
+            result.replace_range(start..start + end + 2, "");
+        } else {
+            break;
+        }
+    }
     result
 }
 
@@ -195,6 +204,28 @@ mod tests {
             vars.get("prior_output_file").map(String::as_str),
             Some("/tmp/last.txt"),
         );
+    }
+
+    #[test]
+    fn test_substitute_variables_strips_unresolved_placeholders() {
+        let vars = HashMap::new();
+        let result = substitute_variables("hello {{unknown}}", &vars);
+        assert_eq!(result, "hello ");
+    }
+
+    #[test]
+    fn test_substitute_variables_resolves_known_strips_unknown() {
+        let mut vars = HashMap::new();
+        vars.insert("name", "world".to_string());
+        let result = substitute_variables("hello {{name}} and {{unknown}}", &vars);
+        assert_eq!(result, "hello world and ");
+    }
+
+    #[test]
+    fn test_substitute_variables_multiple_unresolved() {
+        let vars = HashMap::new();
+        let result = substitute_variables("{{a}} middle {{b}} end {{c}}", &vars);
+        assert_eq!(result, " middle  end ");
     }
 
     #[test]

--- a/conductor-core/src/workflow/tests/output.rs
+++ b/conductor-core/src/workflow/tests/output.rs
@@ -58,7 +58,7 @@ fn test_substitute_variables() {
     let result = substitute_variables(prompt, &vars);
     assert_eq!(
         result,
-        "Fix ticket FEAT-123. Context: Created PLAN.md. Unknown: {{unknown}}."
+        "Fix ticket FEAT-123. Context: Created PLAN.md. Unknown: ."
     );
 }
 


### PR DESCRIPTION
When no feature record is linked to a worktree, {{feature_base_branch}} passed through as literal text, causing push-and-pr.sh to fail on `git fetch origin "{{feature_base_branch}}"`. The shell default `${FEATURE_BASE_BRANCH:-main}` didn't trigger because the env var was set to the literal placeholder string.

Add a post-substitution pass that replaces any remaining {{…}} patterns with empty string, allowing shell defaults like `:-main` to kick in.