### PR TITLE
fix: accept bare key-value shorthand in workflow parser

### DIFF
--- a/conductor-core/src/workflow_dsl/parser.rs
+++ b/conductor-core/src/workflow_dsl/parser.rs
@@ -239,7 +239,6 @@ impl Parser {
     fn parse_kvs(&mut self) -> std::result::Result<HashMap<String, KvValue>, String> {
         let mut kvs = HashMap::new();
         loop {
-            // Peek ahead: if it's an ident/keyword followed by '=', it's a kv.
             if self.pos + 1 < self.tokens.len() {
                 let is_kv_key = matches!(
                     self.peek(),
@@ -252,13 +251,34 @@ impl Parser {
                         | Token::Workflow
                         | Token::Inputs
                 );
-                let next_is_eq = self.tokens.get(self.pos + 1) == Some(&Token::Equals);
-                if is_kv_key && next_is_eq {
-                    let key = self.expect_ident()?;
-                    self.expect(&Token::Equals)?;
-                    let value = self.expect_value()?;
-                    kvs.insert(key, value);
-                    continue;
+
+                if is_kv_key {
+                    let next_is_eq = self.tokens.get(self.pos + 1) == Some(&Token::Equals);
+                    if next_is_eq {
+                        // Standard form: `key = value`
+                        let key = self.expect_ident()?;
+                        self.expect(&Token::Equals)?;
+                        let value = self.expect_value()?;
+                        kvs.insert(key, value);
+                        continue;
+                    }
+
+                    // Bare shorthand: `key value` (no `=`).
+                    // Allowed when the next token is a value literal (string, ident,
+                    // int, or array opener) but NOT a brace (which would be a block).
+                    let next_is_value = matches!(
+                        self.tokens.get(self.pos + 1),
+                        Some(Token::StringLit(_))
+                            | Some(Token::Ident(_))
+                            | Some(Token::Int(_))
+                            | Some(Token::LBracket)
+                    );
+                    if next_is_value {
+                        let key = self.expect_ident()?;
+                        let value = self.expect_value()?;
+                        kvs.insert(key, value);
+                        continue;
+                    }
                 }
             }
             break;
@@ -369,6 +389,12 @@ impl Parser {
                     self.advance();
                     self.expect(&Token::LBrace)?;
                     always.extend(self.parse_body()?);
+                }
+                // Allow an optional `body { ... }` wrapper for step nodes.
+                Token::Ident(ref s) if s == "body" => {
+                    self.advance();
+                    self.expect(&Token::LBrace)?;
+                    body.extend(self.parse_body()?);
                 }
                 _ => {
                     body.push(self.parse_node()?);

--- a/conductor-core/src/workflow_dsl/parser.rs
+++ b/conductor-core/src/workflow_dsl/parser.rs
@@ -253,7 +253,33 @@ impl Parser {
                 );
 
                 if is_kv_key {
-                    let next_is_eq = self.tokens.get(self.pos + 1) == Some(&Token::Equals);
+                    let next_token = self.tokens.get(self.pos + 1);
+                    let next_is_eq = next_token == Some(&Token::Equals);
+                    // Bare shorthand: `key value` (no `=`).
+                    // Allowed when the next token is a value literal (string, ident,
+                    // int, keyword, or array opener) but NOT a brace (which would be a block).
+                    let next_is_value = matches!(
+                        next_token,
+                        Some(Token::StringLit(_))
+                            | Some(Token::Ident(_))
+                            | Some(Token::Int(_))
+                            | Some(Token::LBracket)
+                            // Include all keyword tokens that are accepted by expect_value()
+                            | Some(Token::Required)
+                            | Some(Token::Default)
+                            | Some(Token::Description)
+                            | Some(Token::Boolean)
+                            | Some(Token::Call)
+                            | Some(Token::If)
+                            | Some(Token::Unless)
+                            | Some(Token::While)
+                            | Some(Token::Parallel)
+                            | Some(Token::Gate)
+                            | Some(Token::Always)
+                            | Some(Token::Script)
+                            | Some(Token::ForEach)
+                    );
+
                     if next_is_eq {
                         // Standard form: `key = value`
                         let key = self.expect_ident()?;
@@ -261,19 +287,7 @@ impl Parser {
                         let value = self.expect_value()?;
                         kvs.insert(key, value);
                         continue;
-                    }
-
-                    // Bare shorthand: `key value` (no `=`).
-                    // Allowed when the next token is a value literal (string, ident,
-                    // int, or array opener) but NOT a brace (which would be a block).
-                    let next_is_value = matches!(
-                        self.tokens.get(self.pos + 1),
-                        Some(Token::StringLit(_))
-                            | Some(Token::Ident(_))
-                            | Some(Token::Int(_))
-                            | Some(Token::LBracket)
-                    );
-                    if next_is_value {
+                    } else if next_is_value {
                         let key = self.expect_ident()?;
                         let value = self.expect_value()?;
                         kvs.insert(key, value);

--- a/conductor-core/src/workflow_dsl/parser.rs
+++ b/conductor-core/src/workflow_dsl/parser.rs
@@ -284,9 +284,9 @@ impl Parser {
                     // Bare shorthand: `key value` (no `=`).
                     // Allowed when the next token is a value literal (string, ident,
                     // int, keyword, or array opener) but NOT a brace (which would be a block).
-                    let next_is_value = next_token.is_some_and(|token|
+                    let next_is_value = next_token.is_some_and(|token| {
                         Self::is_value_token(token) && !matches!(token, Token::LBrace)
-                    );
+                    });
 
                     if next_is_eq || next_is_value {
                         let key = self.expect_ident()?;

--- a/conductor-core/src/workflow_dsl/parser.rs
+++ b/conductor-core/src/workflow_dsl/parser.rs
@@ -154,6 +154,32 @@ impl Parser {
         }
     }
 
+    /// Check if the given token can be used as a value in KV pairs
+    fn is_value_token(token: &Token) -> bool {
+        matches!(
+            token,
+            Token::StringLit(_)
+                | Token::Int(_)
+                | Token::Ident(_)
+                | Token::LBracket
+                | Token::LBrace
+                // Keyword tokens that are accepted as values
+                | Token::Required
+                | Token::Default
+                | Token::Description
+                | Token::Boolean
+                | Token::Call
+                | Token::If
+                | Token::Unless
+                | Token::While
+                | Token::Parallel
+                | Token::Gate
+                | Token::Always
+                | Token::Script
+                | Token::ForEach
+        )
+    }
+
     fn expect_value(&mut self) -> std::result::Result<KvValue, String> {
         match self.advance() {
             Token::StringLit(s) => Ok(KvValue::Quoted(s)),
@@ -258,37 +284,17 @@ impl Parser {
                     // Bare shorthand: `key value` (no `=`).
                     // Allowed when the next token is a value literal (string, ident,
                     // int, keyword, or array opener) but NOT a brace (which would be a block).
-                    let next_is_value = matches!(
-                        next_token,
-                        Some(Token::StringLit(_))
-                            | Some(Token::Ident(_))
-                            | Some(Token::Int(_))
-                            | Some(Token::LBracket)
-                            // Include all keyword tokens that are accepted by expect_value()
-                            | Some(Token::Required)
-                            | Some(Token::Default)
-                            | Some(Token::Description)
-                            | Some(Token::Boolean)
-                            | Some(Token::Call)
-                            | Some(Token::If)
-                            | Some(Token::Unless)
-                            | Some(Token::While)
-                            | Some(Token::Parallel)
-                            | Some(Token::Gate)
-                            | Some(Token::Always)
-                            | Some(Token::Script)
-                            | Some(Token::ForEach)
+                    let next_is_value = next_token.is_some_and(|token|
+                        Self::is_value_token(token) && !matches!(token, Token::LBrace)
                     );
 
-                    if next_is_eq {
-                        // Standard form: `key = value`
+                    if next_is_eq || next_is_value {
                         let key = self.expect_ident()?;
-                        self.expect(&Token::Equals)?;
-                        let value = self.expect_value()?;
-                        kvs.insert(key, value);
-                        continue;
-                    } else if next_is_value {
-                        let key = self.expect_ident()?;
+                        if next_is_eq {
+                            // Standard form: `key = value`
+                            self.expect(&Token::Equals)?;
+                        }
+                        // Bare shorthand: `key value` (no `=`) or standard form after consuming `=`
                         let value = self.expect_value()?;
                         kvs.insert(key, value);
                         continue;

--- a/conductor-core/src/workflow_dsl/tests/parser_basic_tests.rs
+++ b/conductor-core/src/workflow_dsl/tests/parser_basic_tests.rs
@@ -626,6 +626,34 @@ workflow bare-kv-test {
     assert_eq!(def.trigger, WorkflowTrigger::Manual);
     assert_eq!(def.targets, vec!["worktree"]);
     assert_eq!(def.body.len(), 2);
+
+    // The test verifies that step-level bare KV parsing works without syntax errors
+    // (e.g., `description "Plan the work"` in the call step)
+}
+
+#[test]
+fn test_bare_kv_with_integer_values() {
+    // Test bare `key integer` syntax for numeric values
+    let src = r#"
+workflow bare-int-test {
+  meta {
+    description "Test integer bare KV"
+    trigger     manual
+    targets     ["worktree"]
+  }
+
+  call build {
+    description "Build with retries"
+    retries 3
+    timeout 300
+  }
+}
+"#;
+    let def = parse_workflow_str(src, "test.wf").unwrap();
+
+    // This test verifies that Token::Int bare-KV syntax works (e.g., `retries 3`, `timeout 300`)
+    // The successful parsing without syntax errors confirms the feature works
+    assert_eq!(def.body.len(), 1);
 }
 
 #[test]

--- a/conductor-core/src/workflow_dsl/tests/parser_basic_tests.rs
+++ b/conductor-core/src/workflow_dsl/tests/parser_basic_tests.rs
@@ -632,28 +632,38 @@ workflow bare-kv-test {
 }
 
 #[test]
-fn test_bare_kv_with_integer_values() {
-    // Test bare `key integer` syntax for numeric values
+fn test_bare_kv_with_keyword_values() {
+    // Test bare `key keyword` syntax for keyword token values
     let src = r#"
-workflow bare-int-test {
+workflow bare-keyword-test {
   meta {
-    description "Test integer bare KV"
+    description "Test keyword bare KV"
     trigger     manual
     targets     ["worktree"]
   }
 
   call build {
-    description "Build with retries"
-    retries 3
-    timeout 300
+    description "Build with keyword values"
+    mode parallel
+    type call
+    state required
   }
 }
 "#;
     let def = parse_workflow_str(src, "test.wf").unwrap();
 
-    // This test verifies that Token::Int bare-KV syntax works (e.g., `retries 3`, `timeout 300`)
-    // The successful parsing without syntax errors confirms the feature works
+    // This test verifies that keyword tokens can be used as bare values
+    // The successful parsing without syntax errors demonstrates that keyword tokens
+    // like 'parallel', 'call', and 'required' are now accepted as bare values
     assert_eq!(def.body.len(), 1);
+
+    // Verify the call node was parsed successfully
+    match &def.body[0] {
+        WorkflowNode::Call(_) => {
+            // Test passes if parsing succeeds - the keyword tokens were accepted as values
+        }
+        _ => panic!("Expected call node"),
+    }
 }
 
 #[test]

--- a/conductor-core/src/workflow_dsl/tests/parser_basic_tests.rs
+++ b/conductor-core/src/workflow_dsl/tests/parser_basic_tests.rs
@@ -598,3 +598,53 @@ workflow my-wf {
     let def = parse_workflow_str(input, "test.wf").unwrap();
     assert_eq!(def.display_name(), "my-wf");
 }
+
+#[test]
+fn test_bare_kv_shorthand_without_equals() {
+    // Bare `key value` syntax (without `=`) should be accepted in meta and step blocks.
+    let src = r#"
+workflow bare-kv-test {
+  meta {
+    description "A bare description"
+    trigger     manual
+    targets     ["worktree"]
+  }
+
+  call plan {
+    description "Plan the work"
+    retries = 1
+  }
+
+  script fmt {
+    description "Run formatter"
+    run = ".conductor/scripts/fmt.sh"
+  }
+}
+"#;
+    let def = parse_workflow_str(src, "test.wf").unwrap();
+    assert_eq!(def.description, "A bare description");
+    assert_eq!(def.trigger, WorkflowTrigger::Manual);
+    assert_eq!(def.targets, vec!["worktree"]);
+    assert_eq!(def.body.len(), 2);
+}
+
+#[test]
+fn test_body_wrapper_block() {
+    // An explicit `body { ... }` wrapper around step nodes should be accepted.
+    let src = r#"
+workflow body-wrapper {
+  meta {
+    description = "Test body block"
+    trigger     = "manual"
+    targets     = ["worktree"]
+  }
+
+  body {
+    call plan
+    call implement
+  }
+}
+"#;
+    let def = parse_workflow_str(src, "test.wf").unwrap();
+    assert_eq!(def.body.len(), 2);
+}


### PR DESCRIPTION
## Summary
- The workflow DSL parser only accepted `key = "value"` syntax. Workflows using bare shorthand (`description "text"`, `trigger manual`, `targets ["worktree"]`) silently failed to parse and were invisible in the UI sidebar.
- Extends `parse_kvs` to accept `key value` without `=` when followed by a string literal, ident, int, or array
- Accepts optional `body { ... }` wrapper block in workflow definitions
- Fixes 6 docs-pipeline workflows that were hidden from the desktop app

## Test plan
- [x] All 222 workflow_dsl tests pass (220 existing + 2 new regression tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Verified docs-pipeline `ticket-to-pr.wf` now parses successfully via `workflow validate --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)