### PR TITLE
fix(tui): eliminate ticket graph flicker with deterministic sibling sort

### DIFF
--- a/conductor-tui/src/ui/graph.rs
+++ b/conductor-tui/src/ui/graph.rs
@@ -186,7 +186,9 @@ impl<N> GraphData<N> {
                 layer_nodes.sort_by(|a, b| {
                     let ba = barycenters.get(a).copied().unwrap_or(0.0);
                     let bb = barycenters.get(b).copied().unwrap_or(0.0);
-                    ba.partial_cmp(&bb).unwrap_or(std::cmp::Ordering::Equal)
+                    ba.partial_cmp(&bb)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then_with(|| a.cmp(b))
                 });
             }
             for (pos, &node) in layer_nodes.iter().enumerate() {


### PR DESCRIPTION
## Problem

Sibling tickets in the dependency graph flicker — their vertical ordering shifts on every render frame.

**Root cause:** `compute_layers()` is called on every render frame (not cached). It populates each layer by iterating a `HashSet`, whose order is non-deterministic. Sibling tickets that share a parent all get the same barycenter value (average of their shared parent's position), so `sort_by` has no way to order them and leaves them in whatever random order the HashSet produced. Since that order changes frame-to-frame, the layout flickers.

## Fix

Add a node-ID tie-breaker to the barycenter sort:

```rust
ba.partial_cmp(&bb)
    .unwrap_or(std::cmp::Ordering::Equal)
    .then_with(|| a.cmp(b))  // ← break ties by ULID for stable ordering
```

When barycenters are equal, siblings are now sorted by their ULID (which is deterministic), producing a stable layout across frames.

## Test plan

- [ ] Open the dependency graph with sibling tickets (tickets sharing a parent or a common blocker) and confirm no flickering
- [ ] Navigate the graph with h/j/k/l — node positions stay stable
- [ ] `cargo clippy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)