### PR TITLE
docs: RFC 007 CliRuntime design + roadmap housekeeping

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Conductor Roadmap
 
-Priority order as of 2026-03-20. See linked GitHub issues for full details.
+Priority order as of 2026-03-28. See linked GitHub issues for full details.
 
 > **Note:** This file tracks upcoming work only. Completed items should be removed, not moved to a "recently completed" section — git history and closed issues are the source of truth for what's done.
 
@@ -10,8 +10,7 @@ Small scope, immediately useful. Start here.
 
 | Priority | Issue | Title | Notes |
 |----------|-------|-------|-------|
-| 1 | [#1367](https://github.com/devinrosen/conductor-ai/issues/1367) | 'Cannot determine repo for this workflow run' on historical runs | Affects 98% of historical workflow runs; repo_id backfill + deleted worktree fallback |
-| 2 | [#140](https://github.com/devinrosen/conductor-ai/issues/140) | Role-based tool profiles for scoped agent MCP access | Important as parallel agent usage scales |
+| 1 | [#140](https://github.com/devinrosen/conductor-ai/issues/140) | Role-based tool profiles for scoped agent MCP access | Important as parallel agent usage scales |
 
 ---
 
@@ -46,10 +45,3 @@ High value but require more design and implementation work.
 |------|-----------|---------|
 | GitHub sync | Sub-issues not supported | Ticket sync uses `gh issue list` which returns a flat list. GitHub sub-issues require the GraphQL API and are not yet pulled in. |
 
----
-
-## Deferred — Phase 5
-
-| Issue | Title | Notes |
-|-------|-------|-------|
-| [#9](https://github.com/devinrosen/conductor-ai/issues/9) | Daemon extraction — async service with IPC | Build once parallel agent workflows make the TUI-must-be-open limitation painful. Requirements will be clearer then. |

--- a/docs/rfc/open/007-multi-runtime-agents.md
+++ b/docs/rfc/open/007-multi-runtime-agents.md
@@ -1,7 +1,7 @@
 # RFC 007: Multi-Runtime Agent Support
 
 **Status:** Draft
-**Date:** 2026-03-18
+**Date:** 2026-03-28
 **Author:** Devin
 
 ---
@@ -88,15 +88,24 @@ pub struct AgentDef {
 ```toml
 # ~/.conductor/config.toml
 
+# CLI-based runtimes (tmux spawn + exit polling, same pattern as Claude)
 [runtimes.gemini]
-api_key_env = "GEMINI_API_KEY"
+type = "cli"
+binary = "gemini"
+args = ["-m", "{{model}}", "-p", "{{prompt}}", "--output-format", "json", "--approval-mode=yolo"]
 default_model = "gemini-2.5-flash"
+result_field = "response"
+token_fields = "stats.models.*.tokens.total"
 
+# API-based runtimes (synchronous HTTP, no tmux)
 [runtimes.openai]
+type = "api"
 api_key_env = "OPENAI_API_KEY"
 default_model = "gpt-4.1"
 
+# Script escape hatch
 [runtimes.script]
+type = "script"
 command = "python3 my_agent.py"
 ```
 
@@ -107,11 +116,23 @@ pub struct Config {
 }
 
 pub struct RuntimeConfig {
-    /// Env var name holding the API key (not the key itself — no secrets in config)
-    pub api_key_env: Option<String>,
-    /// Default model for this runtime (overridden by agent/step)
+    /// "cli", "api", or "script"
+    pub runtime_type: String,
+    /// For "cli": binary to invoke (e.g. "gemini")
+    pub binary: Option<String>,
+    /// For "cli": arg template — {{prompt}} and {{model}} are substituted
+    pub args: Option<Vec<String>>,
+    /// For "cli": "arg" (default) or "stdin"
+    pub prompt_via: Option<String>,
+    /// For "cli"/"api": default model ID, overridden by agent frontmatter
     pub default_model: Option<String>,
-    /// For "script" runtime: the command to execute
+    /// For "cli" with JSON output: dot-path to extract result text (e.g. "response")
+    pub result_field: Option<String>,
+    /// For "cli" with JSON output: dot-path to extract total tokens (optional)
+    pub token_fields: Option<String>,
+    /// For "api": env var name holding the API key (not the key itself)
+    pub api_key_env: Option<String>,
+    /// For "script": the shell command to execute
     pub command: Option<String>,
 }
 ```
@@ -174,13 +195,41 @@ pub trait AgentRuntime {
 - `is_alive()` → checks `list_live_tmux_windows()`
 - `cancel()` → kills tmux window
 
-**GeminiRuntime** — API-based, no tmux:
-- `spawn()` → synchronous HTTP POST to `generativelanguage.googleapis.com`, writes result to DB
+**CliRuntime** — generic tmux-based runner for any CLI agent (Gemini CLI, Codex CLI, etc.):
+- `spawn()` → builds command from config template, spawns tmux window, polls for process exit
+- `poll()` → same exit-based polling as `ClaudeRuntime`
+- `is_alive()` → checks `list_live_tmux_windows()`
+- `cancel()` → kills tmux window
+- Result text extracted from stdout capture; token counts parsed from JSON output if `output_format = "json"` is configured
+
+Config for a `CliRuntime` entry specifies the binary, arg template, output format, and field mappings:
+
+```toml
+[runtimes.gemini]
+type = "cli"
+binary = "gemini"
+args = ["-m", "{{model}}", "-p", "{{prompt}}", "--output-format", "json", "--approval-mode=yolo"]
+default_model = "gemini-2.5-flash"
+result_field = "response"                        # jq-style path into JSON output
+token_fields = "stats.models.*.tokens.total"     # optional, for cost tracking
+```
+
+`{{prompt}}` and `{{model}}` are the only substitution variables. If `prompt_via = "stdin"`, the prompt is written to the process's stdin instead of substituted into args.
+
+**Gemini CLI invocation shape** (researched 2026-03-28):
+- Binary: `gemini` (npm: `@google/gemini-cli`)
+- Prompt flag: `-p "<prompt>"` — forces headless mode, process exits after response
+- Model flag: `-m gemini-2.5-flash`
+- Output: `--output-format json` → `{ "response": "...", "stats": { "models": { "gemini-2.5-flash": { "tokens": { "total": N } } } } }`
+- Tool approval: `--approval-mode=yolo` to suppress interactive prompts
+- Exit codes: `0` success, `1` error, `42` input error, `53` turn limit exceeded
+- No dollar cost in output — token counts only
+
+**OpenAIRuntime** — API-based, no tmux:
+- `spawn()` → synchronous HTTP POST to OpenAI API, writes result to DB
 - `poll()` → reads completed run from DB (already finished in spawn)
 - `is_alive()` → always `false`
 - `cancel()` → no-op
-
-**OpenAIRuntime** — same pattern as Gemini, different API endpoint.
 
 **ScriptRuntime** — escape hatch for arbitrary commands:
 - `spawn()` → runs command via `Command::new("sh")`, passes prompt via env var `CONDUCTOR_PROMPT`
@@ -193,10 +242,17 @@ fn resolve_runtime(name: &str, config: &Config) -> Result<Box<dyn AgentRuntime>>
     let rt_config = config.runtimes.get(name);
     match name {
         "claude" => Ok(Box::new(ClaudeRuntime)),
-        "gemini" => Ok(Box::new(GeminiRuntime::from_config(rt_config?))),
-        "openai" => Ok(Box::new(OpenAIRuntime::from_config(rt_config?))),
         "script" => Ok(Box::new(ScriptRuntime::from_config(rt_config?))),
-        _ => Err(format!("unknown runtime: {name}"))
+        "openai" => Ok(Box::new(OpenAIRuntime::from_config(rt_config?))),
+        _ => {
+            // Any runtime with type = "cli" in config resolves to CliRuntime
+            let cfg = rt_config.ok_or_else(|| format!("unknown runtime: {name}"))?;
+            if cfg.runtime_type == "cli" {
+                Ok(Box::new(CliRuntime::from_config(cfg)))
+            } else {
+                Err(format!("unknown runtime type for '{name}'"))
+            }
+        }
     }
 }
 ```
@@ -238,40 +294,44 @@ ALTER TABLE agent_runs ADD COLUMN runtime TEXT NOT NULL DEFAULT 'claude';
 
 5. **`runtime` defaults to `"claude"`.** Fully backwards compatible — existing agent files work unchanged.
 
-6. **`script` runtime as escape hatch.** Wraps any CLI tool (ADK, Codex, custom scripts) without needing native conductor support.
+6. **`script` runtime as escape hatch.** Wraps any CLI tool (ADK, Codex, custom scripts) without needing native conductor support for each one.
+
+7. **CLI-based runtimes use a single generic `CliRuntime`**, not per-tool implementations. Any CLI agent that accepts a prompt (via flag or stdin) and exits on completion can be configured via `[runtimes.<name>]` with `type = "cli"` — no code changes required to add a new CLI tool. `ClaudeRuntime` stays separate because it has deep conductor integration (`--run-id`, resume, event parsing) that doesn't generalize.
 
 ---
 
 ## Open Questions
 
-1. **CLI-based runtimes (Gemini CLI, Codex CLI):** Should these use the same tmux spawn pattern as Claude, or should they be separate runtime types? If tmux-based, they could share a `CliRuntime` base that parameterizes the binary and args.
+1. **Structured output for API runtimes:** Claude agents produce structured output via conductor's `--output-format json` and schema validation. API runtimes return plain text. For now, skip schema validation for API-based agents — they return `result_text` only. Revisit if there's a real use case for structured output from an API runtime.
 
-2. **Structured output for API runtimes:** Claude agents produce structured output via conductor's `--output-format json`. How should API runtimes produce structured output that integrates with the existing schema validation pipeline?
+2. **Tool use for API runtimes:** Gemini and OpenAI APIs support function calling. Keep them as simple prompt → text for now. Conductor does not expose workflow context as tools to API runtimes.
 
-3. **Tool use for API runtimes:** Gemini and OpenAI APIs support function calling. Should conductor expose workflow context as tools to API-based agents, or keep them as simple prompt → text?
+3. **Cost tracking normalization:** Claude reports dollar cost. CLI runtimes (Gemini) report token counts only; no dollar cost. API runtimes return token counts in response bodies. Store token counts when available; leave `cost_usd` null for non-Claude runtimes until a cost estimation layer is warranted.
 
-4. **Cost tracking:** Claude reports cost via its JSON output. Gemini/OpenAI APIs return token counts in response headers/bodies. Need to normalize cost reporting across runtimes.
+4. **Agent capabilities validation:** `can_commit: true` is meaningless for API-based agents (they can't modify files). Emit a warning at workflow parse time if `can_commit: true` is set on a non-CLI runtime agent; don't hard-error to keep config forgiving.
 
-5. **Agent capabilities validation:** `can_commit: true` makes no sense for an API-based agent. Should conductor validate that capability flags are compatible with the runtime?
+5. **Async consideration:** API calls block the workflow executor thread. `ureq` (blocking, no extra runtime) is the correct choice for now — consistent with the synchronous engine. Revisit if parallel blocks with many API calls cause visible latency.
 
-6. **Async consideration:** API calls are fast but still block the workflow executor thread. For parallel blocks with many API calls, should we consider `ureq` (blocking) vs `reqwest` (async)? The current engine is synchronous, so `ureq` is the path of least resistance.
-
-7. **Rate limiting:** API-based runtimes may hit rate limits. Should retry/backoff logic live in the runtime implementation or be handled by the existing retry mechanism in the workflow executor?
-
-8. **Context window management:** Different runtimes have different context limits. Should conductor be aware of this, or leave it to the user to choose appropriate models?
+6. **Rate limiting and retries:** Leave to the user for now. The existing workflow retry mechanism (`retry:` in DSL) covers transient failures. Per-runtime backoff can be added later if needed.
 
 ---
 
 ## Implementation Order
 
-1. Add `runtime` field to `AgentFrontmatter` / `AgentDef` (backwards-compatible default)
-2. Add `RuntimeConfig` to `Config`
-3. Define `AgentRuntime` trait
+1. Add `runtime` field to `AgentFrontmatter` / `AgentDef` (backwards-compatible default `"claude"`)
+2. Add `RuntimeConfig` to `Config` (with `type`, `binary`, `args`, `prompt_via`, `result_field`, etc.)
+3. Define `AgentRuntime` trait (`spawn`, `poll`, `is_alive`, `cancel`)
 4. Extract existing tmux logic into `ClaudeRuntime` (pure refactor, no behavior change)
 5. Add DB migration for `runtime` column
 6. Wire runtime dispatch into `execute_call_with_schema`
-7. Implement `GeminiRuntime` (API-based)
-8. Implement `ScriptRuntime` (escape hatch)
-9. Implement `OpenAIRuntime` (API-based)
+7. Implement `CliRuntime` (generic tmux-based runner — covers Gemini CLI, Codex CLI, etc.)
+8. Implement `ScriptRuntime` (escape hatch for arbitrary shell commands)
+9. Implement `OpenAIRuntime` (API-based, optional — only if there's a concrete use case)
 
-Steps 1–6 can land as a single PR with no functional change (Claude-only, but via the trait). Steps 7–9 are independent and can land separately.
+Steps 1–6 land as a single PR with no functional change (Claude-only, but via the trait). Steps 7–8 are independent and can land separately. Step 9 is deferred until there's a concrete use case.
+
+---
+
+## Out of Scope — Future Considerations
+
+**Image generation from workflows:** Cloud-based image generation services (e.g. Nano Banana) are not CLI tools and don't fit the `CliRuntime` model — they're API-only with binary output rather than text. Generating images as a workflow step is a desirable future capability but requires a separate design: a dedicated step type (e.g. `generate-image:`), an output artifact model for binary files, and a storage layer for the results. Track separately when there's a concrete use case.


### PR DESCRIPTION
## Summary

- **RFC 007:** Redesigns the multi-runtime agent RFC around a single generic `CliRuntime` (parameterized via config) instead of per-tool implementations. Documents the Gemini CLI invocation shape as the reference example. Resolves all open questions that had clear answers. Adds image generation as an out-of-scope future consideration.
- **ROADMAP:** Removes closed issue #9 (daemon extraction — closed today, superseded by desktop app) and closed issue #1367 (already fixed). Updates date.

## Changes

- `CliRuntime` replaces `GeminiRuntime`/`CodexRuntime` etc — any CLI tool is now configurable via `[runtimes.<name>]` with `type = "cli"`, no code changes needed per tool
- Gemini CLI invocation shape fully documented (`-p`, `--output-format json`, `--approval-mode=yolo`, exit codes, token field paths)
- Open questions resolved: structured output (skip for API runtimes), cost tracking (tokens only for non-Claude), capability validation (warn not error), async (ureq)
- Nano Banana removed (it's a cloud image tool, not a CLI agent)
- OpenAI API runtime deferred to step 9 (no concrete use case yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)