### PR TITLE
chore: explicitly set model for all agents, optimize haiku/sonnet split

### DIFF
--- a/.conductor/agents/address-reviews.md
+++ b/.conductor/agents/address-reviews.md
@@ -1,7 +1,7 @@
 ---
 role: actor
 can_commit: true
-model: claude-haiku-4-5
+model: claude-sonnet-4-6
 ---
 
 You are a software engineer. Your job is to resolve all outstanding PR review issues.

--- a/.conductor/agents/analyze-coverage.md
+++ b/.conductor/agents/analyze-coverage.md
@@ -1,5 +1,6 @@
 ---
 role: reviewer
+model: claude-sonnet-4-6
 ---
 
 You are a test coverage reviewer. Analyze the PR diff and codebase to identify functions, modules, or code paths that lack adequate test coverage.

--- a/.conductor/agents/analyze-file-structure.md
+++ b/.conductor/agents/analyze-file-structure.md
@@ -1,5 +1,6 @@
 ---
 role: reviewer
+model: claude-sonnet-4-6
 can_commit: false
 ---
 

--- a/.conductor/agents/analyze-per-persona.md
+++ b/.conductor/agents/analyze-per-persona.md
@@ -1,5 +1,6 @@
 ---
 role: reviewer
+model: claude-sonnet-4-6
 can_commit: false
 ---
 

--- a/.conductor/agents/analyze-postmortem.md
+++ b/.conductor/agents/analyze-postmortem.md
@@ -1,5 +1,6 @@
 ---
 role: reviewer
+model: claude-sonnet-4-6
 can_commit: false
 ---
 

--- a/.conductor/agents/assess-ticket-readiness.md
+++ b/.conductor/agents/assess-ticket-readiness.md
@@ -1,5 +1,6 @@
 ---
 role: reviewer
+model: claude-sonnet-4-6
 can_commit: false
 ---
 

--- a/.conductor/agents/diagnose-failure.md
+++ b/.conductor/agents/diagnose-failure.md
@@ -1,5 +1,6 @@
 ---
 role: reviewer
+model: claude-sonnet-4-6
 can_commit: false
 ---
 

--- a/.conductor/agents/draft-gh-issue.md
+++ b/.conductor/agents/draft-gh-issue.md
@@ -1,5 +1,6 @@
 ---
 role: actor
+model: claude-sonnet-4-6
 can_commit: false
 ---
 

--- a/.conductor/agents/extract-personas.md
+++ b/.conductor/agents/extract-personas.md
@@ -1,5 +1,6 @@
 ---
 role: actor
+model: claude-sonnet-4-6
 can_commit: true
 ---
 

--- a/.conductor/agents/file-ux-issues.md
+++ b/.conductor/agents/file-ux-issues.md
@@ -1,5 +1,6 @@
 ---
 role: actor
+model: claude-haiku-4-5
 can_commit: false
 ---
 

--- a/.conductor/agents/fix-ci-failures.md
+++ b/.conductor/agents/fix-ci-failures.md
@@ -1,7 +1,7 @@
 ---
 role: actor
 can_commit: true
-model: claude-haiku-4-5
+model: claude-sonnet-4-6
 ---
 
 You are a CI fix engineer. Your job is to check whether CI is passing for this PR, diagnose any failures, fix them, push, and confirm the checks go green.

--- a/.conductor/agents/generate-diagram-files.md
+++ b/.conductor/agents/generate-diagram-files.md
@@ -1,5 +1,6 @@
 ---
 role: actor
+model: claude-sonnet-4-6
 can_commit: true
 ---
 

--- a/.conductor/agents/identify-affected-diagrams.md
+++ b/.conductor/agents/identify-affected-diagrams.md
@@ -1,5 +1,6 @@
 ---
 role: reviewer
+model: claude-sonnet-4-6
 can_commit: false
 ---
 

--- a/.conductor/agents/implement.md
+++ b/.conductor/agents/implement.md
@@ -1,7 +1,7 @@
 ---
 role: actor
 can_commit: true
-model: claude-haiku-4-5
+model: claude-sonnet-4-6
 ---
 
 You are a software engineer. Your job is to implement the plan written in `PLAN.md`.

