### PR TITLE
fix(docs): add missing conductor-desktop to crate count

### DIFF
--- a/.conductor/agents/rt-testing-integration.md
+++ b/.conductor/agents/rt-testing-integration.md
@@ -3,7 +3,7 @@ role: reviewer
 model: claude-sonnet-4-6
 ---
 
-You are an integration test reviewer for a Rust workspace (conductor-ai) with four crates: conductor-core, conductor-cli, conductor-tui, conductor-web.
+You are an integration test reviewer for a Rust workspace (conductor-ai) with five crates: conductor-core, conductor-cli, conductor-tui, conductor-web, conductor-desktop.
 
 Prior step context: {{prior_context}}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,12 +36,13 @@ git config core.hooksPath .githooks
 
 ### Workspace Layout
 
-Four crates in a Cargo workspace:
+Five crates in a Cargo workspace:
 
 - **conductor-core** — Library crate with all domain logic. Everything lives here.
 - **conductor-cli** — Thin binary wrapping core with clap subcommands.
 - **conductor-tui** — TUI binary using ratatui + crossterm.
 - **conductor-web** — Web UI binary using axum + React (Vite + Tailwind frontend embedded via `rust_embed`).
+- **conductor-desktop** — Native macOS desktop app using Tauri v2 (wraps conductor-web).
 
 ### Library-First (v1)
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ For full details on the DSL grammar, constructs, structured output, and design t
 
 ## Architecture
 
-Four crates in a Cargo workspace:
+Five crates in a Cargo workspace:
 
 | Crate | Role |
 |---|---|
@@ -147,6 +147,7 @@ Four crates in a Cargo workspace:
 | **conductor-cli** | Thin CLI binary using clap |
 | **conductor-tui** | Terminal UI using ratatui + crossterm |
 | **conductor-web** | Web UI using axum + React (Vite + Tailwind, embedded via `rust_embed`) |
+| **conductor-desktop** | Native macOS desktop app using Tauri v2 |
 
 Data lives in `~/.conductor/` — a single SQLite database and per-repo worktree directories. No daemon or background process; the CLI and TUI link directly against `conductor-core`.
 


### PR DESCRIPTION
## Summary

- `README.md`, `CLAUDE.md`, and `.conductor/agents/rt-testing-integration.md` all said "four crates" and omitted `conductor-desktop` (the Tauri v2 native macOS app) from the workspace layout.
- Updated count to five and added the missing crate entry in each place.

## Test plan

- [ ] `README.md` Architecture section lists all five crates
- [ ] `CLAUDE.md` Workspace Layout section lists all five crates
- [ ] `rt-testing-integration.md` agent prompt references all five crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)