### PR TITLE
feat(conductor-web): auto-populate ticket_id in workflow run modal

### DIFF
--- a/conductor-web/frontend/src/components/workflows/RunWorkflowModal.tsx
+++ b/conductor-web/frontend/src/components/workflows/RunWorkflowModal.tsx
@@ -5,6 +5,7 @@ import type { WorkflowDefSummary } from "../../api/types";
 interface RunWorkflowModalProps {
   def: WorkflowDefSummary;
   worktreeId: string;
+  ticketId?: string;
   onClose: () => void;
   onStarted: () => void;
 }
@@ -12,6 +13,7 @@ interface RunWorkflowModalProps {
 export function RunWorkflowModal({
   def,
   worktreeId,
+  ticketId,
   onClose,
   onStarted,
 }: RunWorkflowModalProps) {
@@ -22,6 +24,8 @@ export function RunWorkflowModal({
     for (const input of def.inputs) {
       if (input.input_type === "boolean") {
         initial[input.name] = input.default ?? "false";
+      } else if (input.name === "ticket_id" && ticketId) {
+        initial[input.name] = ticketId;
       }
     }
     return initial;

--- a/conductor-web/frontend/src/components/workflows/WorkflowPanel.tsx
+++ b/conductor-web/frontend/src/components/workflows/WorkflowPanel.tsx
@@ -9,9 +9,10 @@ import { RunWorkflowModal } from "./RunWorkflowModal";
 interface WorkflowPanelProps {
   repoId: string;
   worktreeId: string;
+  ticketId?: string;
 }
 
-export function WorkflowPanel({ repoId, worktreeId }: WorkflowPanelProps) {
+export function WorkflowPanel({ repoId, worktreeId, ticketId }: WorkflowPanelProps) {
   const [defs, setDefs] = useState<WorkflowDefSummary[]>([]);
   const [runs, setRuns] = useState<WorkflowRun[]>([]);
   const [runModalDef, setRunModalDef] = useState<WorkflowDefSummary | null>(null);
@@ -99,6 +100,7 @@ export function WorkflowPanel({ repoId, worktreeId }: WorkflowPanelProps) {
         <RunWorkflowModal
           def={runModalDef}
           worktreeId={worktreeId}
+          ticketId={ticketId}
           onClose={() => setRunModalDef(null)}
           onStarted={() => {
             setRunModalDef(null);

--- a/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
+++ b/conductor-web/frontend/src/pages/WorktreeDetailPage.tsx
@@ -553,7 +553,7 @@ export function WorktreeDetailPage() {
       </div>
 
       {activeTab === "workflows" && worktreeId && repoId && (
-        <WorkflowPanel repoId={repoId} worktreeId={worktreeId} />
+        <WorkflowPanel repoId={repoId} worktreeId={worktreeId} ticketId={worktree.ticket_id ?? undefined} />
       )}
 
       {/* Agent Section */}


### PR DESCRIPTION
## Summary
- When opening the Run Workflow modal from a worktree with a linked ticket, the `ticket_id` input field is now pre-filled automatically
- Passes `ticketId` from `WorktreeDetailPage` → `WorkflowPanel` → `RunWorkflowModal`
- Uses the ticket ID as the default value during input state initialization

## Test plan
- [ ] Open a worktree that has a linked ticket, go to Workflows tab, click Run on a workflow with a `ticket_id` input — verify it's pre-filled
- [ ] Open a worktree with no linked ticket — verify the `ticket_id` field remains empty
- [ ] Verify the pre-filled value can still be manually changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)