### PR TITLE
fix: use PR base branch in detect-db-migrations to prevent false positives

### DIFF
--- a/.conductor/scripts/detect-db-migrations.sh
+++ b/.conductor/scripts/detect-db-migrations.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Get changed files relative to main
-changed_files=$(git diff origin/main...HEAD --name-only 2>/dev/null || true)
+# Get the PR's actual base branch (falls back to main for non-PR contexts)
+base_branch=$(gh pr view --json baseRefName -q '.baseRefName' 2>/dev/null || echo "main")
+
+# Get changed files relative to the PR base branch
+changed_files=$(git diff "origin/${base_branch}...HEAD" --name-only 2>/dev/null || true)
 
 # Filter for migration files
 migration_files=()


### PR DESCRIPTION
## Summary
- `detect-db-migrations.sh` hardcoded `origin/main` as the diff base
- PRs targeting a non-main branch (e.g. `release/0.5.0`) would include migrations already in that base branch, falsely triggering `review-db-migrations`
- Reproduced in workflow run `01KP9H3S2ZQQ2QSQGRAVQX7GYT`: `070_features_rfc018.sql` appeared as "new" even though it was already in `release/0.5.0`

## Fix
Query `gh pr view` for the PR's actual base branch and use that for the diff. Falls back to `main` in non-PR contexts (e.g. manual runs without an open PR).

## Test plan
- [ ] Run `review-pr` on a PR targeting `release/0.5.0` that has no new migrations — confirm `detect-db-migrations` outputs `has_db_migrations: false`
- [ ] Run `review-pr` on a PR targeting `main` with a new migration — confirm it still detects correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)