### PR TITLE
test(#1708): add unit tests for TicketSource::from_issue_source and default_config

### DIFF
--- a/conductor-core/src/ticket_source.rs
+++ b/conductor-core/src/ticket_source.rs
@@ -9,6 +9,7 @@ use crate::tickets::TicketInput;
 /// Collapses all `match source.source_type.as_str()` dispatch sites to a single
 /// `TicketSource::from_issue_source(&source)?` call. Adding a new ticket source
 /// only requires updating this enum and its `impl` block.
+#[derive(Debug)]
 pub enum TicketSource {
     GitHub(GitHubConfig),
     Jira(JiraConfig),
@@ -108,6 +109,182 @@ impl TicketSource {
                     .to_string(),
             )),
             (other, _) => Err(ConductorError::UnknownSourceType(other.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_issue_source(source_type: &str, config_json: &str) -> IssueSource {
+        IssueSource {
+            id: "test-id".to_string(),
+            repo_id: "test-repo".to_string(),
+            source_type: source_type.to_string(),
+            config_json: config_json.to_string(),
+        }
+    }
+
+    // --- from_issue_source ---
+
+    #[test]
+    fn from_issue_source_valid_github() {
+        let src = make_issue_source("github", r#"{"owner":"acme","repo":"widget"}"#);
+        let ts = TicketSource::from_issue_source(&src).unwrap();
+        match ts {
+            TicketSource::GitHub(cfg) => {
+                assert_eq!(cfg.owner, "acme");
+                assert_eq!(cfg.repo, "widget");
+            }
+            _ => panic!("expected GitHub variant"),
+        }
+    }
+
+    #[test]
+    fn from_issue_source_valid_jira() {
+        let src = make_issue_source(
+            "jira",
+            r#"{"jql":"project = FOO AND status != Done","url":"https://acme.atlassian.net"}"#,
+        );
+        let ts = TicketSource::from_issue_source(&src).unwrap();
+        match ts {
+            TicketSource::Jira(cfg) => {
+                assert_eq!(cfg.jql, "project = FOO AND status != Done");
+                assert_eq!(cfg.url, "https://acme.atlassian.net");
+            }
+            _ => panic!("expected Jira variant"),
+        }
+    }
+
+    #[test]
+    fn from_issue_source_invalid_github_config() {
+        let src = make_issue_source("github", "not-json");
+        let err = TicketSource::from_issue_source(&src).unwrap_err();
+        match err {
+            ConductorError::TicketSync(msg) => {
+                assert!(
+                    msg.contains("invalid github config"),
+                    "unexpected msg: {msg}"
+                );
+            }
+            _ => panic!("expected TicketSync error, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn from_issue_source_invalid_jira_config() {
+        let src = make_issue_source("jira", "{bad json}");
+        let err = TicketSource::from_issue_source(&src).unwrap_err();
+        match err {
+            ConductorError::TicketSync(msg) => {
+                assert!(msg.contains("invalid jira config"), "unexpected msg: {msg}");
+            }
+            _ => panic!("expected TicketSync error, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn from_issue_source_unknown_source_type() {
+        let src = make_issue_source("linear", r#"{}"#);
+        let err = TicketSource::from_issue_source(&src).unwrap_err();
+        match err {
+            ConductorError::UnknownSourceType(t) => assert_eq!(t, "linear"),
+            _ => panic!("expected UnknownSourceType error, got {err:?}"),
+        }
+    }
+
+    // --- default_config ---
+
+    #[test]
+    fn default_config_github_with_valid_json() {
+        let json = r#"{"owner":"acme","repo":"widget"}"#;
+        let result = TicketSource::default_config("github", Some(json), "").unwrap();
+        assert_eq!(result, json);
+    }
+
+    #[test]
+    fn default_config_jira_with_valid_json() {
+        let json = r#"{"jql":"project = FOO","url":"https://acme.atlassian.net"}"#;
+        let result = TicketSource::default_config("jira", Some(json), "").unwrap();
+        assert_eq!(result, json);
+    }
+
+    #[test]
+    fn default_config_github_with_invalid_json() {
+        let err = TicketSource::default_config("github", Some("not-json"), "").unwrap_err();
+        match err {
+            ConductorError::InvalidInput(msg) => {
+                assert!(msg.contains("invalid JSON config"), "unexpected msg: {msg}");
+            }
+            _ => panic!("expected InvalidInput error, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn default_config_jira_with_invalid_json() {
+        let err = TicketSource::default_config("jira", Some("{bad}"), "").unwrap_err();
+        match err {
+            ConductorError::InvalidInput(msg) => {
+                assert!(msg.contains("invalid JSON config"), "unexpected msg: {msg}");
+            }
+            _ => panic!("expected InvalidInput error, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn default_config_github_no_config_valid_remote_https() {
+        let result =
+            TicketSource::default_config("github", None, "https://github.com/acme/widget.git")
+                .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["owner"], "acme");
+        assert_eq!(v["repo"], "widget");
+    }
+
+    #[test]
+    fn default_config_github_no_config_valid_remote_ssh() {
+        let result =
+            TicketSource::default_config("github", None, "git@github.com:acme/widget.git").unwrap();
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["owner"], "acme");
+        assert_eq!(v["repo"], "widget");
+    }
+
+    #[test]
+    fn default_config_github_no_config_invalid_remote() {
+        let err = TicketSource::default_config("github", None, "not-a-url").unwrap_err();
+        match err {
+            ConductorError::InvalidInput(msg) => {
+                assert!(
+                    msg.contains("cannot infer GitHub config"),
+                    "unexpected msg: {msg}"
+                );
+            }
+            _ => panic!("expected InvalidInput error, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn default_config_jira_no_config_returns_error() {
+        let err = TicketSource::default_config("jira", None, "").unwrap_err();
+        match err {
+            ConductorError::InvalidInput(msg) => {
+                assert!(
+                    msg.contains("--config is required for jira"),
+                    "unexpected msg: {msg}"
+                );
+            }
+            _ => panic!("expected InvalidInput error, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn default_config_unknown_source_type() {
+        let err = TicketSource::default_config("linear", Some("{}"), "").unwrap_err();
+        match err {
+            ConductorError::UnknownSourceType(t) => assert_eq!(t, "linear"),
+            _ => panic!("expected UnknownSourceType error, got {err:?}"),
         }
     }
 }


### PR DESCRIPTION
Cover all 5 branches in default_config and all 5 parse paths in from_issue_source (valid GitHub/Jira, invalid JSON for each, unknown source type). Also derives Debug on TicketSource to enable unwrap_err in tests.