### PR TITLE
docs(rfc-016): close headless agent execution — implemented in v0.3.0

### DIFF
--- a/docs/rfc/closed/016-headless-agent-execution.md
+++ b/docs/rfc/closed/016-headless-agent-execution.md
@@ -1,8 +1,11 @@
 # RFC 016: Headless Agent Execution
 
-**Status:** Draft
+**Status:** Implemented
 **Date:** 2026-04-10
+**Closed:** 2026-04-12
 **Author:** Devin
+
+**Implementation:** Shipped in v0.3.0 (#1993). All tmux-based agent spawning replaced with headless subprocess infrastructure. `HeadlessHandle`, `spawn_headless()`, `drain_stream_json()`, PID-based orphan detection, SIGTERM cancellation, and SSE streaming to the web UI all landed as designed. The orphan reaper was subsequently simplified in v0.3.1 (#1992) once direct subprocess lifecycle ownership made tmux window checks redundant.
 
 ---
 


### PR DESCRIPTION
## Summary

- Moves RFC 016 from `docs/rfc/open/` → `docs/rfc/closed/`
- Updates status from `Draft` → `Implemented`
- Adds implementation note referencing the PRs that shipped it

## Implementation record

The headless subprocess infrastructure landed across v0.3.0 and v0.3.1:

- **#1993 (v0.3.0)** — core implementation: `HeadlessHandle`, `spawn_headless()`, `drain_stream_json()`, PID tracking, SIGTERM cancellation, SSE streaming to web UI, prompt file cleanup in temp dir
- **#1992 (v0.3.1)** — orphan reaper simplified now that direct subprocess ownership makes tmux window checks redundant
- **#2037, #2048 (v0.3.1)** — `HeadlessHandle` fields made private; `from_child()` / `into_drain_parts()` API locked down to prevent drain deadlock regression

All design goals from the RFC were met. No open questions remain that block closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)