### PR TITLE
feat: fix Vantage ticket sync, add Slack integration and workflow active CLI

### DIFF
--- a/conductor-cli/src/commands.rs
+++ b/conductor-cli/src/commands.rs
@@ -149,6 +149,12 @@ pub enum AgentCommands {
 
 #[derive(Subcommand)]
 pub enum WorkflowCommands {
+    /// List active workflow runs across all repos (optionally notify Slack)
+    Active {
+        /// Post the summary to the configured Slack webhook
+        #[arg(long)]
+        slack: bool,
+    },
     /// List workflow run history for a repository
     Runs {
         /// Repository slug

--- a/conductor-cli/src/handlers/workflow.rs
+++ b/conductor-cli/src/handlers/workflow.rs
@@ -55,6 +55,47 @@ pub fn handle_workflow(
     }
 
     match command {
+        WorkflowCommands::Active { slack } => {
+            let wf_mgr = WorkflowManager::new(conn);
+            let runs = wf_mgr.list_active_workflow_runs(&[])?;
+
+            if runs.is_empty() {
+                let msg = "No active workflow runs.";
+                println!("{msg}");
+                if slack {
+                    conductor_core::notify::send_slack_sync(&config.notifications, msg)?;
+                    println!("Posted to Slack.");
+                }
+            } else {
+                let mut lines = vec![format!("*Active workflow runs ({})* ", runs.len())];
+                for run in &runs {
+                    let label = run.target_label.as_deref().unwrap_or("-");
+                    let since = &run.started_at[..16.min(run.started_at.len())];
+                    lines.push(format!(
+                        "• *{}* on `{}` — {} (since {})",
+                        run.workflow_name, label, run.status, since
+                    ));
+                }
+                let summary = lines.join("\n");
+
+                // Print to terminal
+                for run in &runs {
+                    let label = run.target_label.as_deref().unwrap_or("-");
+                    let since = &run.started_at[..16.min(run.started_at.len())];
+                    println!(
+                        "  {:<26}  {:<30}  {:<10}  {label} ({since})",
+                        &run.id[..26.min(run.id.len())],
+                        run.workflow_name,
+                        run.status,
+                    );
+                }
+
+                if slack {
+                    conductor_core::notify::send_slack_sync(&config.notifications, &summary)?;
+                    println!("Posted to Slack.");
+                }
+            }
+        }
         WorkflowCommands::Runs { repo, worktree } => {
             let repo_mgr = RepoManager::new(conn, config);
             let r = repo_mgr.get_by_slug(&repo)?;

--- a/conductor-core/src/notify.rs
+++ b/conductor-core/src/notify.rs
@@ -44,6 +44,34 @@ fn maybe_send_slack(config: &NotificationConfig, text: &str) {
     }
 }
 
+/// Send a message to the configured Slack webhook synchronously.
+///
+/// Returns `Ok(())` if sent, or an error if Slack is not configured or the
+/// request failed. Unlike `maybe_send_slack` this blocks until delivery
+/// completes, which is appropriate for CLI commands that exit immediately.
+pub fn send_slack_sync(config: &NotificationConfig, text: &str) -> crate::error::Result<()> {
+    let url = config
+        .slack
+        .webhook_url
+        .as_deref()
+        .filter(|u| !u.is_empty())
+        .ok_or_else(|| {
+            crate::error::ConductorError::Config(
+                "Slack webhook_url is not configured in ~/.conductor/config.toml".to_string(),
+            )
+        })?;
+    let escaped = escape_slack_mrkdwn(text);
+    let body = serde_json::json!({ "text": escaped });
+    let agent = ureq::AgentBuilder::new()
+        .timeout(std::time::Duration::from_secs(10))
+        .build();
+    agent
+        .post(url)
+        .send_json(&body)
+        .map_err(|e| crate::error::ConductorError::Config(format!("Slack webhook failed: {e}")))?;
+    Ok(())
+}
+
 /// Persist an in-app notification record. Logs a warning on failure.
 fn persist_notification(conn: &rusqlite::Connection, params: &CreateNotification<'_>) {
     let mgr = NotificationManager::new(conn);

--- a/conductor-core/src/vantage.rs
+++ b/conductor-core/src/vantage.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::process::Command;
 
 use rusqlite::Connection;
@@ -51,10 +52,13 @@ pub fn sync_vantage_deliverables(
             tracing::debug!("Vantage sync: skipping {id} (codebase={codebase:?} != {repo_slug:?})");
             continue;
         }
-        // Only sync conductor-mode deliverables in actionable pipeline states
-        let exec_mode = item["execution_mode"].as_str().unwrap_or("");
-        let conductor_status = item["conductor"]["status"].as_str().unwrap_or("");
-        if exec_mode != "conductor" || !ACTIONABLE_CONDUCTOR_STATUSES.contains(&conductor_status) {
+        // Only sync conductor-mode deliverables in actionable pipeline states.
+        // The sdlc CLI may not include these fields in JSON output, so fall back
+        // to reading the YAML frontmatter from the deliverable file directly.
+        let (exec_mode, conductor_status) = resolve_conductor_fields(item, id, sdlc_root);
+        if exec_mode != "conductor"
+            || !ACTIONABLE_CONDUCTOR_STATUSES.contains(&conductor_status.as_str())
+        {
             skipped_mode_or_status += 1;
             tracing::debug!(
                 "Vantage sync: skipping {id} (execution_mode={exec_mode:?}, conductor.status={conductor_status:?})"
@@ -119,6 +123,62 @@ pub fn fetch_vantage_deliverable(deliverable_id: &str, sdlc_root: &str) -> Resul
     }
 
     Ok(parse_vantage_deliverable(&value))
+}
+
+/// Resolve `execution_mode` and `conductor.status` for a deliverable.
+///
+/// First checks the CLI JSON output; if the fields are missing (the sdlc CLI
+/// may not serialize them), falls back to reading the YAML frontmatter from
+/// `{sdlc_root}/deliverables/{id}.md`.
+fn resolve_conductor_fields(
+    item: &serde_json::Value,
+    id: &str,
+    sdlc_root: &str,
+) -> (String, String) {
+    let exec_mode = item["execution_mode"].as_str().unwrap_or("").to_string();
+    let conductor_status = item["conductor"]["status"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+
+    if !exec_mode.is_empty() && !conductor_status.is_empty() {
+        return (exec_mode, conductor_status);
+    }
+
+    // Fall back to reading the deliverable file frontmatter directly.
+    let file_path = Path::new(sdlc_root)
+        .join("deliverables")
+        .join(format!("{id}.md"));
+    match std::fs::read_to_string(&file_path) {
+        Ok(contents) => {
+            parse_conductor_frontmatter(&contents).unwrap_or((exec_mode, conductor_status))
+        }
+        Err(e) => {
+            tracing::debug!("Vantage sync: could not read {}: {e}", file_path.display());
+            (exec_mode, conductor_status)
+        }
+    }
+}
+
+/// Extract `execution_mode` and `conductor.status` from YAML frontmatter.
+///
+/// Expects `---` delimited frontmatter at the start of the file.
+fn parse_conductor_frontmatter(contents: &str) -> Option<(String, String)> {
+    let trimmed = contents.trim_start();
+    if !trimmed.starts_with("---") {
+        return None;
+    }
+    let after_open = &trimmed[3..];
+    let end = after_open.find("\n---")?;
+    let frontmatter = &after_open[..end];
+
+    let yaml: serde_json::Value = serde_yml::from_str(frontmatter).ok()?;
+    let exec_mode = yaml["execution_mode"].as_str().unwrap_or("").to_string();
+    let conductor_status = yaml["conductor"]["status"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    Some((exec_mode, conductor_status))
 }
 
 /// Run the `sdlc` CLI with the given arguments, optionally setting --sdlc-root.
@@ -835,6 +895,40 @@ mod tests {
     fn test_map_vantage_status_unknown_defaults_to_open() {
         assert_eq!(map_vantage_status("something_else"), "open");
         assert_eq!(map_vantage_status(""), "open");
+    }
+
+    #[test]
+    fn test_parse_conductor_frontmatter_full() {
+        let md =
+            "---\nid: D-136\nexecution_mode: conductor\nconductor:\n  status: ready\n---\n# Body";
+        let (em, cs) = parse_conductor_frontmatter(md).unwrap();
+        assert_eq!(em, "conductor");
+        assert_eq!(cs, "ready");
+    }
+
+    #[test]
+    fn test_parse_conductor_frontmatter_missing_fields() {
+        let md = "---\nid: D-001\nstatus: draft\n---\n# Body";
+        let (em, cs) = parse_conductor_frontmatter(md).unwrap();
+        assert_eq!(em, "");
+        assert_eq!(cs, "");
+    }
+
+    #[test]
+    fn test_parse_conductor_frontmatter_no_frontmatter() {
+        let md = "# Just a heading\nNo frontmatter here.";
+        assert!(parse_conductor_frontmatter(md).is_none());
+    }
+
+    #[test]
+    fn test_resolve_conductor_fields_from_json() {
+        let item = serde_json::json!({
+            "execution_mode": "conductor",
+            "conductor": { "status": "ready" }
+        });
+        let (em, cs) = resolve_conductor_fields(&item, "D-001", "/nonexistent");
+        assert_eq!(em, "conductor");
+        assert_eq!(cs, "ready");
     }
 
     #[test]

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -9,9 +9,9 @@ use conductor_core::error::ConductorError;
 use conductor_core::feature::FeatureManager;
 use conductor_core::github;
 use conductor_core::github_app;
-use conductor_core::issue_source::{GitHubConfig, IssueSourceManager, JiraConfig};
-use conductor_core::jira_acli;
+use conductor_core::issue_source::IssueSourceManager;
 use conductor_core::repo::RepoManager;
+use conductor_core::ticket_source::TicketSource;
 use conductor_core::tickets::{TicketInput, TicketSyncer};
 use conductor_core::worktree::WorktreeManager;
 
@@ -658,36 +658,19 @@ fn sync_sources_for_repo(
         }
     } else {
         for source in sources {
-            match source.source_type.as_str() {
-                "github" => {
-                    let action = match serde_json::from_str::<GitHubConfig>(&source.config_json) {
-                        Ok(cfg) => sync_repo(syncer, repo_id, repo_slug, "github", || {
-                            github::sync_github_issues(&cfg.owner, &cfg.repo, token)
-                        }),
-                        Err(e) => Action::TicketSyncFailed {
-                            repo_slug: repo_slug.to_string(),
-                            error: format!("invalid github config: {e}"),
-                        },
-                    };
-                    if !tx.send(action) {
-                        return false;
-                    }
+            let action = match TicketSource::from_issue_source(&source) {
+                Ok(ts) => {
+                    let ts = ts.with_repo_slug(repo_slug);
+                    let source_type = ts.source_type_str();
+                    sync_repo(syncer, repo_id, repo_slug, source_type, || ts.sync(token))
                 }
-                "jira" => {
-                    let action = match serde_json::from_str::<JiraConfig>(&source.config_json) {
-                        Ok(cfg) => sync_repo(syncer, repo_id, repo_slug, "jira", || {
-                            jira_acli::sync_jira_issues_acli(&cfg.jql, &cfg.url)
-                        }),
-                        Err(e) => Action::TicketSyncFailed {
-                            repo_slug: repo_slug.to_string(),
-                            error: format!("invalid jira config: {e}"),
-                        },
-                    };
-                    if !tx.send(action) {
-                        return false;
-                    }
-                }
-                _ => {}
+                Err(e) => Action::TicketSyncFailed {
+                    repo_slug: repo_slug.to_string(),
+                    error: format!("unsupported source type {:?}: {e}", source.source_type),
+                },
+            };
+            if !tx.send(action) {
+                return false;
             }
         }
     }

--- a/conductor-web/src/routes/mod.rs
+++ b/conductor-web/src/routes/mod.rs
@@ -8,6 +8,7 @@ pub mod model_config;
 pub mod notifications;
 pub mod push;
 pub mod repos;
+pub mod slack;
 pub mod stats;
 pub mod tickets;
 pub mod workflows;
@@ -319,6 +320,8 @@ pub fn api_router() -> Router<AppState> {
             "/api/push/subscribe",
             post(push::subscribe_push).delete(push::unsubscribe_push),
         )
+        // Slack slash commands
+        .route("/api/slack/commands", post(slack::handle_slash_command))
         // Model Config
         .route(
             "/api/config/model",

--- a/conductor-web/src/routes/slack.rs
+++ b/conductor-web/src/routes/slack.rs
@@ -1,0 +1,97 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Form;
+use serde::{Deserialize, Serialize};
+
+use conductor_core::workflow::{WorkflowManager, WorkflowRunStatus};
+
+use crate::state::AppState;
+
+/// Slack sends slash command payloads as application/x-www-form-urlencoded.
+#[derive(Debug, Deserialize)]
+pub struct SlackSlashCommand {
+    pub command: Option<String>,
+    pub text: Option<String>,
+    #[allow(dead_code)]
+    pub response_url: Option<String>,
+    #[allow(dead_code)]
+    pub user_name: Option<String>,
+}
+
+/// Slack expects a JSON response with a `text` field (and optional `response_type`).
+#[derive(Serialize)]
+struct SlackResponse {
+    response_type: &'static str,
+    text: String,
+}
+
+/// Handle Slack slash commands.
+///
+/// Supports:
+///   /conductor active   — list active workflow runs
+///   /conductor help     — show available commands
+pub async fn handle_slash_command(
+    State(state): State<AppState>,
+    Form(payload): Form<SlackSlashCommand>,
+) -> impl IntoResponse {
+    let subcommand = payload.text.as_deref().unwrap_or("").trim();
+
+    let response = match subcommand.split_whitespace().next().unwrap_or("help") {
+        "active" => handle_active(&state).await,
+        _ => SlackResponse {
+            response_type: "ephemeral",
+            text: concat!(
+                "*Available commands:*\n",
+                "• `/conductor active` — list active workflow runs\n",
+                "• `/conductor help` — show this message",
+            )
+            .to_string(),
+        },
+    };
+
+    (StatusCode::OK, axum::Json(response))
+}
+
+async fn handle_active(state: &AppState) -> SlackResponse {
+    let db = state.db.lock().await;
+    let wf_mgr = WorkflowManager::new(&db);
+
+    let runs = match wf_mgr.list_active_workflow_runs(&[]) {
+        Ok(r) => r,
+        Err(e) => {
+            return SlackResponse {
+                response_type: "ephemeral",
+                text: format!("Error querying workflows: {e}"),
+            };
+        }
+    };
+
+    if runs.is_empty() {
+        return SlackResponse {
+            response_type: "in_channel",
+            text: "No active workflow runs.".to_string(),
+        };
+    }
+
+    let mut lines = vec![format!("*Active workflow runs ({}):*", runs.len())];
+    for run in &runs {
+        let label = run.target_label.as_deref().unwrap_or("-");
+        let since = &run.started_at[..16.min(run.started_at.len())];
+        let status_emoji = match run.status {
+            WorkflowRunStatus::Running => ":arrows_counterclockwise:",
+            WorkflowRunStatus::Waiting => ":hourglass_flowing_sand:",
+            WorkflowRunStatus::Pending => ":clock3:",
+            _ => ":grey_question:",
+        };
+        lines.push(format!(
+            "{status_emoji} *{}* on `{label}` — {} (since {since})",
+            run.workflow_name, run.status,
+        ));
+    }
+
+    SlackResponse {
+        response_type: "in_channel",
+        text: lines.join("\n"),
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix TUI/Desktop Vantage sync** — Vantage ticket sources were silently ignored in the TUI background sync. Replaced manual `match` dispatch with `TicketSource::from_issue_source()` + `with_repo_slug()`. Unknown source types now surface errors instead of being silently dropped.
- **Vantage frontmatter fallback** — The `sdlc` CLI omits `execution_mode` and `conductor.status` from JSON output. Added fallback to read these fields directly from the deliverable `.md` file's YAML frontmatter.
- **`conductor workflow active` CLI command** — Lists active (pending/running/waiting) workflow runs across all repos. `--slack` flag posts the summary to the configured Slack webhook.
- **Slack slash command endpoint** — `POST /api/slack/commands` in conductor-web handles `/conductor active` and `/conductor help` from Slack.
- **`send_slack_sync()`** — Synchronous Slack delivery for CLI contexts where fire-and-forget threads would exit before delivery.

Rebased cleanly onto current main. Supersedes #1778.

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy -p conductor-core -p conductor-tui -p conductor-cli -p conductor-web -- -D warnings` clean
- [x] `cargo build` succeeds across all 4 crates
- [x] Slack slash command endpoint tested via curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)