--- a/.conductor/agents/report-coverage.md
+++ b/.conductor/agents/report-coverage.md
@@ -1,5 +1,6 @@
 ---
 role: reviewer
+model: claude-haiku-4-5
 ---
 
 You are a reporter. Post a summary comment to the PR describing the outcome of the test coverage workflow.

--- a/.conductor/agents/report-open-questions.md
+++ b/.conductor/agents/report-open-questions.md
@@ -1,5 +1,6 @@
 ---
 role: reviewer
+model: claude-haiku-4-5
 can_commit: false
 ---
 

--- a/.conductor/agents/resolve-conflicts.md
+++ b/.conductor/agents/resolve-conflicts.md
@@ -1,7 +1,7 @@
 ---
 role: actor
 can_commit: true
-model: claude-haiku-4-5
+model: claude-sonnet-4-6
 ---
 
 You are a merge conflict resolution agent. The current branch has conflicts with main that need to be resolved before the PR can proceed.

--- a/.conductor/agents/review-db-migrations.md
+++ b/.conductor/agents/review-db-migrations.md
@@ -1,6 +1,6 @@
 ---
 role: reviewer
-model: claude-sonnet-4-6
+model: claude-haiku-4-5
 ---
 
 You are a database migration reviewer working on a Rust project using SQLite with WAL mode.

--- a/.conductor/agents/review-error-handling.md
+++ b/.conductor/agents/review-error-handling.md
@@ -1,6 +1,6 @@
 ---
 role: reviewer
-model: claude-sonnet-4-6
+model: claude-haiku-4-5
 ---
 
 You are an error-handling reviewer working on a Rust project.

--- a/.conductor/agents/review-test-coverage.md
+++ b/.conductor/agents/review-test-coverage.md
@@ -1,6 +1,6 @@
 ---
 role: reviewer
-model: claude-sonnet-4-6
+model: claude-haiku-4-5
 ---
 
 You are a test coverage reviewer working on a Rust project.

--- a/.conductor/agents/synthesize-repo-report.md
+++ b/.conductor/agents/synthesize-repo-report.md
@@ -1,5 +1,6 @@
 ---
 role: actor
+model: claude-sonnet-4-6
 can_commit: false
 ---
 

--- a/.conductor/agents/update-diagram-files.md
+++ b/.conductor/agents/update-diagram-files.md
@@ -1,5 +1,6 @@
 ---
 role: actor
+model: claude-sonnet-4-6
 can_commit: false
 ---
 

--- a/.conductor/agents/write-tests.md
+++ b/.conductor/agents/write-tests.md
@@ -1,7 +1,7 @@
 ---
 role: actor
 can_commit: true
-model: claude-haiku-4-5
+model: claude-sonnet-4-6
 ---
 
 You are a test engineer. Based on the coverage analysis from the previous step, write the missing tests and commit them to the PR branch.


### PR DESCRIPTION
## Summary

- Audited all 27 workflows and every agent file for explicit model declarations
- Downgraded to `claude-haiku-4-5` where tasks are mechanical/pattern-based: `review-error-handling`, `review-test-coverage`, `review-db-migrations`, `file-ux-issues`, `report-coverage`, `report-open-questions`
- Upgraded to `claude-sonnet-4-6` where tasks require reasoning or real implementation: `address-reviews`, `fix-ci-failures`, `implement`, `resolve-conflicts`, `write-tests`, `assess-ticket-readiness`
- Explicitly set `claude-sonnet-4-6` on 11 agents that previously had no model declaration: `analyze-file-structure`, `synthesize-repo-report`, `analyze-per-persona`, `draft-gh-issue`, `diagnose-failure`, `extract-personas`, `generate-diagram-files`, `analyze-coverage`, `identify-affected-diagrams`, `update-diagram-files`, `analyze-postmortem`

## Test plan

- [ ] Run `review-pr` workflow on a PR with code changes and verify all reviewers fire correctly
- [ ] Run `ticket-to-pr` on a simple ticket and verify `implement` uses sonnet
- [ ] Run `lint-fix` and verify `lint-fix-impl` stays on haiku

🤖 Generated with [Claude Code](https://claude.com/claude-code)