### PR TITLE
fix: unlock dependent tickets on completed ticket-to-pr workflow

### DIFF
--- a/.conductor/scripts/push-and-pr.sh
+++ b/.conductor/scripts/push-and-pr.sh
@@ -17,6 +17,13 @@ EOF
   exit 0
 fi
 
+# Rebase on top of any remote commits on this branch (e.g. from prior iterations)
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if git ls-remote --exit-code --heads origin "$current_branch" >/dev/null 2>&1; then
+  git fetch origin "$current_branch" --quiet
+  git rebase "origin/$current_branch" --quiet
+fi
+
 SKIP_E2E=1 git push -u origin HEAD
 
 pr_create_err=$(mktemp)

--- a/conductor-core/src/tickets.rs
+++ b/conductor-core/src/tickets.rs
@@ -31,6 +31,11 @@ pub struct Ticket {
     pub raw_json: String,
     pub workflow: Option<String>,
     pub agent_map: Option<String>,
+    /// True when a `ticket-to-pr` workflow run has completed for this ticket.
+    /// Populated by dependency queries; defaults to `false` when loaded outside
+    /// that context.
+    #[serde(default)]
+    pub workflow_completed: bool,
 }
 
 /// A normalized ticket from any source, ready to be upserted into the database.
@@ -109,14 +114,20 @@ pub struct TicketDependencies {
 }
 
 impl TicketDependencies {
-    /// Returns `true` if this ticket has at least one unresolved (non-closed) blocker.
+    /// Returns `true` if this ticket has at least one unresolved blocker.
+    /// A blocker is resolved when it is closed or has a completed `ticket-to-pr` workflow.
     pub fn is_actively_blocked(&self) -> bool {
-        self.blocked_by.iter().any(|b| b.state != "closed")
+        self.blocked_by
+            .iter()
+            .any(|b| b.state != "closed" && !b.workflow_completed)
     }
 
-    /// Returns an iterator over unresolved (non-closed) blockers.
+    /// Returns an iterator over unresolved blockers.
+    /// A blocker is resolved when it is closed or has a completed `ticket-to-pr` workflow.
     pub fn active_blockers(&self) -> impl Iterator<Item = &Ticket> {
-        self.blocked_by.iter().filter(|b| b.state != "closed")
+        self.blocked_by
+            .iter()
+            .filter(|b| b.state != "closed" && !b.workflow_completed)
     }
 }
 
@@ -761,10 +772,35 @@ impl<'a> TicketSyncer<'a> {
         Ok(map)
     }
 
