### PR TITLE
fix: sync terminal Vantage deliverables as closed tickets

### DIFF
--- a/conductor-core/src/vantage.rs
+++ b/conductor-core/src/vantage.rs
@@ -22,6 +22,9 @@ const ACTIONABLE_CONDUCTOR_STATUSES: &[&str] = &[
 
 /// Terminal conductor statuses that are synced as closed tickets so that
 /// `close_missing_tickets` can reconcile stale DB rows.
+///
+/// Keep in sync with `VANTAGE_APPROVED_STATUSES` in
+/// `conductor-web/frontend/src/utils/ticketDeps.ts`.
 const TERMINAL_CONDUCTOR_STATUSES: &[&str] = &["merged", "pr_approved", "released"];
 
 /// Sync deliverables from a Vantage SDLC project, filtered to those whose
@@ -770,6 +773,40 @@ mod tests {
                 assert!(tickets[0].labels.contains(&"my-repo".to_string()));
                 assert!(tickets[0].labels.contains(&"feature".to_string()));
             });
+        }
+
+        #[test]
+        fn test_sync_terminal_conductor_status_synced_as_closed() {
+            // Regression: deliverables with terminal conductor.status (pr_approved,
+            // merged, released) must be returned with state="closed" so that
+            // close_missing_tickets can reconcile stale DB rows.
+            // Mirrors TERMINAL_CONDUCTOR_STATUSES and VANTAGE_APPROVED_STATUSES in
+            // conductor-web/frontend/src/utils/ticketDeps.ts.
+            for terminal_status in &["pr_approved", "merged", "released"] {
+                let list = serde_json::json!([
+                    {
+                        "id": "D-T01", "title": "Terminal", "status": "complete",
+                        "codebase": "my-repo",
+                        "execution_mode": "conductor",
+                        "conductor": { "status": terminal_status },
+                        "body": "some body",
+                    },
+                ]);
+                let dir = tempfile::tempdir().unwrap();
+                write_fake_sdlc(dir.path(), &format!("echo '{list}'"));
+                with_sdlc_on_path(dir.path(), || {
+                    let tickets = sync_vantage_deliverables("PROJ-1", "", "my-repo").unwrap();
+                    assert_eq!(
+                        tickets.len(),
+                        1,
+                        "terminal status={terminal_status} should be included (as closed)"
+                    );
+                    assert_eq!(
+                        tickets[0].state, "closed",
+                        "terminal conductor.status={terminal_status} must produce state=closed"
+                    );
+                });
+            }
         }
 
         #[test]

--- a/conductor-core/src/vantage.rs
+++ b/conductor-core/src/vantage.rs
@@ -11,8 +11,14 @@ use crate::tickets::TicketInput;
 /// Conductor pipeline statuses that should be synced into Conductor as open
 /// tickets. Pre-ready states (pending_audit, audited, enriching) are excluded —
 /// those deliverables aren't actionable yet.
-const ACTIONABLE_CONDUCTOR_STATUSES: &[&str] =
-    &["ready", "dispatched", "running", "in_progress", "completed", "failed"];
+const ACTIONABLE_CONDUCTOR_STATUSES: &[&str] = &[
+    "ready",
+    "dispatched",
+    "running",
+    "in_progress",
+    "completed",
+    "failed",
+];
 
 /// Terminal conductor statuses that are synced as closed tickets so that
 /// `close_missing_tickets` can reconcile stale DB rows.

--- a/conductor-core/src/vantage.rs
+++ b/conductor-core/src/vantage.rs
@@ -8,11 +8,15 @@ use crate::error::{ConductorError, Result};
 use crate::issue_source::{IssueSourceManager, VantageConfig};
 use crate::tickets::TicketInput;
 
-/// Conductor pipeline statuses that should be synced into Conductor.
-/// Pre-ready states (pending_audit, audited, enriching) are excluded —
+/// Conductor pipeline statuses that should be synced into Conductor as open
+/// tickets. Pre-ready states (pending_audit, audited, enriching) are excluded —
 /// those deliverables aren't actionable yet.
 const ACTIONABLE_CONDUCTOR_STATUSES: &[&str] =
-    &["ready", "dispatched", "running", "completed", "failed"];
+    &["ready", "dispatched", "running", "in_progress", "completed", "failed"];
+
+/// Terminal conductor statuses that are synced as closed tickets so that
+/// `close_missing_tickets` can reconcile stale DB rows.
+const TERMINAL_CONDUCTOR_STATUSES: &[&str] = &["merged", "pr_approved", "released"];
 
 /// Sync deliverables from a Vantage SDLC project, filtered to those whose
 /// `codebase` field matches the given `repo_slug`.
