### PR TITLE
docs(rfc-009): close RFC and move to closed directory

### DIFF
--- a/docs/rfc/closed/009-ticket-dependency-graph.md
+++ b/docs/rfc/closed/009-ticket-dependency-graph.md
@@ -1,6 +1,6 @@
 # RFC 009: Ticket Dependency Graph
 
-**Status:** Partially Implemented — workflow engine primitives deferred to [RFC 010](010-for-each-ticket-workflow-step.md)
+**Status:** Closed — remaining workflow engine primitives tracked in [RFC 010](../open/010-for-each-ticket-workflow-step.md)
 **Date:** 2026-04-01
 **Author:** Devin
 


### PR DESCRIPTION
## Summary

- Moves RFC 009 (Ticket Dependency Graph) from `docs/rfc/open/` to `docs/rfc/closed/`
- Updates status header to reflect closure
- Updates relative link to RFC 010 to reflect new path

All checkboxes in the RFC were complete. The two remaining open items (`foreach` step type and Vantage blocking relationships) are tracked in RFC 010 / #1743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)