+    /// Returns the set of ticket IDs that have at least one completed
+    /// `ticket-to-pr` workflow run. Used to mark blockers as resolved even
+    /// when their ticket state has not yet transitioned to `closed`.
+    fn tickets_with_completed_workflow(&self) -> Result<HashSet<String>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT DISTINCT ticket_id FROM workflow_runs \
+             WHERE ticket_id IS NOT NULL \
+               AND status = 'completed' \
+               AND workflow_name = 'ticket-to-pr'",
+            )
+            .map_err(ConductorError::Database)?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(ConductorError::Database)?;
+        let mut set = HashSet::new();
+        for r in rows {
+            set.insert(r.map_err(ConductorError::Database)?);
+        }
+        Ok(set)
+    }
+
     /// Returns dependency relationships for a single ticket.
     pub fn get_dependencies(&self, ticket_id: &str) -> Result<TicketDependencies> {
+        let completed = self.tickets_with_completed_workflow()?;
+
         // Tickets that block this one (from_ticket_id = blocker, to_ticket_id = this)
-        let blocked_by = query_collect(
+        let mut blocked_by = query_collect(
             self.conn,
             &format!(
                 "SELECT {TICKET_COLS} FROM tickets t
@@ -774,6 +810,9 @@ impl<'a> TicketSyncer<'a> {
             params![ticket_id],
             map_ticket_row,
         )?;
+        for t in &mut blocked_by {
+            t.workflow_completed = completed.contains(&t.id);
+        }
 
         // Tickets this one blocks (from_ticket_id = this, to_ticket_id = blocked)
         let blocks = query_collect(
@@ -830,10 +869,12 @@ impl<'a> TicketSyncer<'a> {
     ) -> Result<HashMap<String, TicketDependencies>> {
         let blocks_rows = query_dep_pairs_for_repo(self.conn, "blocks", repo_id)?;
         let parent_rows = query_dep_pairs_for_repo(self.conn, "parent_of", repo_id)?;
+        let completed = self.tickets_with_completed_workflow()?;
 
         let mut map: HashMap<String, TicketDependencies> = HashMap::new();
 
-        for (from_id, to_id, from_ticket, to_ticket) in blocks_rows {
+        for (from_id, to_id, mut from_ticket, to_ticket) in blocks_rows {
+            from_ticket.workflow_completed = completed.contains(&from_ticket.id);
             map.entry(to_id).or_default().blocked_by.push(from_ticket);
             map.entry(from_id).or_default().blocks.push(to_ticket);
         }
@@ -852,12 +893,14 @@ impl<'a> TicketSyncer<'a> {
     pub fn get_all_dependencies(&self) -> Result<HashMap<String, TicketDependencies>> {
         let blocks_rows = query_dep_pairs(self.conn, "blocks")?;
         let parent_rows = query_dep_pairs(self.conn, "parent_of")?;
+        let completed = self.tickets_with_completed_workflow()?;
 
         let mut map: HashMap<String, TicketDependencies> = HashMap::new();
 
         // blocks_rows: (from_id=blocker, to_id=blocked, from_ticket=blocker, to_ticket=blocked)
         // → to_id's blocked_by list gets the blocker; from_id's blocks list gets the blocked
-        for (from_id, to_id, from_ticket, to_ticket) in blocks_rows {
+        for (from_id, to_id, mut from_ticket, to_ticket) in blocks_rows {
+            from_ticket.workflow_completed = completed.contains(&from_ticket.id);
             map.entry(to_id).or_default().blocked_by.push(from_ticket);
             map.entry(from_id).or_default().blocks.push(to_ticket);
         }
@@ -959,10 +1002,15 @@ impl<'a> TicketSyncer<'a> {
                AND NOT EXISTS ( \
                    SELECT 1 FROM ticket_dependencies dep \
                    JOIN tickets blocker ON blocker.id = dep.from_ticket_id \
-                   LEFT JOIN workflow_runs wr ON wr.ticket_id = blocker.id \
                    WHERE dep.to_ticket_id = t.id \
                      AND dep.dep_type = 'blocks' \
-                     AND (blocker.state != 'closed' OR COALESCE(wr.status, 'completed') != 'completed') \
+                     AND blocker.state != 'closed' \
+                     AND NOT EXISTS ( \
+                         SELECT 1 FROM workflow_runs wr \
+                         WHERE wr.ticket_id = blocker.id \
+                           AND wr.status = 'completed' \
+                           AND wr.workflow_name = 'ticket-to-pr' \
+                     ) \
                ) \
                AND NOT EXISTS ( \
                    SELECT 1 FROM workflow_runs wr \
@@ -1225,6 +1273,7 @@ fn map_ticket_row_at(row: &rusqlite::Row, offset: usize) -> rusqlite::Result<Tic
         raw_json: row.get(offset + 12)?,
         workflow: row.get(offset + 13)?,
         agent_map: row.get(offset + 14)?,
+        workflow_completed: false,
     })
 }
 
@@ -1282,6 +1331,7 @@ mod tests {
             raw_json: "{}".to_string(),
             workflow: None,
             agent_map: None,
+            workflow_completed: false,
         }
     }
 
@@ -2156,6 +2206,7 @@ mod tests {
             raw_json: "{}".to_string(),
             workflow: None,
             agent_map: None,
+            workflow_completed: false,
         };
 
         let prompt = build_agent_prompt(&ticket);
@@ -2184,6 +2235,7 @@ mod tests {
             raw_json: "{}".to_string(),
             workflow: None,
             agent_map: None,
+            workflow_completed: false,
         };
 
         let prompt = build_agent_prompt(&ticket);

--- a/conductor-tui/src/app/crud_operations.rs
+++ b/conductor-tui/src/app/crud_operations.rs
@@ -732,6 +732,7 @@ mod tests {
             raw_json: "{}".into(),
             workflow: None,
             agent_map: None,
+            workflow_completed: false,
         };
         app.state.filtered_detail_tickets = vec![ticket];
         app.state.detail_ticket_index = 0;

--- a/conductor-tui/src/app/navigation.rs
+++ b/conductor-tui/src/app/navigation.rs
@@ -1160,6 +1160,7 @@ mod tests {
             raw_json: "{}".into(),
             workflow: None,
             agent_map: None,
+            workflow_completed: false,
         }];
         app.state.ticket_index = 5;
         app.clamp_indices();

--- a/conductor-tui/src/app/tests/action_handler_tests.rs
+++ b/conductor-tui/src/app/tests/action_handler_tests.rs
@@ -1037,6 +1037,7 @@ fn selected_ticket_url_from_ticket_info_modal() {
             raw_json: "{}".into(),
             workflow: None,
             agent_map: None,
+            workflow_completed: false,
         }),
     };
     assert_eq!(
@@ -1125,6 +1126,7 @@ fn selected_ticket_url_from_repo_detail_tickets() {
         raw_json: "{}".into(),
         workflow: None,
         agent_map: None,
+        workflow_completed: false,
     }];
     app.state.detail_ticket_index = 0;
     assert_eq!(

--- a/conductor-tui/src/state/tests/mod.rs
+++ b/conductor-tui/src/state/tests/mod.rs
@@ -39,6 +39,7 @@ pub(crate) fn make_ticket(id: &str, state: &str) -> conductor_core::tickets::Tic
         raw_json: String::new(),
         workflow: None,
         agent_map: None,
+        workflow_completed: false,
     }
 }
 

--- a/conductor-tui/src/state/tree.rs
+++ b/conductor-tui/src/state/tree.rs
@@ -300,6 +300,7 @@ mod tests {
             raw_json: String::new(),
             workflow: None,
             agent_map: None,
+            workflow_completed: false,
         }
     }
 

--- a/conductor-tui/tests/tui_snapshots.rs
+++ b/conductor-tui/tests/tui_snapshots.rs
@@ -109,6 +109,7 @@ fn make_tickets(repos: &[Repo]) -> Vec<Ticket> {
             raw_json: "{}".into(),
             workflow: None,
             agent_map: None,
+            workflow_completed: false,
         },
         Ticket {
             id: "01TKT0000000000000000000B1".into(),
@@ -126,6 +127,7 @@ fn make_tickets(repos: &[Repo]) -> Vec<Ticket> {
             raw_json: "{}".into(),
             workflow: None,
             agent_map: None,
+            workflow_completed: false,
         },
     ]
 }
@@ -506,6 +508,7 @@ fn snap_modal_ticket_info() {
             raw_json: "{}".into(),
             workflow: None,
             agent_map: None,
+            workflow_completed: false,
         }),
     };
     insta::assert_snapshot!(render_to_string(&state));