@@ -56,13 +60,13 @@ pub fn sync_vantage_deliverables(
             tracing::debug!("Vantage sync: skipping {id} (codebase={codebase:?} != {repo_slug:?})");
             continue;
         }
-        // Only sync conductor-mode deliverables in actionable pipeline states.
-        // The sdlc CLI may not include these fields in JSON output, so fall back
-        // to the pre-loaded YAML frontmatter cache.
+        // Only sync conductor-mode deliverables in actionable or terminal pipeline
+        // states. The sdlc CLI may not include these fields in JSON output, so
+        // fall back to the pre-loaded YAML frontmatter cache.
         let (exec_mode, conductor_status) = resolve_conductor_fields(item, id, &frontmatter_cache);
-        if exec_mode != "conductor"
-            || !ACTIONABLE_CONDUCTOR_STATUSES.contains(&conductor_status.as_str())
-        {
+        let is_actionable = ACTIONABLE_CONDUCTOR_STATUSES.contains(&conductor_status.as_str());
+        let is_terminal = TERMINAL_CONDUCTOR_STATUSES.contains(&conductor_status.as_str());
+        if exec_mode != "conductor" || (!is_actionable && !is_terminal) {
             skipped_mode_or_status += 1;
             tracing::debug!(
                 "Vantage sync: skipping {id} (execution_mode={exec_mode:?}, conductor.status={conductor_status:?})"
@@ -72,7 +76,7 @@ pub fn sync_vantage_deliverables(
         let status = item["status"].as_str().unwrap_or("");
         tracing::debug!("Vantage sync: matched {id} (codebase={codebase:?}, status={status:?}, conductor.status={conductor_status:?})");
         // Use list data directly when body is present; fetch full detail only if missing.
-        let ticket = if item["body"].as_str().is_some_and(|b| !b.is_empty()) {
+        let mut ticket = if item["body"].as_str().is_some_and(|b| !b.is_empty()) {
             parse_vantage_deliverable(item)
         } else {
             match fetch_vantage_deliverable(id, sdlc_root) {
@@ -83,6 +87,11 @@ pub fn sync_vantage_deliverables(
                 }
             }
         };
+        // Terminal-state deliverables are synced as closed so that
+        // close_missing_tickets can reconcile the DB.
+        if is_terminal {
+            ticket.state = "closed".to_string();
+        }
         tickets.push(ticket);
     }
 

--- a/conductor-core/src/vantage.rs
+++ b/conductor-core/src/vantage.rs
@@ -292,7 +292,11 @@ fn notify_dispatched(deliverable_id: &str, sdlc_root: &str, workflow_run_id: &st
     Ok(())
 }
 
-/// Update Vantage conductor status to "completed" when a workflow succeeds.
+/// Update Vantage conductor status to "pr_approved" when a workflow succeeds.
+///
+/// The ticket-to-pr workflow completion means conductor has reviewed and approved
+/// the PR — the deliverable is ready for merge. This status is used by dependent
+/// tickets to determine when they are unblocked.
 fn notify_completed(
     deliverable_id: &str,
     sdlc_root: &str,
@@ -305,7 +309,7 @@ fn notify_completed(
         "set",
         "--",
         deliverable_id,
-        "conductor.status=completed",
+        "conductor.status=pr_approved",
     ];
     let completed_at = format!("conductor.completed_at={now}");
     args.push(&completed_at);
@@ -320,7 +324,7 @@ fn notify_completed(
         args.push(&wt_arg);
     }
     run_sdlc(sdlc_root, &args)?;
-    tracing::info!("Vantage: marked {deliverable_id} as completed");
+    tracing::info!("Vantage: marked {deliverable_id} as pr_approved");
     Ok(())
 }
 
@@ -430,7 +434,7 @@ impl VantageLifecycle {
         notify_dispatched(&self.deliverable_id, &self.sdlc_root, workflow_run_id)
     }
 
-    /// Notify Vantage that the workflow completed successfully (best-effort).
+    /// Notify Vantage that the workflow completed and the PR is approved (best-effort).
     pub fn on_completed(&self, pr_url: Option<&str>, worktree_slug: Option<&str>) -> Result<()> {
         notify_completed(&self.deliverable_id, &self.sdlc_root, pr_url, worktree_slug)
     }

--- a/conductor-web/frontend/src/utils/ticketDeps.ts
+++ b/conductor-web/frontend/src/utils/ticketDeps.ts
@@ -143,6 +143,7 @@ export function buildTicketTree(
 
   // Build a set of ticket IDs whose Vantage conductor.status is terminal/approved
   const vantagePrApproved = new Set<string>();
+  // Keep in sync with TERMINAL_CONDUCTOR_STATUSES in conductor-core/src/vantage.rs
   const VANTAGE_APPROVED_STATUSES = ["pr_approved", "merged", "released"];
   for (const t of tickets) {
     if (t.source_type !== "vantage") continue;

--- a/conductor-web/frontend/src/utils/ticketDeps.ts
+++ b/conductor-web/frontend/src/utils/ticketDeps.ts
@@ -38,7 +38,8 @@ export interface TicketTree {
  * - When `apiDeps` is provided (preferred), uses DB-backed dependency data for all
  *   source types. Falls back to Vantage `raw_json` parsing when `apiDeps` is absent.
  * - A ticket is "blocked" if any blocker in `blocked_by` is not closed.
- * - A blocked ticket is "unlocked" if every blocker has a PR with review_decision "APPROVED".
+ * - A blocked ticket is "unlocked" if every blocker has a GitHub PR with review_decision "APPROVED"
+ *   or (for Vantage tickets) a conductor.status of pr_approved/merged/released.
  * - Non-vantage tickets without apiDeps are always roots.
  */
 export function buildTicketTree(
@@ -136,36 +137,57 @@ export function buildTicketTree(
   // Roots: tickets that have no parent in the list
   const roots = tickets.filter((t) => !hasParentInList.has(t.source_id));
 
-  // Compute unlocked set: blocked tickets whose blocking parents all have approved PRs
+  // Compute unlocked set: blocked tickets whose blocking parents all have approved PRs.
+  // For Vantage tickets, conductor.status of pr_approved/merged/released also counts.
   const unlocked = new Set<string>();
-  if (worktrees?.length && prs?.length) {
-    // ticket_id → worktree branch
-    const wtBranchByTicketId = new Map<string, string>();
+
+  // Build a set of ticket IDs whose Vantage conductor.status is terminal/approved
+  const vantagePrApproved = new Set<string>();
+  const VANTAGE_APPROVED_STATUSES = ["pr_approved", "merged", "released"];
+  for (const t of tickets) {
+    if (t.source_type !== "vantage") continue;
+    try {
+      const raw = JSON.parse(t.raw_json);
+      const conductorStatus = raw?.conductor?.status ?? "";
+      if (VANTAGE_APPROVED_STATUSES.includes(conductorStatus)) {
+        vantagePrApproved.add(t.id);
+      }
+    } catch { /* skip */ }
+  }
+
+  // ticket_id → worktree branch (for GitHub PR lookup)
+  const wtBranchByTicketId = new Map<string, string>();
+  if (worktrees?.length) {
     for (const wt of worktrees) {
       if (wt.ticket_id) {
         wtBranchByTicketId.set(wt.ticket_id, wt.branch);
       }
     }
-    // branch → PR
-    const prByBranch = new Map<string, GithubPr>();
+  }
+  // branch → PR
+  const prByBranch = new Map<string, GithubPr>();
+  if (prs?.length) {
     for (const pr of prs) {
       prByBranch.set(pr.head_ref_name, pr);
     }
+  }
 
-    for (const ticketId of blocked) {
-      const parentIds = blockingParentIds.get(ticketId);
-      if (!parentIds?.length) continue;
+  for (const ticketId of blocked) {
+    const parentIds = blockingParentIds.get(ticketId);
+    if (!parentIds?.length) continue;
 
-      const allApproved = parentIds.every((parentId) => {
-        const branch = wtBranchByTicketId.get(parentId);
-        if (!branch) return false;
-        const pr = prByBranch.get(branch);
-        return pr?.review_decision === "APPROVED";
-      });
+    const allApproved = parentIds.every((parentId) => {
+      // Vantage conductor.status check
+      if (vantagePrApproved.has(parentId)) return true;
+      // GitHub PR review_decision check
+      const branch = wtBranchByTicketId.get(parentId);
+      if (!branch) return false;
+      const pr = prByBranch.get(branch);
+      return pr?.review_decision === "APPROVED";
+    });
 
-      if (allApproved) {
-        unlocked.add(ticketId);
-      }
+    if (allApproved) {
+      unlocked.add(ticketId);
     }
   }
 


### PR DESCRIPTION
## Summary
- Deliverables with `conductor.status` of `merged`/`pr_approved`/`released` were filtered out of the Vantage sync batch entirely, so `close_missing_tickets` never ran (empty-batch safety guard) and stale tickets stayed open in the DB forever
- Terminal-state deliverables are now included in the sync with `state="closed"`, allowing upsert to update them and `close_missing_tickets` to reconcile stale rows
- Adds `in_progress` to actionable conductor statuses

## Test plan
- [x] All 58 vantage tests pass
- [x] `cargo clippy` and `cargo fmt` clean
- [x] Verified `tickets sync docs` now correctly closes merged tickets (D-147/148/149/182/183 → closed, D-170 stays in_progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)