### PR TITLE
fix(#1461): default agent permission mode back to skip-permissions

### DIFF
--- a/conductor-core/src/config.rs
+++ b/conductor-core/src/config.rs
@@ -10,16 +10,16 @@ use crate::error::{ConductorError, Result};
 ///
 /// ```toml
 /// [general]
-/// agent_permission_mode = "auto-mode"       # default — uses --enable-auto-mode
-/// agent_permission_mode = "skip-permissions" # legacy — uses --dangerously-skip-permissions
+/// agent_permission_mode = "skip-permissions" # default — uses --dangerously-skip-permissions
+/// agent_permission_mode = "auto-mode"        # uses --enable-auto-mode (may prompt in headless agents)
 /// ```
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum AgentPermissionMode {
-    /// Use `--enable-auto-mode` (default, recommended).
-    #[default]
+    /// Use `--enable-auto-mode` (may prompt for permissions in headless agents).
     AutoMode,
-    /// Use `--dangerously-skip-permissions` (legacy fallback).
+    /// Use `--dangerously-skip-permissions` (default for headless agent runs).
+    #[default]
     SkipPermissions,
     /// Use `--permission-mode plan` (read-only mode for repo-scoped agents).
     Plan,
@@ -557,7 +557,7 @@ mod tests {
         let config: Config = toml::from_str("").unwrap();
         assert_eq!(
             config.general.agent_permission_mode,
-            AgentPermissionMode::AutoMode
+            AgentPermissionMode::SkipPermissions
         );
     }
 


### PR DESCRIPTION
## Summary

- Changes the default `AgentPermissionMode` from `AutoMode` to `SkipPermissions`
- `--enable-auto-mode` can prompt for permissions in headless tmux agent sessions, causing agents to get stuck (observed in ticket-to-pr workflow on feat-1469 worktree)
- `--dangerously-skip-permissions` is the correct default for headless agent runs
- Users can still opt into auto-mode via `config.toml`: `agent_permission_mode = "auto-mode"`

## Test plan

- [x] All 7 `test_agent_permission_mode_*` tests pass
- [ ] Verify stuck worktree agent resumes after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)