### PR TITLE
fix: use RustEmbed derive for rust_embed v8 compatibility

### DIFF
--- a/conductor-web/src/assets.rs
+++ b/conductor-web/src/assets.rs
@@ -1,8 +1,8 @@
 use axum::http::{header, StatusCode, Uri};
 use axum::response::{Html, IntoResponse, Response};
-use rust_embed::Embed;
+use rust_embed::RustEmbed;
 
-#[derive(Embed)]
+#[derive(RustEmbed)]
 #[folder = "frontend/dist/"]
 struct Assets;
 


### PR DESCRIPTION
## Summary
- Fix `E0599: no function or associated item named 'get' found for struct 'Assets'` compile error
- The `Embed` derive macro doesn't implement the trait providing `get()` — `RustEmbed` is the correct derive in rust_embed v8

## Test plan
- [ ] `cargo build --bin conductor-web` compiles without errors
- [ ] CI passes (clippy + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)