--- a/conductor-web/frontend/src/api/types.ts
+++ b/conductor-web/frontend/src/api/types.ts
@@ -44,6 +44,7 @@ export interface Ticket {
   url: string;
   synced_at: string;
   raw_json: string;
+  workflow_completed?: boolean;
 }
 
 export interface TicketLabel {

--- a/conductor-web/frontend/src/utils/ticketDeps.ts
+++ b/conductor-web/frontend/src/utils/ticketDeps.ts
@@ -1,4 +1,4 @@
-import type { GithubPr, Ticket, TicketDependencies, Worktree } from "../api/types";
+import type { Ticket, TicketDependencies } from "../api/types";
 
 interface DepInfo {
   dependencies: string[];
@@ -38,13 +38,13 @@ export interface TicketTree {
  * - When `apiDeps` is provided (preferred), uses DB-backed dependency data for all
  *   source types. Falls back to Vantage `raw_json` parsing when `apiDeps` is absent.
  * - A ticket is "blocked" if any blocker in `blocked_by` is not closed.
- * - A blocked ticket is "unlocked" if every blocker has a PR with review_decision "APPROVED".
+ * - A blocked ticket is "unlocked" if every blocker has `workflow_completed === true`.
  * - Non-vantage tickets without apiDeps are always roots.
  */
 export function buildTicketTree(
   tickets: Ticket[],
-  worktrees?: Worktree[],
-  prs?: GithubPr[],
+  _worktrees?: unknown,
+  _prs?: unknown,
   apiDeps?: Record<string, TicketDependencies>,
 ): TicketTree {
   // Index tickets by source_id and by id for fast lookup
@@ -136,36 +136,20 @@ export function buildTicketTree(
   // Roots: tickets that have no parent in the list
   const roots = tickets.filter((t) => !hasParentInList.has(t.source_id));
 
-  // Compute unlocked set: blocked tickets whose blocking parents all have approved PRs
+  // Compute unlocked set: blocked tickets whose blocking parents all have
+  // completed ticket-to-pr workflows (determined by the backend).
   const unlocked = new Set<string>();
-  if (worktrees?.length && prs?.length) {
-    // ticket_id → worktree branch
-    const wtBranchByTicketId = new Map<string, string>();
-    for (const wt of worktrees) {
-      if (wt.ticket_id) {
-        wtBranchByTicketId.set(wt.ticket_id, wt.branch);
-      }
-    }
-    // branch → PR
-    const prByBranch = new Map<string, GithubPr>();
-    for (const pr of prs) {
-      prByBranch.set(pr.head_ref_name, pr);
-    }
+  for (const ticketId of blocked) {
+    const parentIds = blockingParentIds.get(ticketId);
+    if (!parentIds?.length) continue;
 
-    for (const ticketId of blocked) {
-      const parentIds = blockingParentIds.get(ticketId);
-      if (!parentIds?.length) continue;
+    const allCompleted = parentIds.every((parentId) => {
+      const parent = byId.get(parentId);
+      return parent?.workflow_completed === true;
+    });
 
-      const allApproved = parentIds.every((parentId) => {
-        const branch = wtBranchByTicketId.get(parentId);
-        if (!branch) return false;
-        const pr = prByBranch.get(branch);
-        return pr?.review_decision === "APPROVED";
-      });
-
-      if (allApproved) {
-        unlocked.add(ticketId);
-      }
+    if (allCompleted) {
+      unlocked.add(ticketId);
     }
   }
 


### PR DESCRIPTION
## Summary

- **Fixed ticket unlock logic**: Dependent tickets now unlock when their blocker has a completed `ticket-to-pr` workflow run, rather than requiring the blocker's state to transition to `closed`
- **Conductor as source of truth**: Replaced the frontend's GitHub PR `review_decision === "APPROVED"` check with a backend-driven `workflow_completed` flag on the `Ticket` struct
- **Fixed `push-and-pr.sh`**: Script now rebases on the remote feature branch before pushing, preventing rejection when prior workflow iterations pushed to the same branch

## Root cause

The `get_ready_tickets()` SQL used a `LEFT JOIN workflow_runs` that produced one row per run. If a blocker had both a `completed` and a `cancelled` run, the `EXISTS` subquery found the cancelled row and kept dependents blocked. Additionally, the frontend unlock computation required worktree→branch→PR joins with GitHub approval status instead of using Conductor's own workflow state.

## Test plan

- [x] All 92 ticket tests pass
- [x] Full workspace tests pass
- [x] Clippy clean
- [x] TypeScript type check clean
- [ ] Verify in web UI that dependent tickets show unlocked state when parent workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)