### PR TITLE
fix(tui): always show default-branch sentinel in branch picker

### DIFF
--- a/conductor-tui/src/app/input_handling.rs
+++ b/conductor-tui/src/app/input_handling.rs
@@ -794,14 +794,7 @@ impl App {
         wt_slug: String,
         items: Vec<BranchPickerItem>,
     ) {
-        let mut items_with_sentinel = vec![BranchPickerItem {
-            branch: None,
-            worktree_count: 0,
-            ticket_count: 0,
-            base_branch: None,
-            stale_days: None,
-            inferred_from: None,
-        }];
+        let mut items_with_sentinel = vec![BranchPickerItem::default()];
         items_with_sentinel.extend(items);
         let (ordered, tree_positions) =
             crate::state::build_branch_picker_tree(&items_with_sentinel);
@@ -870,14 +863,7 @@ impl App {
         ticket_id: Option<String>,
         items: Vec<crate::state::BranchPickerItem>,
     ) {
-        let mut items_with_sentinel = vec![crate::state::BranchPickerItem {
-            branch: None,
-            worktree_count: 0,
-            ticket_count: 0,
-            base_branch: None,
-            stale_days: None,
-            inferred_from: None,
-        }];
+        let mut items_with_sentinel = vec![crate::state::BranchPickerItem::default()];
         items_with_sentinel.extend(items);
         let (ordered, tree_positions) =
             crate::state::build_branch_picker_tree(&items_with_sentinel);
@@ -1069,21 +1055,11 @@ mod tests {
 
     fn branch_picker_items() -> Vec<crate::state::BranchPickerItem> {
         vec![
-            crate::state::BranchPickerItem {
-                branch: None,
-                worktree_count: 0,
-                ticket_count: 0,
-                base_branch: None,
-                stale_days: None,
-                inferred_from: None,
-            },
+            crate::state::BranchPickerItem::default(),
             crate::state::BranchPickerItem {
                 branch: Some("feat/notifications".to_string()),
-                worktree_count: 0,
-                ticket_count: 0,
                 base_branch: Some("main".to_string()),
-                stale_days: None,
-                inferred_from: None,
+                ..Default::default()
             },
         ]
     }
@@ -1186,11 +1162,8 @@ mod tests {
         let mut app = make_app();
         let worktree_items = vec![crate::state::BranchPickerItem {
             branch: Some("feat/notifications".to_string()),
-            worktree_count: 0,
-            ticket_count: 0,
-            base_branch: None,
-            stale_days: None,
             inferred_from: Some("feat-notifications".to_string()),
+            ..Default::default()
         }];
         app.handle_worktree_branches_loaded(
             "repo".to_string(),

--- a/conductor-tui/src/app/input_handling.rs
+++ b/conductor-tui/src/app/input_handling.rs
@@ -860,11 +860,17 @@ impl App {
         ticket_id: Option<String>,
         items: Vec<crate::state::BranchPickerItem>,
     ) {
-        if items.is_empty() {
-            self.state.modal = pr_step_modal(repo_slug, wt_name, ticket_id, None);
-            return;
-        }
-        let (ordered, tree_positions) = crate::state::build_branch_picker_tree(&items);
+        let mut items_with_sentinel = vec![crate::state::BranchPickerItem {
+            branch: None,
+            worktree_count: 0,
+            ticket_count: 0,
+            base_branch: None,
+            stale_days: None,
+            inferred_from: None,
+        }];
+        items_with_sentinel.extend(items);
+        let (ordered, tree_positions) =
+            crate::state::build_branch_picker_tree(&items_with_sentinel);
         self.state.modal = Modal::BranchPicker {
             repo_slug,
             wt_name,
@@ -1163,5 +1169,47 @@ mod tests {
         app.handle_branch_pick(Some(0));
         // Modal should stay None (no-op).
         assert!(matches!(app.state.modal, Modal::None));
+    }
+
+    #[test]
+    fn worktree_branches_loaded_always_has_default_branch_sentinel() {
+        let mut app = make_app();
+        let worktree_items = vec![crate::state::BranchPickerItem {
+            branch: Some("feat/notifications".to_string()),
+            worktree_count: 0,
+            ticket_count: 0,
+            base_branch: None,
+            stale_days: None,
+            inferred_from: Some("feat-notifications".to_string()),
+        }];
+        app.handle_worktree_branches_loaded(
+            "repo".to_string(),
+            "my-wt".to_string(),
+            None,
+            worktree_items,
+        );
+        match &app.state.modal {
+            Modal::BranchPicker { items, .. } => {
+                assert!(
+                    items[0].branch.is_none(),
+                    "first item must be the default-branch sentinel (branch: None)"
+                );
+                assert_eq!(items.len(), 2, "sentinel + one worktree branch");
+            }
+            other => panic!("expected BranchPicker modal, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn worktree_branches_loaded_no_worktrees_shows_picker_with_only_sentinel() {
+        let mut app = make_app();
+        app.handle_worktree_branches_loaded("repo".to_string(), "my-wt".to_string(), None, vec![]);
+        match &app.state.modal {
+            Modal::BranchPicker { items, .. } => {
+                assert_eq!(items.len(), 1, "only the default-branch sentinel");
+                assert!(items[0].branch.is_none());
+            }
+            other => panic!("expected BranchPicker modal, got {:?}", other),
+        }
     }
 }

--- a/conductor-tui/src/app/input_handling.rs
+++ b/conductor-tui/src/app/input_handling.rs
@@ -794,7 +794,17 @@ impl App {
         wt_slug: String,
         items: Vec<BranchPickerItem>,
     ) {
-        let (ordered, tree_positions) = crate::state::build_branch_picker_tree(&items);
+        let mut items_with_sentinel = vec![BranchPickerItem {
+            branch: None,
+            worktree_count: 0,
+            ticket_count: 0,
+            base_branch: None,
+            stale_days: None,
+            inferred_from: None,
+        }];
+        items_with_sentinel.extend(items);
+        let (ordered, tree_positions) =
+            crate::state::build_branch_picker_tree(&items_with_sentinel);
         self.state.modal = Modal::BaseBranchPicker {
             repo_slug,
             wt_slug,

--- a/conductor-tui/src/state/enums.rs
+++ b/conductor-tui/src/state/enums.rs
@@ -316,7 +316,7 @@ impl WorkflowPickerItem {
 }
 
 /// One selectable row in the branch picker modal.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BranchPickerItem {
     /// `None` → repo default branch; `Some(branch)` → feature branch name.
     pub branch: Option<String>,


### PR DESCRIPTION
## Summary

- The branch picker was missing the "default branch / main" option because the `branch: None` sentinel was never prepended to the items list before passing to `build_branch_picker_tree` (which assumes `items[0]` is that sentinel)
- Fixed by prepending the sentinel inside `handle_worktree_branches_loaded`, making the invariant guaranteed regardless of what the background thread sends
- Added two regression tests covering the no-worktrees case (picker shows only sentinel) and the has-worktrees case (sentinel is always first)

Closes #2297

## Test plan

- [ ] `cargo test -p conductor-tui worktree_branches_loaded` — both new regression tests pass
- [ ] `cargo test -p conductor-tui` — full suite passes (491 tests)
- [ ] Manually open branch picker in TUI — "default branch" appears as option 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)