### PR TITLE
fix(web): default log level to INFO with env-filter override

### DIFF
--- a/conductor-web/Cargo.toml
+++ b/conductor-web/Cargo.toml
@@ -23,7 +23,7 @@ rust-embed = "8"
 mime_guess = "2"
 rusqlite = { version = "0.32", features = ["bundled"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
 web-push = "0.10"
 base64 = "0.22"

--- a/conductor-web/src/main.rs
+++ b/conductor-web/src/main.rs
@@ -17,7 +17,12 @@ use conductor_web::state::AppState;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
 
     let mut config = load_config()?;
     ensure_dirs(&config)?;


### PR DESCRIPTION
## Summary
- `tracing_subscriber::fmt::init()` defaulted to `ERROR` when `RUST_LOG` was unset, silently dropping all `INFO` and `WARN` output (e.g. "Listening on http://...")
- Switch to `EnvFilter` with an `"info"` default so startup messages and warnings are visible out of the box
- Add `env-filter` feature to `tracing-subscriber` in `conductor-web/Cargo.toml`
- `RUST_LOG` still overrides (e.g. `RUST_LOG=debug` enables `TraceLayer` HTTP request logs)

## Test plan
- [ ] Run `cargo run --bin conductor-web` without `RUST_LOG` set — confirm INFO logs appear (e.g. "Listening on http://127.0.0.1:3000")
- [ ] Run with `RUST_LOG=warn cargo run --bin conductor-web` — confirm INFO logs are suppressed
- [ ] Run with `RUST_LOG=debug cargo run --bin conductor-web` — confirm HTTP request traces from `TraceLayer` appear
- [ ] `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)