### PR TITLE
docs(rfc): close RFC 001 and RFC 011

### DIFF
--- a/docs/rfc/closed/001-communication-obligation-tracker.md
+++ b/docs/rfc/closed/001-communication-obligation-tracker.md
@@ -1,6 +1,6 @@
 # RFC 001: Communication Obligation Tracker
 
-**Status:** Draft
+**Status:** Closed (out of scope — describes a separate tool, not conductor-ai)
 **Date:** 2026-03-10
 **Author:** Devin
 

--- a/docs/rfc/closed/011-notification-hooks.md
+++ b/docs/rfc/closed/011-notification-hooks.md
@@ -1,6 +1,6 @@
 # RFC 011: Notification Hooks
 
-**Status:** Draft
+**Status:** Implemented
 **Date:** 2026-04-07
 **Author:** Devin
 


### PR DESCRIPTION
## Summary

- **RFC 001 (Communication Obligation Tracker)** → closed as out of scope. The RFC describes a separate tool (a personal comms obligation tracker), not conductor-ai. Its own recommendation was to build it as a separate product.
- **RFC 011 (Notification Hooks)** → closed as implemented. `HookRunner` is wired into `dispatch_notification()`, the Slack sender is removed from conductor-core, and `HookConfig` is parsed from `[[notify.hooks]]` in config.

## Test plan

- [ ] Verify `docs/rfc/closed/` contains both files with updated status fields
- [ ] Verify `docs/rfc/open/` no longer contains RFC 001 or RFC 011

🤖 Generated with [Claude Code](https://claude.com/claude-code)