### PR TITLE
fix(worktree): ignore untracked files in base-branch dirty check

### DIFF
--- a/conductor-core/src/worktree/git_helpers.rs
+++ b/conductor-core/src/worktree/git_helpers.rs
@@ -29,30 +29,36 @@ pub struct MainHealthStatus {
 ///
 /// Does not modify any git state (no checkout, no merge, no fetch).
 pub fn check_main_health(repo_path: &str, base_branch: &str) -> MainHealthStatus {
-    // 1. Check dirty state
-    let (is_dirty, dirty_files, status_check_failed) =
-        match git_in(repo_path).args(["status", "--porcelain"]).output() {
-            Ok(o) if o.status.success() && !o.stdout.is_empty() => {
-                let files: Vec<String> = String::from_utf8_lossy(&o.stdout)
-                    .lines()
-                    .filter(|l| !l.trim().is_empty())
-                    .map(|l| {
-                        l.trim_start_matches(|c: char| !c.is_whitespace())
-                            .trim()
-                            .to_string()
-                    })
-                    .collect();
-                (true, files, false)
-            }
-            Ok(o) if o.status.success() => {
-                // Empty stdout → working tree is clean
-                (false, Vec::new(), false)
-            }
-            _ => {
-                // Command failed or non-zero exit — cannot determine dirty state
-                (false, Vec::new(), true)
-            }
-        };
+    // 1. Check dirty state. Untracked files are excluded because `git worktree add`
+    //    creates a new working directory and never touches the original worktree's
+    //    untracked files — blocking on them just produces false positives (e.g.
+    //    untracked test-helper submodule directories that the user can't easily
+    //    commit or stash).
+    let (is_dirty, dirty_files, status_check_failed) = match git_in(repo_path)
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .output()
+    {
+        Ok(o) if o.status.success() && !o.stdout.is_empty() => {
+            let files: Vec<String> = String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .map(|l| {
+                    l.trim_start_matches(|c: char| !c.is_whitespace())
+                        .trim()
+                        .to_string()
+                })
+                .collect();
+            (true, files, false)
+        }
+        Ok(o) if o.status.success() => {
+            // Empty stdout → working tree is clean
+            (false, Vec::new(), false)
+        }
+        _ => {
+            // Command failed or non-zero exit — cannot determine dirty state
+            (false, Vec::new(), true)
+        }
+    };
 
     // 2. Count commits behind using cached remote refs (no fetch — avoids double
     //    fetch with the subsequent ensure_base_up_to_date call in create()).
@@ -236,9 +242,14 @@ fn ensure_base_up_to_date_with_fetch_control(
 ) -> Result<Vec<String>> {
     let mut warnings = Vec::new();
 
-    // 1. Check for uncommitted changes in the repo working tree
+    // 1. Check for uncommitted changes in the repo working tree. Untracked files are
+    //    excluded — they don't affect `git worktree add` (new directory, separate from
+    //    the main working tree) and are the most common source of false-positive
+    //    "dirty" reports (e.g. untracked test-helper directories).
     if !force_dirty && !pre_verified_clean {
-        let output = git_in(repo_path).args(["status", "--porcelain"]).output()?;
+        let output = git_in(repo_path)
+            .args(["status", "--porcelain", "--untracked-files=no"])
+            .output()?;
         if output.status.success() && !output.stdout.is_empty() {
             return Err(ConductorError::InvalidInput(
                 "uncommitted changes on base branch, please commit or stash first".to_string(),

--- a/conductor-core/src/worktree/tests.rs
+++ b/conductor-core/src/worktree/tests.rs
@@ -146,8 +146,9 @@ fn test_ensure_base_up_to_date_clean_fast_forward() {
 fn test_ensure_base_up_to_date_dirty_working_tree() {
     let (_tmp, _, local) = setup_repo_with_remote();
 
-    // Make the working tree dirty
-    fs::write(local.join("dirty.txt"), "uncommitted").unwrap();
+    // Make the working tree dirty by modifying a tracked file (untracked files are
+    // intentionally ignored — see `check_main_health`).
+    fs::write(local.join("README.md"), "modified").unwrap();
 
     let result = git_helpers::ensure_base_up_to_date(local.to_str().unwrap(), "main", false, false);
     assert!(result.is_err());
@@ -155,6 +156,23 @@ fn test_ensure_base_up_to_date_dirty_working_tree() {
     assert!(
         err.contains("uncommitted changes"),
         "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_ensure_base_up_to_date_allows_untracked_files() {
+    let (_tmp, _, local) = setup_repo_with_remote();
+
+    // Untracked files don't affect `git worktree add` and must not block creation.
+    fs::write(local.join("untracked.txt"), "untracked").unwrap();
+    fs::create_dir_all(local.join("untracked_dir")).unwrap();
+    fs::write(local.join("untracked_dir").join("file"), "x").unwrap();
+
+    let result = git_helpers::ensure_base_up_to_date(local.to_str().unwrap(), "main", false, false);
+    assert!(
+        result.is_ok(),
+        "untracked files should not block worktree creation; got: {:?}",
+        result.err()
     );
 }
 
@@ -200,14 +218,36 @@ fn test_check_main_health_clean_repo() {
 fn test_check_main_health_dirty_repo() {
     let (_tmp, _, local) = setup_repo_with_remote();
 
-    // Make the working tree dirty
-    fs::write(local.join("dirty_health.txt"), "uncommitted").unwrap();
+    // Modify a tracked file — that's real uncommitted work.
+    fs::write(local.join("README.md"), "modified").unwrap();
 
     let health = git_helpers::check_main_health(local.to_str().unwrap(), "main");
-    assert!(health.is_dirty, "repo with untracked file should be dirty");
+    assert!(
+        health.is_dirty,
+        "repo with modified tracked file should be dirty"
+    );
     assert!(
         !health.dirty_files.is_empty(),
         "dirty_files should be non-empty"
+    );
+}
+
+#[test]
+fn test_check_main_health_untracked_files_not_dirty() {
+    let (_tmp, _, local) = setup_repo_with_remote();
+
+    // Untracked files and directories don't affect `git worktree add`. Flagging them
+    // as dirty produces false positives that block ticket starts (e.g. test-helper
+    // submodule directories that exist locally but aren't committed).
+    fs::write(local.join("untracked.txt"), "untracked").unwrap();
+    fs::create_dir_all(local.join("untracked_dir")).unwrap();
+    fs::write(local.join("untracked_dir").join("file"), "x").unwrap();
+
+    let health = git_helpers::check_main_health(local.to_str().unwrap(), "main");
+    assert!(
+        !health.is_dirty,
+        "untracked files must not be reported as dirty; got dirty_files: {:?}",
+        health.dirty_files
     );
 }
 
@@ -250,8 +290,8 @@ fn test_check_main_health_commits_behind_positive() {
 fn test_ensure_base_up_to_date_force_dirty_skips_check() {
     let (_tmp, _, local) = setup_repo_with_remote();
 
-    // Make the working tree dirty
-    fs::write(local.join("dirty_force.txt"), "uncommitted").unwrap();
+    // Make the working tree dirty via a tracked-file modification.
+    fs::write(local.join("README.md"), "modified").unwrap();
 
     // With force_dirty=true, the dirty check is skipped — should succeed
     let result = git_helpers::ensure_base_up_to_date(local.to_str().unwrap(), "main", true, false);
@@ -266,8 +306,9 @@ fn test_ensure_base_up_to_date_force_dirty_skips_check() {
 fn test_ensure_base_up_to_date_skips_status_when_pre_verified_clean() {
     let (_tmp, _, local) = setup_repo_with_remote();
 
-    // Make the working tree dirty — would normally cause an error
-    fs::write(local.join("dirty_pre_verified.txt"), "uncommitted").unwrap();
+    // Make the working tree dirty via a tracked-file modification — would normally
+    // cause an error.
+    fs::write(local.join("README.md"), "modified").unwrap();
 
     // With pre_verified_clean=true, the git status check is skipped
     // (the fetch may fail too since there's no network, but that's a soft warning)

--- a/conductor-web/src/test_helpers.rs
+++ b/conductor-web/src/test_helpers.rs
@@ -66,19 +66,22 @@ pub fn seeded_state_with_dirty_repo() -> (AppState, NamedTempFile, TempDir) {
             .expect("git command failed");
     };
     run(&["init"]);
+    // Commit a tracked file we can later modify. (Untracked files don't count as
+    // dirty — only tracked-file changes do — so we need a committed file here.)
+    std::fs::write(git_dir.path().join("tracked.txt"), "original").expect("write tracked file");
+    run(&["add", "tracked.txt"]);
     run(&[
         "-c",
         "user.email=test@test.com",
         "-c",
         "user.name=Test",
         "commit",
-        "--allow-empty",
         "-m",
         "init",
     ]);
 
-    // Write an uncommitted file so that `git status --porcelain` reports dirty.
-    std::fs::write(git_dir.path().join("dirty.txt"), "dirty").expect("write dirty file");
+    // Modify the tracked file so `git status --porcelain` reports dirty.
+    std::fs::write(git_dir.path().join("tracked.txt"), "modified").expect("modify tracked file");
 
     let git_path_for_seed = git_path.clone();
     let (state, tmp) = state_with_file_db(move |conn| {

--- a/docs/diagrams/database-schema.mmd
+++ b/docs/diagrams/database-schema.mmd
@@ -1,4 +1,4 @@
-%% Updated 2026-04-16 — Entity-relationship diagram for conductor.db (74 migrations)
+%% Updated 2026-04-17 — Entity-relationship diagram for conductor.db (74 migrations)
 erDiagram
 
     _conductor_meta {


### PR DESCRIPTION
## Summary
- `git worktree add` creates a separate working directory and never touches the base branch's original worktree — so untracked files there don't affect creation. Flagging them as dirty produced false-positive `409 main_dirty` errors when users clicked **Start** on tickets (reported in the field for untracked `test/helpers/bats-assert/` / `test/helpers/bats-support/` directories).
- Pass `--untracked-files=no` to the two `git status --porcelain` calls (`check_main_health` and `ensure_base_up_to_date`). Only tracked-file modifications — the changes that actually represent uncommitted work — now gate creation.
- Update the web + core dirty-repo test fixtures to modify a tracked file (they previously relied on untracked files to simulate "dirty"), and add regression tests confirming untracked files / directories are no longer reported as dirty.

## Test plan
- [x] `cargo test -p conductor-core --lib worktree::` — 160 passed, including new `test_check_main_health_untracked_files_not_dirty` and `test_ensure_base_up_to_date_allows_untracked_files`
- [x] `cargo test -p conductor-web --lib routes::worktrees` — 14 passed, including the existing `create_worktree_returns_409_when_base_branch_is_dirty` path now driven by a modified tracked file
- [x] `cargo clippy -p conductor-core -p conductor-web -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] Click **Start** on a ticket in a repo whose base branch has untracked directories — expect it to proceed without `409 main_dirty`