### PR TITLE
refactor(cli-runtime): migrate CliRuntime from tmux to headless subpr…

### DIFF
--- a/conductor-cli/src/handlers/conversation.rs
+++ b/conductor-cli/src/handlers/conversation.rs
@@ -182,7 +182,7 @@ mod tests {
 
         let agent_mgr = AgentManager::new(&conn);
         agent_mgr
-            .create_run_for_conversation("wt3", "hello", None, None, &conv.id)
+            .create_run_for_conversation("wt3", "hello", None, &conv.id)
             .unwrap();
 
         // The active run should block the clear.

--- a/conductor-cli/src/handlers/worktree.rs
+++ b/conductor-cli/src/handlers/worktree.rs
@@ -104,7 +104,7 @@ pub fn handle_worktree(
                             );
                             let model = resolved_model.as_deref();
                             let agent_mgr = AgentManager::new(conn);
-                            let run = agent_mgr.create_run(Some(&wt.id), &prompt, None, model)?;
+                            let run = agent_mgr.create_run(Some(&wt.id), &prompt, model)?;
                             run_agent(
                                 conn,
                                 &run.id,

--- a/conductor-cli/src/mcp/tools/agents.rs
+++ b/conductor-cli/src/mcp/tools/agents.rs
@@ -285,12 +285,8 @@ mod tests {
                 [],
             ).unwrap();
             let mgr = AgentManager::new(&conn);
-            let r1 = mgr
-                .create_run(Some("w1"), "running task", None, None)
-                .unwrap();
-            let r2 = mgr
-                .create_run(Some("w1"), "completed task", None, None)
-                .unwrap();
+            let r1 = mgr.create_run(Some("w1"), "running task", None).unwrap();
+            let r2 = mgr.create_run(Some("w1"), "completed task", None).unwrap();
             mgr.update_run_completed(
                 &r2.id,
                 None,
@@ -338,9 +334,7 @@ mod tests {
                 [],
             ).unwrap();
             let mgr = AgentManager::new(&conn);
-            let run = mgr
-                .create_run(Some("w1"), "needs feedback", None, None)
-                .unwrap();
+            let run = mgr.create_run(Some("w1"), "needs feedback", None).unwrap();
             // Transition to waiting_for_feedback via request_feedback
             mgr.request_feedback(&run.id, "Please approve?", None)
                 .unwrap();
@@ -392,7 +386,7 @@ mod tests {
         let conn = open_database(&db).expect("open db");
         let mgr = AgentManager::new(&conn);
         let run = mgr
-            .create_run(None, "do something", None, None)
+            .create_run(None, "do something", None)
             .expect("create run");
 
         let mut args = serde_json::Map::new();
@@ -419,7 +413,7 @@ mod tests {
         let conn = open_database(&db).expect("open db");
         let mgr = AgentManager::new(&conn);
         let run = mgr
-            .create_run(None, "do something", None, None)
+            .create_run(None, "do something", None)
             .expect("create run");
         // Create a pending feedback request (this also sets run status to waiting_for_feedback)
         mgr.request_feedback(&run.id, "Should I proceed?", None)

--- a/conductor-cli/src/mcp/tools/gates.rs
+++ b/conductor-cli/src/mcp/tools/gates.rs
@@ -102,7 +102,7 @@ mod tests {
         // FK: workflow_runs.parent_run_id references agent_runs.id
         let agent_mgr = AgentManager::new(&conn);
         let parent = agent_mgr
-            .create_run(None, "workflow", None, None)
+            .create_run(None, "workflow", None)
             .expect("create agent run");
 
         let mgr = WorkflowManager::new(&conn);

--- a/conductor-cli/src/mcp/tools/repos.rs
+++ b/conductor-cli/src/mcp/tools/repos.rs
@@ -220,7 +220,7 @@ mod tests {
             ).expect("insert worktree");
             // Create an agent run in running status via AgentManager (default status = running)
             AgentManager::new(&conn)
-                .create_run(Some("wt-test-1"), "test prompt", None, None)
+                .create_run(Some("wt-test-1"), "test prompt", None)
                 .expect("create run");
         }
         let result = tool_list_repos(&db);

--- a/conductor-cli/src/mcp/tools/runs.rs
+++ b/conductor-cli/src/mcp/tools/runs.rs
@@ -379,7 +379,7 @@ mod tests {
         let conn = open_database(db_path).expect("open db");
         let agent_mgr = AgentManager::new(&conn);
         let parent = agent_mgr
-            .create_run(None, "workflow", None, None)
+            .create_run(None, "workflow", None)
             .expect("create agent run");
         let mgr = WorkflowManager::new(&conn);
         let run = mgr
@@ -397,7 +397,7 @@ mod tests {
         use conductor_core::agent::AgentManager;
         let mgr = AgentManager::new(conn);
         let run = mgr
-            .create_run(None, "agent", None, None)
+            .create_run(None, "agent", None)
             .expect("create agent run");
         mgr.update_run_log_file(&run.id, log_path)
             .expect("set log_file");
@@ -413,7 +413,7 @@ mod tests {
         let conn = open_database(db_path).expect("open db");
         let agent_mgr = AgentManager::new(&conn);
         let parent = agent_mgr
-            .create_run(None, "workflow", None, None)
+            .create_run(None, "workflow", None)
             .expect("create parent run");
         let mgr = WorkflowManager::new(&conn);
         let run = mgr
@@ -507,12 +507,8 @@ mod tests {
             ).unwrap();
 
             let agent_mgr = AgentManager::new(&conn);
-            let p1 = agent_mgr
-                .create_run(Some("w1"), "wf-a", None, None)
-                .unwrap();
-            let p2 = agent_mgr
-                .create_run(Some("w2"), "wf-b", None, None)
-                .unwrap();
+            let p1 = agent_mgr.create_run(Some("w1"), "wf-a", None).unwrap();
+            let p2 = agent_mgr.create_run(Some("w2"), "wf-b", None).unwrap();
 
             let wf_mgr = WorkflowManager::new(&conn);
             wf_mgr
@@ -615,7 +611,7 @@ mod tests {
         let mgr = WorkflowManager::new(&conn);
 
         let parent = agent_mgr
-            .create_run(None, "workflow", None, None)
+            .create_run(None, "workflow", None)
             .expect("create agent run");
 
         // Create one run for repo-A and one for repo-B
@@ -896,7 +892,7 @@ mod tests {
         // Create a workflow run linked to both the worktree and the repo.
         let agent_mgr = AgentManager::new(&conn);
         let parent = agent_mgr
-            .create_run(None, "workflow", None, None)
+            .create_run(None, "workflow", None)
             .expect("create agent run");
         WorkflowManager::new(&conn)
             .create_workflow_run_with_targets(
@@ -1035,7 +1031,7 @@ mod tests {
         let conn = open_database(&db).expect("open db");
         let agent_mgr = AgentManager::new(&conn);
         let child_run = agent_mgr
-            .create_run(None, "agent", None, None)
+            .create_run(None, "agent", None)
             .expect("create child run");
         conn.execute(
             "UPDATE agent_runs SET log_file = ?1 WHERE id = ?2",

--- a/conductor-core/src/agent/context.rs
+++ b/conductor-core/src/agent/context.rs
@@ -199,9 +199,7 @@ mod tests {
     fn test_build_startup_context_with_worktree_no_ticket() {
         let conn = setup_conn();
         let mgr = AgentManager::new(&conn);
-        let run = mgr
-            .create_run(Some("w1"), "initial prompt", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "initial prompt", None).unwrap();
 
         // "w1" is the test worktree with branch "feat/test" (from setup_db).
         let ctx = build_startup_context(&conn, &Config::default(), Some("w1"), &run.id, "/tmp");
@@ -217,9 +215,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create and complete a prior run.
-        let prior = mgr
-            .create_run(Some("w1"), "do the thing", None, None)
-            .unwrap();
+        let prior = mgr.create_run(Some("w1"), "do the thing", None).unwrap();
         mgr.update_run_completed(
             &prior.id,
             None,
@@ -235,7 +231,7 @@ mod tests {
         .unwrap();
 
         // Create a new (current) run.
-        let current = mgr.create_run(Some("w1"), "follow-up", None, None).unwrap();
+        let current = mgr.create_run(Some("w1"), "follow-up", None).unwrap();
         assert_eq!(current.status, AgentRunStatus::Running);
 
         let ctx = build_startup_context(&conn, &Config::default(), Some("w1"), &current.id, "/tmp");
@@ -251,7 +247,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Only one run exists — the current one. No prior run section should appear.
-        let run = mgr.create_run(Some("w1"), "only run", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "only run", None).unwrap();
         let ctx = build_startup_context(&conn, &Config::default(), Some("w1"), &run.id, "/tmp");
         assert!(
             !ctx.contains("**Prior run outcome"),
@@ -273,7 +269,7 @@ mod tests {
             .unwrap();
 
         let mgr = AgentManager::new(&conn);
-        let current = mgr.create_run(Some("w1"), "Fix it", None, None).unwrap();
+        let current = mgr.create_run(Some("w1"), "Fix it", None).unwrap();
 
         let ctx = build_startup_context(&conn, &Config::default(), Some("w1"), &current.id, "/tmp");
         assert!(ctx.contains("**Ticket:** #42 — Fix payment bug"));
@@ -285,9 +281,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create a prior completed run with a plan
-        let prior = mgr
-            .create_run(Some("w1"), "Prior work", None, None)
-            .unwrap();
+        let prior = mgr.create_run(Some("w1"), "Prior work", None).unwrap();
         let steps = vec![
             PlanStep {
                 description: "Read the code".to_string(),
@@ -322,9 +316,7 @@ mod tests {
         .unwrap();
 
         // Create current run
-        let current = mgr
-            .create_run(Some("w1"), "Continue work", None, None)
-            .unwrap();
+        let current = mgr.create_run(Some("w1"), "Continue work", None).unwrap();
 
         let ctx = build_startup_context(&conn, &Config::default(), Some("w1"), &current.id, "/tmp");
         assert!(ctx.contains("**Plan steps (from prior run):**"));
@@ -339,9 +331,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create a prior run with a very long result
-        let prior = mgr
-            .create_run(Some("w1"), "Prior task", None, None)
-            .unwrap();
+        let prior = mgr.create_run(Some("w1"), "Prior task", None).unwrap();
         let long_result = "x".repeat(1000);
         mgr.update_run_completed(
             &prior.id,
@@ -357,7 +347,7 @@ mod tests {
         )
         .unwrap();
 
-        let current = mgr.create_run(Some("w1"), "Next", None, None).unwrap();
+        let current = mgr.create_run(Some("w1"), "Next", None).unwrap();
 
         let ctx = build_startup_context(&conn, &Config::default(), Some("w1"), &current.id, "/tmp");
         assert!(ctx.contains("**Prior run outcome (completed):**"));

--- a/conductor-core/src/agent/db.rs
+++ b/conductor-core/src/agent/db.rs
@@ -12,7 +12,7 @@ pub(super) const FEEDBACK_SELECT: &str =
 /// Shared SELECT column list for the `agent_runs` table (plain, unaliased form).
 pub(super) const AGENT_RUN_SELECT: &str =
     "SELECT id, worktree_id, repo_id, claude_session_id, prompt, status, result_text, \
-     cost_usd, num_turns, duration_ms, started_at, ended_at, tmux_window, log_file, \
+     cost_usd, num_turns, duration_ms, started_at, ended_at, log_file, \
      model, plan, parent_run_id, \
      input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens, \
      bot_name, conversation_id, subprocess_pid, \
@@ -54,8 +54,6 @@ macro_rules! agent_run_cols {
             "started_at, ",
             $alias,
             "ended_at, ",
-            $alias,
-            "tmux_window, ",
             $alias,
             "log_file, ",
             $alias,
@@ -109,8 +107,6 @@ macro_rules! agent_run_cols {
             "started_at, ",
             $alias,
             "ended_at, ",
-            $alias,
-            "tmux_window, ",
             $alias,
             "log_file, ",
             $alias,
@@ -230,7 +226,6 @@ pub(super) fn row_to_agent_run(row: &rusqlite::Row) -> rusqlite::Result<AgentRun
         duration_ms: row.get("duration_ms")?,
         started_at: row.get("started_at")?,
         ended_at: row.get("ended_at")?,
-        tmux_window: row.get("tmux_window")?,
         log_file: row.get("log_file")?,
         model: row.get("model")?,
         plan: None,
@@ -289,7 +284,6 @@ mod tests {
         "duration_ms",
         "started_at",
         "ended_at",
-        "tmux_window",
         "log_file",
         "model",
         "plan",
@@ -379,12 +373,12 @@ mod tests {
         conn.execute(
             "INSERT INTO agent_runs (id, prompt, status, started_at, worktree_id, repo_id, \
              claude_session_id, result_text, cost_usd, num_turns, duration_ms, ended_at, \
-             tmux_window, log_file, model, plan, parent_run_id, \
+             log_file, model, plan, parent_run_id, \
              input_tokens, output_tokens, cache_read_input_tokens, \
              cache_creation_input_tokens, bot_name) \
              VALUES (:id, :prompt, :status, :started_at, :worktree_id, :repo_id, \
                      :claude_session_id, :result_text, :cost_usd, :num_turns, :duration_ms, :ended_at, \
-                     :tmux_window, :log_file, :model, :plan, :parent_run_id, \
+                     :log_file, :model, :plan, :parent_run_id, \
                      :input_tokens, :output_tokens, :cache_read_input_tokens, \
                      :cache_creation_input_tokens, :bot_name)",
             rusqlite::named_params! {
@@ -400,7 +394,6 @@ mod tests {
                 ":num_turns": 10i64,
                 ":duration_ms": 5000i64,
                 ":ended_at": "2025-01-01T00:05:00Z",
-                ":tmux_window": "tmux-win",
                 ":log_file": "/tmp/log.txt",
                 ":model": "claude-sonnet-4-6",
                 ":plan": "[]",
@@ -434,7 +427,6 @@ mod tests {
         assert_eq!(run.duration_ms, Some(5000));
         assert_eq!(run.started_at, "2025-01-01T00:00:00Z");
         assert_eq!(run.ended_at.as_deref(), Some("2025-01-01T00:05:00Z"));
-        assert_eq!(run.tmux_window.as_deref(), Some("tmux-win"));
         assert_eq!(run.log_file.as_deref(), Some("/tmp/log.txt"));
         assert_eq!(run.model.as_deref(), Some("claude-sonnet-4-6"));
         // plan is always None (populated separately by caller)
@@ -471,7 +463,6 @@ mod tests {
         assert!(run.num_turns.is_none());
         assert!(run.duration_ms.is_none());
         assert!(run.ended_at.is_none());
-        assert!(run.tmux_window.is_none());
         assert!(run.log_file.is_none());
         assert!(run.model.is_none());
         assert!(run.plan.is_none());

--- a/conductor-core/src/agent/log_parsing.rs
+++ b/conductor-core/src/agent/log_parsing.rs
@@ -1030,7 +1030,7 @@ mod tests {
     fn test_try_recover_from_log_at_completed() {
         let conn = crate::agent::manager::setup_db();
         let mgr = AgentManager::new(&conn);
-        let run = mgr.create_run(Some("w1"), "test", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "test", None).unwrap();
 
         let tmp_dir = tempfile::tempdir().unwrap();
         write_result_log(tmp_dir.path(), &run.id, false, "all done");
@@ -1046,7 +1046,7 @@ mod tests {
     fn test_try_recover_from_log_at_error_result() {
         let conn = crate::agent::manager::setup_db();
         let mgr = AgentManager::new(&conn);
-        let run = mgr.create_run(Some("w1"), "test", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "test", None).unwrap();
 
         let tmp_dir = tempfile::tempdir().unwrap();
         write_result_log(tmp_dir.path(), &run.id, true, "something went wrong");
@@ -1068,7 +1068,7 @@ mod tests {
     fn test_try_recover_from_log_at_missing_log() {
         let conn = crate::agent::manager::setup_db();
         let mgr = AgentManager::new(&conn);
-        let run = mgr.create_run(Some("w1"), "test", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "test", None).unwrap();
 
         let tmp_dir = tempfile::tempdir().unwrap();
         // No log file written — should return None without touching the DB.
@@ -1083,7 +1083,7 @@ mod tests {
     fn test_try_recover_from_log_at_no_result_event() {
         let conn = crate::agent::manager::setup_db();
         let mgr = AgentManager::new(&conn);
-        let run = mgr.create_run(Some("w1"), "test", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "test", None).unwrap();
 
         let tmp_dir = tempfile::tempdir().unwrap();
         // Log exists but contains no result event.

--- a/conductor-core/src/agent/manager/aggregation.rs
+++ b/conductor-core/src/agent/manager/aggregation.rs
@@ -266,7 +266,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Two completed runs on w1
-        let run1 = mgr.create_run(Some("w1"), "Task 1", None, None).unwrap();
+        let run1 = mgr.create_run(Some("w1"), "Task 1", None).unwrap();
         mgr.update_run_completed(
             &run1.id,
             None,
@@ -281,7 +281,7 @@ mod tests {
         )
         .unwrap();
 
-        let run2 = mgr.create_run(Some("w1"), "Task 2", None, None).unwrap();
+        let run2 = mgr.create_run(Some("w1"), "Task 2", None).unwrap();
         mgr.update_run_completed(
             &run2.id,
             None,
@@ -297,7 +297,7 @@ mod tests {
         .unwrap();
 
         // One completed run on w2
-        let run3 = mgr.create_run(Some("w2"), "Task 3", None, None).unwrap();
+        let run3 = mgr.create_run(Some("w2"), "Task 3", None).unwrap();
         mgr.update_run_completed(
             &run3.id,
             None,
@@ -313,9 +313,7 @@ mod tests {
         .unwrap();
 
         // A running (non-completed) run on w1 — must NOT be included
-        let _run4 = mgr
-            .create_run(Some("w1"), "In progress", None, None)
-            .unwrap();
+        let _run4 = mgr.create_run(Some("w1"), "In progress", None).unwrap();
 
         let totals = mgr.totals_by_worktree().unwrap();
         assert_eq!(totals.len(), 2);
@@ -339,15 +337,15 @@ mod tests {
         assert!(counts.is_empty());
 
         // Create runs: two running in w1 (repo r1), one waiting_for_feedback in w2 (repo r1)
-        let _run1 = mgr.create_run(Some("w1"), "Task 1", None, None).unwrap();
-        let _run2 = mgr.create_run(Some("w1"), "Task 2", None, None).unwrap();
-        let run3 = mgr.create_run(Some("w2"), "Task 3", None, None).unwrap();
+        let _run1 = mgr.create_run(Some("w1"), "Task 1", None).unwrap();
+        let _run2 = mgr.create_run(Some("w1"), "Task 2", None).unwrap();
+        let run3 = mgr.create_run(Some("w2"), "Task 3", None).unwrap();
         // Set run3 to waiting_for_feedback via request_feedback
         mgr.request_feedback(&run3.id, "What should I do?", None)
             .unwrap();
 
         // Also create a completed run — should not appear in counts
-        let run4 = mgr.create_run(Some("w1"), "Task 4", None, None).unwrap();
+        let run4 = mgr.create_run(Some("w1"), "Task 4", None).unwrap();
         mgr.update_run_completed(
             &run4.id,
             None,
@@ -384,8 +382,8 @@ mod tests {
         ).unwrap();
 
         let mgr = AgentManager::new(&conn);
-        let _r1 = mgr.create_run(Some("w1"), "r1 task", None, None).unwrap();
-        let _r2 = mgr.create_run(Some("w3"), "r2 task", None, None).unwrap();
+        let _r1 = mgr.create_run(Some("w1"), "r1 task", None).unwrap();
+        let _r2 = mgr.create_run(Some("w3"), "r2 task", None).unwrap();
 
         let counts = mgr.active_run_counts_by_repo().unwrap();
         assert_eq!(counts.len(), 2);
@@ -410,9 +408,7 @@ mod tests {
         conn.execute("UPDATE worktrees SET ticket_id = 't1' WHERE id = 'w2'", [])
             .unwrap();
 
-        let run1 = mgr
-            .create_run(Some("w1"), "First task", None, None)
-            .unwrap();
+        let run1 = mgr.create_run(Some("w1"), "First task", None).unwrap();
         mgr.update_run_completed(
             &run1.id,
             None,
@@ -426,9 +422,7 @@ mod tests {
             None,
         )
         .unwrap();
-        let run2 = mgr
-            .create_run(Some("w1"), "Second task", None, None)
-            .unwrap();
+        let run2 = mgr.create_run(Some("w1"), "Second task", None).unwrap();
         mgr.update_run_completed(
             &run2.id,
             None,
@@ -442,9 +436,7 @@ mod tests {
             None,
         )
         .unwrap();
-        let run3 = mgr
-            .create_run(Some("w2"), "Third task", None, None)
-            .unwrap();
+        let run3 = mgr.create_run(Some("w2"), "Third task", None).unwrap();
         mgr.update_run_completed(
             &run3.id,
             None,
@@ -459,9 +451,7 @@ mod tests {
         )
         .unwrap();
 
-        let _run4 = mgr
-            .create_run(Some("w1"), "In progress", None, None)
-            .unwrap();
+        let _run4 = mgr.create_run(Some("w1"), "In progress", None).unwrap();
 
         let totals = mgr.totals_by_ticket_all().unwrap();
         assert_eq!(totals.len(), 1);
@@ -489,9 +479,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let parent = mgr
-            .create_run(Some("w1"), "Supervisor", None, None)
-            .unwrap();
+        let parent = mgr.create_run(Some("w1"), "Supervisor", None).unwrap();
         mgr.update_run_completed(
             &parent.id,
             None,
@@ -507,7 +495,7 @@ mod tests {
         .unwrap();
 
         let child1 = mgr
-            .create_child_run(Some("w1"), "Child 1", None, None, &parent.id, None)
+            .create_child_run(Some("w1"), "Child 1", None, &parent.id, None)
             .unwrap();
         mgr.update_run_completed(
             &child1.id,
@@ -524,7 +512,7 @@ mod tests {
         .unwrap();
 
         let child2 = mgr
-            .create_child_run(Some("w2"), "Child 2", None, None, &parent.id, None)
+            .create_child_run(Some("w2"), "Child 2", None, &parent.id, None)
             .unwrap();
         mgr.update_run_completed(
             &child2.id,
@@ -541,7 +529,7 @@ mod tests {
         .unwrap();
 
         let _running = mgr
-            .create_child_run(Some("w1"), "Still running", None, None, &parent.id, None)
+            .create_child_run(Some("w1"), "Still running", None, &parent.id, None)
             .unwrap();
 
         let totals = mgr.aggregate_run_tree(&parent.id).unwrap();
@@ -568,7 +556,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, Some("claude-sonnet-4-6"))
+            .create_run(Some("w1"), "Fix the bug", Some("claude-sonnet-4-6"))
             .unwrap();
         mgr.update_run_completed(
             &run.id,
@@ -598,7 +586,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         let run1 = mgr
-            .create_run(Some("w1"), "Implement feature", None, Some("sonnet"))
+            .create_run(Some("w1"), "Implement feature", Some("sonnet"))
             .unwrap();
         mgr.update_run_completed(
             &run1.id,
@@ -618,7 +606,6 @@ mod tests {
             .create_run(
                 Some("w1"),
                 "PR review swarm for branch 'feat/test'. Coordinating 2 reviewer agents.",
-                None,
                 Some("haiku"),
             )
             .unwrap();
@@ -626,7 +613,6 @@ mod tests {
             .create_child_run(
                 Some("w1"),
                 "Review correctness",
-                None,
                 Some("haiku"),
                 &review.id,
                 None,
@@ -675,7 +661,7 @@ mod tests {
 
         // 1. Initial implementation run
         let run1 = mgr
-            .create_run(Some("w1"), "Implement the feature", None, Some("sonnet"))
+            .create_run(Some("w1"), "Implement the feature", Some("sonnet"))
             .unwrap();
         mgr.update_run_completed(
             &run1.id,
@@ -696,7 +682,6 @@ mod tests {
             .create_run(
                 Some("w1"),
                 "PR review swarm for branch 'feat/test'.",
-                None,
                 Some("haiku"),
             )
             .unwrap();
@@ -716,7 +701,7 @@ mod tests {
 
         // 3. Fix run — non-review prompt after a review: triggers the `else if review_count > 0` branch
         let fix = mgr
-            .create_run(Some("w1"), "Address review comments", None, Some("sonnet"))
+            .create_run(Some("w1"), "Address review comments", Some("sonnet"))
             .unwrap();
         mgr.update_run_completed(
             &fix.id,
@@ -744,11 +729,9 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let parent = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let parent = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let child = mgr
-            .create_child_run(Some("w1"), "Sub-task", None, None, &parent.id, None)
+            .create_child_run(Some("w1"), "Sub-task", None, &parent.id, None)
             .unwrap();
         mgr.update_run_completed(
             &parent.id,
@@ -816,7 +799,7 @@ mod tests {
             .unwrap();
 
         // Create completed runs for both repos
-        let run1 = mgr.create_run(Some("w1"), "r1 task", None, None).unwrap();
+        let run1 = mgr.create_run(Some("w1"), "r1 task", None).unwrap();
         mgr.update_run_completed(
             &run1.id,
             None,
@@ -831,7 +814,7 @@ mod tests {
         )
         .unwrap();
 
-        let run2 = mgr.create_run(Some("w3"), "r2 task", None, None).unwrap();
+        let run2 = mgr.create_run(Some("w3"), "r2 task", None).unwrap();
         mgr.update_run_completed(
             &run2.id,
             None,
@@ -848,9 +831,7 @@ mod tests {
 
         // Add a non-completed (running) run for r1/t1 — should be excluded by the
         // `status = 'completed'` filter and not inflate totals.
-        let _running_run = mgr
-            .create_run(Some("w1"), "still running", None, None)
-            .unwrap();
+        let _running_run = mgr.create_run(Some("w1"), "still running", None).unwrap();
 
         // Repo r1 should only include t1, and the running run should be excluded
         let r1_totals = mgr.totals_by_ticket_for_repo("r1").unwrap();

--- a/conductor-core/src/agent/manager/events.rs
+++ b/conductor-core/src/agent/manager/events.rs
@@ -274,9 +274,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let t = "2024-01-01T00:00:00Z";
 
         let ev1 = mgr
@@ -310,8 +308,8 @@ mod tests {
         let mgr = AgentManager::new(&conn);
         let t = "2024-01-01T00:00:00Z";
 
-        let run_a = mgr.create_run(Some("w1"), "Run A", None, None).unwrap();
-        let run_b = mgr.create_run(Some("w1"), "Run B", None, None).unwrap();
+        let run_a = mgr.create_run(Some("w1"), "Run A", None).unwrap();
+        let run_b = mgr.create_run(Some("w1"), "Run B", None).unwrap();
 
         mgr.create_event(&run_a.id, "tool", "Event for A", t, None)
             .unwrap();
@@ -337,9 +335,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
         let t = "2024-01-01T00:00:00Z";
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let ev1 = mgr
             .create_event(&run.id, "tool", "[Bash] cargo build", t, None)
             .unwrap();
@@ -371,9 +367,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let t0 = "2024-01-01T00:00:00Z";
         let t1 = "2024-01-01T00:00:02Z";
         let t2 = "2024-01-01T00:00:05Z";
@@ -405,15 +399,9 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run1 = mgr
-            .create_run(Some("w1"), "First task", None, None)
-            .unwrap();
-        let run2 = mgr
-            .create_run(Some("w1"), "Second task", None, None)
-            .unwrap();
-        let run3 = mgr
-            .create_run(Some("w2"), "Other task", None, None)
-            .unwrap();
+        let run1 = mgr.create_run(Some("w1"), "First task", None).unwrap();
+        let run2 = mgr.create_run(Some("w1"), "Second task", None).unwrap();
+        let run3 = mgr.create_run(Some("w2"), "Other task", None).unwrap();
 
         let t = "2024-01-01T00:00:00Z";
         mgr.create_event(&run1.id, "text", "Planning", t, None)
@@ -440,7 +428,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         let prompt_text = "Fix the login bug";
-        let run = mgr.create_run(Some("w1"), prompt_text, None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), prompt_text, None).unwrap();
 
         let t0 = "2024-01-01T00:00:00Z";
         let t1 = "2024-01-01T00:00:01Z";
@@ -470,9 +458,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let t = "2024-01-01T00:00:00Z";
         mgr.create_event(&run.id, "text", "hello", t, None).unwrap();
         mgr.create_event(&run.id, "tool", "[Bash] ls", t, None)
@@ -493,12 +479,8 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run1 = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
-        let run2 = mgr
-            .create_run(Some("w2"), "Other task", None, None)
-            .unwrap();
+        let run1 = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
+        let run2 = mgr.create_run(Some("w2"), "Other task", None).unwrap();
 
         // No issues yet
         assert!(mgr
@@ -564,15 +546,11 @@ mod tests {
         let t = "2024-01-01T00:00:00Z";
 
         // Create repo-scoped runs for r1
-        let repo_run1 = mgr
-            .create_repo_run("r1", "Repo task 1", None, None)
-            .unwrap();
-        let repo_run2 = mgr
-            .create_repo_run("r1", "Repo task 2", None, None)
-            .unwrap();
+        let repo_run1 = mgr.create_repo_run("r1", "Repo task 1", None).unwrap();
+        let repo_run2 = mgr.create_repo_run("r1", "Repo task 2", None).unwrap();
 
         // Create a worktree-scoped run for the same repo — should be excluded
-        let wt_run = mgr.create_run(Some("w1"), "WT task", None, None).unwrap();
+        let wt_run = mgr.create_run(Some("w1"), "WT task", None).unwrap();
 
         mgr.create_event(&repo_run1.id, "text", "Planning repo", t, None)
             .unwrap();

--- a/conductor-core/src/agent/manager/feedback.rs
+++ b/conductor-core/src/agent/manager/feedback.rs
@@ -459,9 +459,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         assert_eq!(run.status, AgentRunStatus::Running);
 
         let fb = mgr
@@ -482,9 +480,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let fb = mgr
             .request_feedback(&run.id, "Proceed with refactor?", None)
             .unwrap();
@@ -503,9 +499,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let fb = mgr
             .request_feedback(&run.id, "Need approval", None)
             .unwrap();
@@ -524,9 +518,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
 
         assert!(mgr.pending_feedback_for_run(&run.id).unwrap().is_none());
 
@@ -543,9 +535,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
 
         assert!(mgr.pending_feedback_for_worktree("w1").unwrap().is_none());
 
@@ -563,9 +553,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
 
         let fb1 = mgr.request_feedback(&run.id, "Question 1", None).unwrap();
         mgr.submit_feedback(&fb1.id, "Answer 1").unwrap();
@@ -579,9 +567,7 @@ mod tests {
         assert_eq!(all[1].prompt, "Question 1");
         assert_eq!(all[1].status, FeedbackStatus::Responded);
 
-        let run2 = mgr
-            .create_run(Some("w2"), "Other task", None, None)
-            .unwrap();
+        let run2 = mgr.create_run(Some("w2"), "Other task", None).unwrap();
         assert!(mgr.list_feedback_for_run(&run2.id).unwrap().is_empty());
 
         mgr.dismiss_feedback(&fb2.id).unwrap();
@@ -592,9 +578,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let fb = mgr.request_feedback(&run.id, "Approve?", None).unwrap();
 
         conn.execute(
@@ -611,9 +595,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let fb = mgr.request_feedback(&run.id, "Proceed?", None).unwrap();
 
         mgr.submit_feedback(&fb.id, "Yes").unwrap();
@@ -635,9 +617,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let fb = mgr.request_feedback(&run.id, "Approve?", None).unwrap();
 
         mgr.dismiss_feedback(&fb.id).unwrap();
@@ -666,9 +646,7 @@ mod tests {
     fn list_all_pending_feedback_requests_returns_pending_only() {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
-        let run = mgr
-            .create_run(Some("w1"), "test prompt", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "test prompt", None).unwrap();
 
         let req1 = mgr.request_feedback(&run.id, "question 1", None).unwrap();
         let req2 = mgr.request_feedback(&run.id, "question 2", None).unwrap();
@@ -686,8 +664,8 @@ mod tests {
     fn list_all_pending_feedback_requests_across_runs() {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
-        let run1 = mgr.create_run(Some("w1"), "run 1", None, None).unwrap();
-        let run2 = mgr.create_run(Some("w2"), "run 2", None, None).unwrap();
+        let run1 = mgr.create_run(Some("w1"), "run 1", None).unwrap();
+        let run2 = mgr.create_run(Some("w2"), "run 2", None).unwrap();
 
         mgr.request_feedback(&run1.id, "from run 1", None).unwrap();
         mgr.request_feedback(&run2.id, "from run 2", None).unwrap();
@@ -704,9 +682,7 @@ mod tests {
     fn test_request_feedback_with_structured_params() {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
 
         let params = FeedbackRequestParams {
             feedback_type: FeedbackType::SingleSelect,
@@ -742,9 +718,7 @@ mod tests {
     fn test_request_feedback_select_requires_options() {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
 
         let params = FeedbackRequestParams {
             feedback_type: FeedbackType::SingleSelect,
@@ -765,7 +739,7 @@ mod tests {
     fn test_dismiss_expired_feedback_requests() {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
-        let run = mgr.create_run(Some("w1"), "task", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "task", None).unwrap();
 
         // Create a feedback request with a 0-second timeout (already expired)
         let params = FeedbackRequestParams {
@@ -778,7 +752,7 @@ mod tests {
             .unwrap();
 
         // Also create one without a timeout (should NOT be dismissed)
-        let run2 = mgr.create_run(Some("w2"), "task2", None, None).unwrap();
+        let run2 = mgr.create_run(Some("w2"), "task2", None).unwrap();
         let fb2 = mgr.request_feedback(&run2.id, "no timeout", None).unwrap();
 
         let dismissed = mgr.dismiss_expired_feedback_requests().unwrap();
@@ -803,7 +777,7 @@ mod tests {
         insert_conversation(&conn, "conv1", "w1");
         let mgr = AgentManager::new(&conn);
         let run = mgr
-            .create_run_for_conversation("w1", "task", None, None, "conv1")
+            .create_run_for_conversation("w1", "task", None, "conv1")
             .unwrap();
         let fb = mgr.request_feedback(&run.id, "Approve?", None).unwrap();
 
@@ -837,7 +811,7 @@ mod tests {
         insert_conversation(&conn, "conv1", "w1");
         let mgr = AgentManager::new(&conn);
         let run = mgr
-            .create_run_for_conversation("w1", "task", None, None, "conv1")
+            .create_run_for_conversation("w1", "task", None, "conv1")
             .unwrap();
         let fb = mgr.request_feedback(&run.id, "Approve?", None).unwrap();
 
@@ -856,7 +830,7 @@ mod tests {
         insert_conversation(&conn, "conv1", "w1");
         let mgr = AgentManager::new(&conn);
         let run = mgr
-            .create_run_for_conversation("w1", "task", None, None, "conv1")
+            .create_run_for_conversation("w1", "task", None, "conv1")
             .unwrap();
 
         let err = mgr
@@ -874,10 +848,10 @@ mod tests {
         insert_conversation(&conn, "conv1", "w1");
         let mgr = AgentManager::new(&conn);
         let run1 = mgr
-            .create_run_for_conversation("w1", "task1", None, None, "conv1")
+            .create_run_for_conversation("w1", "task1", None, "conv1")
             .unwrap();
         let run2 = mgr
-            .create_run_for_conversation("w2", "task2", None, None, "conv1")
+            .create_run_for_conversation("w2", "task2", None, "conv1")
             .unwrap();
         let fb2 = mgr.request_feedback(&run2.id, "Approve?", None).unwrap();
 
@@ -899,7 +873,7 @@ mod tests {
         insert_conversation(&conn, "conv1", "w1");
         let mgr = AgentManager::new(&conn);
         let run = mgr
-            .create_run_for_conversation("w1", "task", None, None, "conv1")
+            .create_run_for_conversation("w1", "task", None, "conv1")
             .unwrap();
         mgr.request_feedback(&run.id, "Approve?", None).unwrap();
 
@@ -930,7 +904,7 @@ mod tests {
         insert_conversation(&conn, "conv1", "w1");
         let mgr = AgentManager::new(&conn);
         let run = mgr
-            .create_run_for_conversation("w1", "task", None, None, "conv1")
+            .create_run_for_conversation("w1", "task", None, "conv1")
             .unwrap();
 
         let err = mgr
@@ -948,7 +922,7 @@ mod tests {
         insert_conversation(&conn, "conv1", "w1");
         let mgr = AgentManager::new(&conn);
         let run = mgr
-            .create_run_for_conversation("w1", "task", None, None, "conv1")
+            .create_run_for_conversation("w1", "task", None, "conv1")
             .unwrap();
 
         let err = mgr

--- a/conductor-core/src/agent/manager/lifecycle.rs
+++ b/conductor-core/src/agent/manager/lifecycle.rs
@@ -12,20 +12,9 @@ impl<'a> AgentManager<'a> {
         &self,
         worktree_id: Option<&str>,
         prompt: &str,
-        tmux_window: Option<&str>,
         model: Option<&str>,
     ) -> Result<AgentRun> {
-        self.create_run_with_parent(
-            worktree_id,
-            None,
-            prompt,
-            tmux_window,
-            model,
-            None,
-            None,
-            None,
-            None,
-        )
+        self.create_run_with_parent(worktree_id, None, prompt, model, None, None, None, None)
     }
 
     /// Create a run scoped to a repo (no worktree). Used for read-only repo agents.
@@ -33,27 +22,15 @@ impl<'a> AgentManager<'a> {
         &self,
         repo_id: &str,
         prompt: &str,
-        tmux_window: Option<&str>,
         model: Option<&str>,
     ) -> Result<AgentRun> {
-        self.create_run_with_parent(
-            None,
-            Some(repo_id),
-            prompt,
-            tmux_window,
-            model,
-            None,
-            None,
-            None,
-            None,
-        )
+        self.create_run_with_parent(None, Some(repo_id), prompt, model, None, None, None, None)
     }
 
     pub fn create_child_run(
         &self,
         worktree_id: Option<&str>,
         prompt: &str,
-        tmux_window: Option<&str>,
         model: Option<&str>,
         parent_run_id: &str,
         bot_name: Option<&str>,
@@ -62,7 +39,6 @@ impl<'a> AgentManager<'a> {
             worktree_id,
             None,
             prompt,
-            tmux_window,
             model,
             Some(parent_run_id),
             bot_name,
@@ -76,7 +52,6 @@ impl<'a> AgentManager<'a> {
         &self,
         worktree_id: &str,
         prompt: &str,
-        tmux_window: Option<&str>,
         model: Option<&str>,
         conversation_id: &str,
     ) -> Result<AgentRun> {
@@ -84,7 +59,6 @@ impl<'a> AgentManager<'a> {
             Some(worktree_id),
             None,
             prompt,
-            tmux_window,
             model,
             None,
             None,
@@ -98,7 +72,6 @@ impl<'a> AgentManager<'a> {
         &self,
         repo_id: &str,
         prompt: &str,
-        tmux_window: Option<&str>,
         model: Option<&str>,
         conversation_id: &str,
     ) -> Result<AgentRun> {
@@ -106,7 +79,6 @@ impl<'a> AgentManager<'a> {
             None,
             Some(repo_id),
             prompt,
-            tmux_window,
             model,
             None,
             None,
@@ -121,7 +93,6 @@ impl<'a> AgentManager<'a> {
         worktree_id: Option<&str>,
         repo_id: Option<&str>,
         prompt: &str,
-        tmux_window: Option<&str>,
         model: Option<&str>,
         parent_run_id: Option<&str>,
         bot_name: Option<&str>,
@@ -144,7 +115,6 @@ impl<'a> AgentManager<'a> {
             duration_ms: None,
             started_at: now.clone(),
             ended_at: None,
-            tmux_window: tmux_window.map(String::from),
             log_file: log_file.map(String::from),
             model: model.map(String::from),
             plan: None,
@@ -161,9 +131,9 @@ impl<'a> AgentManager<'a> {
 
         self.conn.execute(
             "INSERT INTO agent_runs \
-             (id, worktree_id, repo_id, prompt, status, started_at, tmux_window, model, \
+             (id, worktree_id, repo_id, prompt, status, started_at, model, \
               parent_run_id, bot_name, log_file, conversation_id, runtime) \
-             VALUES (:id, :worktree_id, :repo_id, :prompt, :status, :started_at, :tmux_window, \
+             VALUES (:id, :worktree_id, :repo_id, :prompt, :status, :started_at, \
                      :model, :parent_run_id, :bot_name, :log_file, :conversation_id, :runtime)",
             named_params! {
                 ":id": run.id,
@@ -172,7 +142,6 @@ impl<'a> AgentManager<'a> {
                 ":prompt": run.prompt,
                 ":status": run.status,
                 ":started_at": run.started_at,
-                ":tmux_window": run.tmux_window,
                 ":model": run.model,
                 ":parent_run_id": run.parent_run_id,
                 ":bot_name": run.bot_name,
@@ -414,16 +383,6 @@ impl<'a> AgentManager<'a> {
         Ok(())
     }
 
-    /// Persist the tmux window name for an agent run so liveness checks and
-    /// the orphan reaper can find it.
-    pub fn update_run_tmux_window(&self, run_id: &str, window: &str) -> Result<()> {
-        self.conn.execute(
-            "UPDATE agent_runs SET tmux_window = :window WHERE id = :id",
-            named_params! { ":window": window, ":id": run_id },
-        )?;
-        Ok(())
-    }
-
     /// Store the OS PID for a headless agent run immediately after spawn.
     pub fn update_run_subprocess_pid(&self, run_id: &str, pid: u32) -> Result<()> {
         self.conn.execute(
@@ -505,7 +464,6 @@ impl<'a> AgentManager<'a> {
             original.worktree_id.as_deref(),
             original.repo_id.as_deref(),
             &original.prompt,
-            original.tmux_window.as_deref(),
             original.model.as_deref(),
             Some(run_id),
             original.bot_name.as_deref(),
@@ -552,12 +510,9 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         assert_eq!(run.status, AgentRunStatus::Running);
         assert_eq!(run.prompt, "Fix the bug");
-        assert!(run.tmux_window.is_none());
 
         let runs = mgr.list_for_worktree("w1").unwrap();
         assert_eq!(runs.len(), 1);
@@ -565,27 +520,11 @@ mod tests {
     }
 
     #[test]
-    fn test_create_with_tmux_window() {
-        let conn = setup_db();
-        let mgr = AgentManager::new(&conn);
-
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", Some("feat-test"), None)
-            .unwrap();
-        assert_eq!(run.tmux_window.as_deref(), Some("feat-test"));
-
-        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
-        assert_eq!(fetched.tmux_window.as_deref(), Some("feat-test"));
-    }
-
-    #[test]
     fn test_update_completed() {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         mgr.update_run_completed(
             &run.id,
             Some("sess-123"),
@@ -611,9 +550,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         mgr.update_run_failed(&run.id, "Something went wrong")
             .unwrap();
 
@@ -627,9 +564,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         mgr.update_run_cancelled(&run.id).unwrap();
 
         let latest = mgr.latest_for_worktree("w1").unwrap().unwrap();
@@ -642,9 +577,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", Some("feat-test"), None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         assert!(run.log_file.is_none());
 
         mgr.update_run_log_file(&run.id, "/tmp/agent-logs/test.log")
@@ -662,9 +595,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         mgr.update_run_failed_with_session(&run.id, "Context exhausted", Some("sess-456"))
             .unwrap();
 
@@ -679,9 +610,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         assert!(run.claude_session_id.is_none());
 
         mgr.update_run_session_id(&run.id, "sess-early").unwrap();
@@ -695,9 +624,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         // Session ID was saved eagerly during stream
         mgr.update_run_session_id(&run.id, "sess-eager").unwrap();
         // Fail without passing session_id (uses COALESCE to keep existing)
@@ -713,7 +640,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, Some("claude-sonnet-4-6"))
+            .create_run(Some("w1"), "Fix the bug", Some("claude-sonnet-4-6"))
             .unwrap();
         assert_eq!(run.model.as_deref(), Some("claude-sonnet-4-6"));
 
@@ -726,9 +653,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         assert!(run.input_tokens.is_none());
 
         mgr.update_run_tokens_partial(&run.id, 100, 50, 20, 10)
@@ -751,9 +676,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
 
         mgr.update_run_tokens_partial(&run.id, 100, 50, 20, 10)
             .unwrap();
@@ -773,9 +696,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         mgr.update_run_tokens_partial(&run.id, 100, 50, 20, 10)
             .unwrap();
 
@@ -806,9 +727,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         assert!(run.model.is_none());
 
         let fetched = mgr.get_run(&run.id).unwrap().unwrap();
@@ -821,12 +740,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         let run = mgr
-            .create_run(
-                Some("w1"),
-                "Fix the bug",
-                Some("feat-test"),
-                Some("claude-sonnet-4-6"),
-            )
+            .create_run(Some("w1"), "Fix the bug", Some("claude-sonnet-4-6"))
             .unwrap();
         mgr.update_run_failed(&run.id, "Crashed").unwrap();
 
@@ -834,7 +748,6 @@ mod tests {
         assert_eq!(restarted.status, AgentRunStatus::Running);
         assert_eq!(restarted.prompt, "Fix the bug");
         assert_eq!(restarted.model.as_deref(), Some("claude-sonnet-4-6"));
-        assert_eq!(restarted.tmux_window.as_deref(), Some("feat-test"));
         assert_eq!(restarted.parent_run_id.as_deref(), Some(run.id.as_str()));
         assert_ne!(restarted.id, run.id);
 
@@ -849,12 +762,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         let run = mgr
-            .create_run(
-                Some("w1"),
-                "Fix the bug",
-                Some("feat-test"),
-                Some("claude-sonnet-4-6"),
-            )
+            .create_run(Some("w1"), "Fix the bug", Some("claude-sonnet-4-6"))
             .unwrap();
         mgr.update_run_cancelled(&run.id).unwrap();
 
@@ -874,9 +782,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         // Run is still Running — restart should fail
         let result = mgr.restart_run(&run.id);
         assert!(result.is_err());
@@ -895,9 +801,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_repo_run("r1", "Analyse the repo", Some("repo-test-abc"), None)
-            .unwrap();
+        let run = mgr.create_repo_run("r1", "Analyse the repo", None).unwrap();
         mgr.update_run_failed(&run.id, "Crashed").unwrap();
 
         let restarted = mgr.restart_run(&run.id).unwrap();
@@ -912,14 +816,11 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_repo_run("r1", "Analyse the repo", Some("repo-test-abc"), None)
-            .unwrap();
+        let run = mgr.create_repo_run("r1", "Analyse the repo", None).unwrap();
 
         assert_eq!(run.repo_id.as_deref(), Some("r1"));
         assert!(run.worktree_id.is_none());
         assert_eq!(run.prompt, "Analyse the repo");
-        assert_eq!(run.tmux_window.as_deref(), Some("repo-test-abc"));
         assert_eq!(run.status, AgentRunStatus::Running);
 
         let fetched = mgr.get_run(&run.id).unwrap().unwrap();
@@ -937,7 +838,6 @@ mod tests {
                 Some("w1"),
                 None,
                 "Fix the bug",
-                Some("feat-test"),
                 None,
                 None,
                 None,
@@ -959,7 +859,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr.create_run(Some("w1"), "task", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "task", None).unwrap();
         mgr.update_run_failed(&run.id, "original error").unwrap();
 
         // Calling the if_running variant on an already-failed run must be a no-op.
@@ -983,7 +883,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr.create_run(Some("w1"), "task", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "task", None).unwrap();
         mgr.update_run_completed_if_running(&run.id, "done")
             .unwrap();
 
@@ -1011,7 +911,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr.create_run(Some("w1"), "task", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "task", None).unwrap();
         mgr.update_run_failed(&run.id, "original error").unwrap();
 
         // Calling the if_running variant on an already-failed run must be a no-op.
@@ -1032,7 +932,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr.create_run(Some("w1"), "task", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "task", None).unwrap();
 
         mgr.update_run_completed_if_running_full(
             &run.id,
@@ -1072,7 +972,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr.create_run(Some("w1"), "task", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "task", None).unwrap();
         mgr.update_run_session_id(&run.id, "sess-early").unwrap();
 
         mgr.update_run_completed_if_running_full(
@@ -1107,7 +1007,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr.create_run(Some("w1"), "task", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "task", None).unwrap();
         mgr.update_run_failed(&run.id, "original error").unwrap();
 
         // Guard must prevent overwriting a finalized run
@@ -1148,7 +1048,7 @@ mod tests {
 
         // Create a run with a known model
         let run = mgr
-            .create_run(Some("w1"), "test", None, Some("original-model"))
+            .create_run(Some("w1"), "test", Some("original-model"))
             .unwrap();
         assert_eq!(run.model.as_deref(), Some("original-model"));
 
@@ -1189,7 +1089,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr.create_run(Some("w1"), "task", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "task", None).unwrap();
         mgr.request_feedback(&run.id, "what should I do?", None)
             .expect("request_feedback must succeed");
 
@@ -1223,7 +1123,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr.create_run(Some("w1"), "task", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "task", None).unwrap();
         mgr.cancel_run(&run.id, None).unwrap();
 
         let fetched = mgr.get_run(&run.id).unwrap().unwrap();
@@ -1237,7 +1137,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr.create_run(Some("w1"), "task", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "task", None).unwrap();
         mgr.cancel_run(&run.id, None).unwrap();
         // Second cancel should succeed — the UPDATE is a no-op but still OK.
         mgr.cancel_run(&run.id, None).unwrap();
@@ -1256,7 +1156,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr.create_run(Some("w1"), "task", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "task", None).unwrap();
         // i64::MAX is guaranteed not to be a real PID on any platform.
         mgr.cancel_run(&run.id, Some(i64::MAX)).unwrap();
 
@@ -1270,9 +1170,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
 
         let pid_err = "disk I/O error";
         let msg = format!("failed to persist subprocess pid: {pid_err}");
@@ -1315,7 +1213,7 @@ mod tests {
             "/tmp/ws/feat-test",
         );
         let run = AgentManager::new(&conn)
-            .create_run(Some("w1"), "test prompt", None, None)
+            .create_run(Some("w1"), "test prompt", None)
             .expect("create run");
         let run_id = run.id.clone();
 
@@ -1355,21 +1253,10 @@ mod tests {
     fn test_update_run_runtime() {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
-        let run = mgr.create_run(Some("w1"), "prompt", None, None).unwrap();
+        let run = mgr.create_run(Some("w1"), "prompt", None).unwrap();
         assert_eq!(run.runtime.as_str(), "claude");
         mgr.update_run_runtime(&run.id, "gemini").unwrap();
         let fetched = mgr.get_run(&run.id).unwrap().unwrap();
         assert_eq!(fetched.runtime.as_str(), "gemini");
-    }
-
-    #[test]
-    fn test_update_run_tmux_window() {
-        let conn = setup_db();
-        let mgr = AgentManager::new(&conn);
-        let run = mgr.create_run(Some("w1"), "prompt", None, None).unwrap();
-        assert!(run.tmux_window.is_none());
-        mgr.update_run_tmux_window(&run.id, "cli-abc12345").unwrap();
-        let fetched = mgr.get_run(&run.id).unwrap().unwrap();
-        assert_eq!(fetched.tmux_window.as_deref(), Some("cli-abc12345"));
     }
 }

--- a/conductor-core/src/agent/manager/orphans.rs
+++ b/conductor-core/src/agent/manager/orphans.rs
@@ -218,9 +218,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "test prompt", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "test prompt", None).unwrap();
         assert_eq!(run.status, AgentRunStatus::Running);
 
         let reaped = mgr.reap_orphaned_runs().unwrap();
@@ -241,9 +239,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "test prompt", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "test prompt", None).unwrap();
         mgr.update_run_completed(
             &run.id,
             None,
@@ -271,9 +267,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create an agent run with no subprocess PID (would normally be reaped).
-        let parent_run = mgr
-            .create_run(Some("w1"), "workflow parent", None, None)
-            .unwrap();
+        let parent_run = mgr.create_run(Some("w1"), "workflow parent", None).unwrap();
         assert_eq!(parent_run.status, AgentRunStatus::Running);
 
         // Insert an active workflow run referencing this agent run as its parent.
@@ -303,9 +297,9 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let r1 = mgr.create_run(Some("w1"), "prompt 1", None, None).unwrap();
-        let r2 = mgr.create_run(Some("w1"), "prompt 2", None, None).unwrap();
-        let r3 = mgr.create_run(Some("w1"), "prompt 3", None, None).unwrap();
+        let r1 = mgr.create_run(Some("w1"), "prompt 1", None).unwrap();
+        let r2 = mgr.create_run(Some("w1"), "prompt 2", None).unwrap();
+        let r3 = mgr.create_run(Some("w1"), "prompt 3", None).unwrap();
         mgr.update_run_completed(
             &r3.id,
             None,
@@ -352,9 +346,7 @@ mod tests {
         // Give the OS a moment to fully reap the child.
         std::thread::sleep(std::time::Duration::from_millis(50));
 
-        let run = mgr
-            .create_run(Some("w1"), "headless task", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "headless task", None).unwrap();
         // Set subprocess_pid to the dead PID.
         conn.execute(
             "UPDATE agent_runs SET subprocess_pid = :pid WHERE id = :id",
@@ -391,7 +383,7 @@ mod tests {
         let live_pid = child.id();
 
         let run = mgr
-            .create_run(Some("w1"), "headless task recycled", None, None)
+            .create_run(Some("w1"), "headless task recycled", None)
             .unwrap();
 
         // Backdate started_at to 2020 — far outside the 60-second tolerance.
@@ -435,9 +427,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Parent run of an active workflow (no subprocess_pid by design).
-        let parent_run = mgr
-            .create_run(Some("w1"), "workflow parent", None, None)
-            .unwrap();
+        let parent_run = mgr.create_run(Some("w1"), "workflow parent", None).unwrap();
 
         // Insert an active workflow run whose parent is the run above.
         let wf_run_id = crate::new_id();
@@ -451,7 +441,7 @@ mod tests {
 
         // Child run (e.g. plan step) — subprocess_pid not yet stored.
         let child_run = mgr
-            .create_child_run(Some("w1"), "plan prompt", None, None, &parent_run.id, None)
+            .create_child_run(Some("w1"), "plan prompt", None, &parent_run.id, None)
             .unwrap();
         assert_eq!(child_run.status, AgentRunStatus::Running);
         assert!(child_run.subprocess_pid.is_none());
@@ -482,9 +472,7 @@ mod tests {
         parent_status: &str,
         wf_status: &str,
     ) -> String {
-        let run = mgr
-            .create_run(Some("w1"), "test prompt", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "test prompt", None).unwrap();
         conn.execute(
             "UPDATE agent_runs SET status = :status, ended_at = '2025-01-01T00:01:00Z' WHERE id = :id",
             rusqlite::named_params! { ":status": parent_status, ":id": run.id },
@@ -680,7 +668,7 @@ mod tests {
         let live_pid = std::process::id();
 
         let run = mgr
-            .create_run(Some("w1"), "headless task alive", None, None)
+            .create_run(Some("w1"), "headless task alive", None)
             .unwrap();
         conn.execute(
             "UPDATE agent_runs SET subprocess_pid = :pid WHERE id = :id",

--- a/conductor-core/src/agent/manager/plan_steps.rs
+++ b/conductor-core/src/agent/manager/plan_steps.rs
@@ -137,9 +137,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         assert!(run.plan.is_none());
 
         let steps = vec![
@@ -172,9 +170,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let steps = vec![
             PlanStep {
                 description: "Step one".to_string(),
@@ -203,9 +199,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         // Should not error when no plan exists
         mgr.mark_plan_done(&run.id).unwrap();
 
@@ -218,9 +212,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let steps = vec![PlanStep {
             description: "Do the thing".to_string(),
             done: true,
@@ -242,9 +234,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let steps = vec![
             PlanStep {
                 description: "Step one".to_string(),
@@ -287,9 +277,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let steps = vec![PlanStep {
             description: "Step one".to_string(),
             ..Default::default()
@@ -311,9 +299,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let steps = vec![
             PlanStep {
                 description: "First".to_string(),
@@ -345,9 +331,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let steps1 = vec![PlanStep {
             description: "Old step".to_string(),
             ..Default::default()
@@ -377,9 +361,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let steps = vec![
             PlanStep {
                 description: "Investigate".to_string(),
@@ -411,9 +393,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let steps = vec![
             PlanStep {
                 description: "Step 1".to_string(),
@@ -439,9 +419,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let steps = vec![PlanStep {
             description: "Step 1".to_string(),
             ..Default::default()
@@ -471,9 +449,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let steps = vec![PlanStep {
             description: "Step 1".to_string(),
             ..Default::default()
@@ -491,9 +467,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let steps = vec![PlanStep {
             description: "Step 1".to_string(),
             done: true,
@@ -525,7 +499,6 @@ mod tests {
             duration_ms: None,
             started_at: "2024-01-01T00:00:00Z".to_string(),
             ended_at: None,
-            tmux_window: None,
             log_file: None,
             model: None,
             plan: Some(vec![

--- a/conductor-core/src/agent/manager/queries.rs
+++ b/conductor-core/src/agent/manager/queries.rs
@@ -395,9 +395,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
         let fetched = mgr.get_run(&run.id).unwrap().unwrap();
         assert_eq!(fetched.id, run.id);
         assert_eq!(fetched.prompt, "Fix the bug");
@@ -424,8 +422,7 @@ mod tests {
         assert!(!mgr.has_runs_for_worktree("w1").unwrap());
 
         // Create a run
-        mgr.create_run(Some("w1"), "First prompt", None, None)
-            .unwrap();
+        mgr.create_run(Some("w1"), "First prompt", None).unwrap();
         assert!(mgr.has_runs_for_worktree("w1").unwrap());
 
         // Different worktree still has no runs
@@ -438,15 +435,9 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create runs for two different worktrees
-        let _run1 = mgr
-            .create_run(Some("w1"), "First prompt", None, None)
-            .unwrap();
-        let run2 = mgr
-            .create_run(Some("w1"), "Second prompt", None, None)
-            .unwrap();
-        let run3 = mgr
-            .create_run(Some("w2"), "Other prompt", None, None)
-            .unwrap();
+        let _run1 = mgr.create_run(Some("w1"), "First prompt", None).unwrap();
+        let run2 = mgr.create_run(Some("w1"), "Second prompt", None).unwrap();
+        let run3 = mgr.create_run(Some("w2"), "Other prompt", None).unwrap();
 
         let map = mgr.latest_runs_by_worktree().unwrap();
         assert_eq!(map.len(), 2);
@@ -460,12 +451,9 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create an ephemeral run with no worktree_id
-        mgr.create_run(None, "ephemeral prompt", None, None)
-            .unwrap();
+        mgr.create_run(None, "ephemeral prompt", None).unwrap();
         // Create a run with a real worktree_id
-        let run_w1 = mgr
-            .create_run(Some("w1"), "real prompt", None, None)
-            .unwrap();
+        let run_w1 = mgr.create_run(Some("w1"), "real prompt", None).unwrap();
 
         let map = mgr.latest_runs_by_worktree().unwrap();
         // Only the run with a worktree_id should appear
@@ -480,13 +468,11 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let parent = mgr
-            .create_run(Some("w1"), "Supervisor task", None, None)
-            .unwrap();
+        let parent = mgr.create_run(Some("w1"), "Supervisor task", None).unwrap();
         assert!(parent.parent_run_id.is_none());
 
         let child = mgr
-            .create_child_run(Some("w1"), "Sub-task A", None, None, &parent.id, None)
+            .create_child_run(Some("w1"), "Sub-task A", None, &parent.id, None)
             .unwrap();
         assert_eq!(child.parent_run_id.as_deref(), Some(parent.id.as_str()));
 
@@ -499,20 +485,16 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let parent = mgr
-            .create_run(Some("w1"), "Supervisor", None, None)
-            .unwrap();
+        let parent = mgr.create_run(Some("w1"), "Supervisor", None).unwrap();
         let _child1 = mgr
-            .create_child_run(Some("w1"), "Child 1", None, None, &parent.id, None)
+            .create_child_run(Some("w1"), "Child 1", None, &parent.id, None)
             .unwrap();
         let _child2 = mgr
-            .create_child_run(Some("w1"), "Child 2", None, None, &parent.id, None)
+            .create_child_run(Some("w1"), "Child 2", None, &parent.id, None)
             .unwrap();
 
         // Unrelated run should not appear
-        let _other = mgr
-            .create_run(Some("w1"), "Independent", None, None)
-            .unwrap();
+        let _other = mgr.create_run(Some("w1"), "Independent", None).unwrap();
 
         let children = mgr.list_child_runs(&parent.id).unwrap();
         assert_eq!(children.len(), 2);
@@ -527,19 +509,19 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Build a tree: parent -> child1, child2 -> grandchild
-        let parent = mgr.create_run(Some("w1"), "Root task", None, None).unwrap();
+        let parent = mgr.create_run(Some("w1"), "Root task", None).unwrap();
         let child1 = mgr
-            .create_child_run(Some("w1"), "Child 1", None, None, &parent.id, None)
+            .create_child_run(Some("w1"), "Child 1", None, &parent.id, None)
             .unwrap();
         let _child2 = mgr
-            .create_child_run(Some("w2"), "Child 2", None, None, &parent.id, None)
+            .create_child_run(Some("w2"), "Child 2", None, &parent.id, None)
             .unwrap();
         let _grandchild = mgr
-            .create_child_run(Some("w1"), "Grandchild", None, None, &child1.id, None)
+            .create_child_run(Some("w1"), "Grandchild", None, &child1.id, None)
             .unwrap();
 
         // Unrelated run
-        let _other = mgr.create_run(Some("w1"), "Other", None, None).unwrap();
+        let _other = mgr.create_run(Some("w1"), "Other", None).unwrap();
 
         let tree = mgr.get_run_tree(&parent.id).unwrap();
         assert_eq!(tree.len(), 4); // parent + 2 children + 1 grandchild
@@ -551,15 +533,11 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let parent = mgr
-            .create_run(Some("w1"), "Supervisor", None, None)
-            .unwrap();
+        let parent = mgr.create_run(Some("w1"), "Supervisor", None).unwrap();
         let _child = mgr
-            .create_child_run(Some("w1"), "Child", None, None, &parent.id, None)
+            .create_child_run(Some("w1"), "Child", None, &parent.id, None)
             .unwrap();
-        let standalone = mgr
-            .create_run(Some("w1"), "Standalone", None, None)
-            .unwrap();
+        let standalone = mgr.create_run(Some("w1"), "Standalone", None).unwrap();
 
         let root_runs = mgr.list_root_runs_for_worktree("w1").unwrap();
         assert_eq!(root_runs.len(), 2);
@@ -574,9 +552,9 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let parent = mgr.create_run(Some("w1"), "Parent", None, None).unwrap();
+        let parent = mgr.create_run(Some("w1"), "Parent", None).unwrap();
         let child = mgr
-            .create_child_run(Some("w1"), "Child", None, None, &parent.id, None)
+            .create_child_run(Some("w1"), "Child", None, &parent.id, None)
             .unwrap();
 
         // Delete the parent — ON DELETE SET NULL should clear child's parent_run_id
@@ -595,9 +573,9 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let r1 = mgr.create_run(Some("w1"), "Task 1", None, None).unwrap();
-        let r2 = mgr.create_run(Some("w1"), "Task 2", None, None).unwrap();
-        let r3 = mgr.create_run(Some("w1"), "Task 3", None, None).unwrap();
+        let r1 = mgr.create_run(Some("w1"), "Task 1", None).unwrap();
+        let r2 = mgr.create_run(Some("w1"), "Task 2", None).unwrap();
+        let r3 = mgr.create_run(Some("w1"), "Task 3", None).unwrap();
 
         let ids = vec![r1.id.as_str(), r2.id.as_str()];
         let result = mgr.get_runs_by_ids(&ids).unwrap();
@@ -615,7 +593,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let _r1 = mgr.create_run(Some("w1"), "Task 1", None, None).unwrap();
+        let _r1 = mgr.create_run(Some("w1"), "Task 1", None).unwrap();
 
         let result = mgr.get_runs_by_ids(&[]).unwrap();
         assert!(result.is_empty());
@@ -626,7 +604,7 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let r1 = mgr.create_run(Some("w1"), "Task 1", None, None).unwrap();
+        let r1 = mgr.create_run(Some("w1"), "Task 1", None).unwrap();
 
         let ids = vec![r1.id.as_str(), "nonexistent-id-xyz"];
         let result = mgr.get_runs_by_ids(&ids).unwrap();
@@ -641,8 +619,8 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let r1 = mgr.create_run(Some("w1"), "Task 1", None, None).unwrap();
-        let r2 = mgr.create_run(Some("w1"), "Task 2", None, None).unwrap();
+        let r1 = mgr.create_run(Some("w1"), "Task 1", None).unwrap();
+        let r2 = mgr.create_run(Some("w1"), "Task 2", None).unwrap();
 
         let runs = mgr.list_agent_runs(None, None, None, 50, 0).unwrap();
         assert_eq!(runs.len(), 2);
@@ -657,12 +635,8 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // w1 and w2 are both seeded; create runs in each
-        let r1 = mgr
-            .create_run(Some("w1"), "Task in w1", None, None)
-            .unwrap();
-        let _r2 = mgr
-            .create_run(Some("w2"), "Task in w2", None, None)
-            .unwrap();
+        let r1 = mgr.create_run(Some("w1"), "Task in w1", None).unwrap();
+        let _r2 = mgr.create_run(Some("w2"), "Task in w2", None).unwrap();
 
         let runs = mgr.list_agent_runs(Some("w1"), None, None, 50, 0).unwrap();
         assert_eq!(runs.len(), 1);
@@ -674,8 +648,8 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let r1 = mgr.create_run(Some("w1"), "Task 1", None, None).unwrap();
-        let r2 = mgr.create_run(Some("w1"), "Task 2", None, None).unwrap();
+        let r1 = mgr.create_run(Some("w1"), "Task 1", None).unwrap();
+        let r2 = mgr.create_run(Some("w1"), "Task 2", None).unwrap();
         mgr.update_run_completed(
             &r2.id,
             None,
@@ -720,8 +694,8 @@ mod tests {
         ).unwrap();
 
         let mgr = AgentManager::new(&conn);
-        let r1 = mgr.create_run(Some("w1"), "r1 task", None, None).unwrap();
-        let _r3 = mgr.create_run(Some("w3"), "r2 task", None, None).unwrap();
+        let r1 = mgr.create_run(Some("w1"), "r1 task", None).unwrap();
+        let _r3 = mgr.create_run(Some("w3"), "r2 task", None).unwrap();
 
         let runs = mgr.list_agent_runs(None, Some("r1"), None, 50, 0).unwrap();
         assert_eq!(runs.len(), 1);
@@ -745,15 +719,11 @@ mod tests {
         ).unwrap();
 
         let mgr = AgentManager::new(&conn);
-        let r1_running = mgr
-            .create_run(Some("w1"), "r1 running task", None, None)
-            .unwrap();
+        let r1_running = mgr.create_run(Some("w1"), "r1 running task", None).unwrap();
         let r1_completed = mgr
-            .create_run(Some("w1"), "r1 completed task", None, None)
+            .create_run(Some("w1"), "r1 completed task", None)
             .unwrap();
-        let _r2_running = mgr
-            .create_run(Some("w3"), "r2 running task", None, None)
-            .unwrap();
+        let _r2_running = mgr.create_run(Some("w3"), "r2 running task", None).unwrap();
 
         mgr.update_run_completed(
             &r1_completed.id,
@@ -801,8 +771,8 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let r1 = mgr.create_run(Some("w1"), "Task 1", None, None).unwrap();
-        let r2 = mgr.create_run(Some("w1"), "Task 2", None, None).unwrap();
+        let r1 = mgr.create_run(Some("w1"), "Task 1", None).unwrap();
+        let r2 = mgr.create_run(Some("w1"), "Task 2", None).unwrap();
         mgr.update_run_completed(
             &r1.id,
             None,
@@ -830,7 +800,7 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         for i in 0..5 {
-            mgr.create_run(Some("w1"), &format!("Task {i}"), None, None)
+            mgr.create_run(Some("w1"), &format!("Task {i}"), None)
                 .unwrap();
         }
 
@@ -857,15 +827,9 @@ mod tests {
         ).unwrap();
 
         let mgr = AgentManager::new(&conn);
-        let r1a = mgr
-            .create_run(Some("w1"), "Task for r1 w1", None, None)
-            .unwrap();
-        let r1b = mgr
-            .create_run(Some("w2"), "Task for r1 w2", None, None)
-            .unwrap();
-        let _r2 = mgr
-            .create_run(Some("w3"), "Task for r2", None, None)
-            .unwrap();
+        let r1a = mgr.create_run(Some("w1"), "Task for r1 w1", None).unwrap();
+        let r1b = mgr.create_run(Some("w2"), "Task for r1 w2", None).unwrap();
+        let _r2 = mgr.create_run(Some("w3"), "Task for r2", None).unwrap();
 
         let runs = mgr.list_for_repo("r1").unwrap();
         assert_eq!(runs.len(), 2);
@@ -882,9 +846,9 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let parent = mgr.create_run(Some("w1"), "Parent", None, None).unwrap();
+        let parent = mgr.create_run(Some("w1"), "Parent", None).unwrap();
         let run = mgr
-            .create_child_run(Some("w1"), "Task", None, None, &parent.id, Some("my-bot"))
+            .create_child_run(Some("w1"), "Task", None, &parent.id, Some("my-bot"))
             .unwrap();
         assert_eq!(run.bot_name.as_deref(), Some("my-bot"));
 
@@ -902,13 +866,11 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create a top-level parent run
-        let parent = mgr
-            .create_run(Some("w1"), "Parent task", None, None)
-            .unwrap();
+        let parent = mgr.create_run(Some("w1"), "Parent task", None).unwrap();
 
         // Create a child run on the same worktree (simulates a sub-agent)
         let child = mgr
-            .create_child_run(Some("w1"), "Child task", None, None, &parent.id, None)
+            .create_child_run(Some("w1"), "Child task", None, &parent.id, None)
             .unwrap();
 
         // latest_run_for_worktree should return only the parent (top-level) run,
@@ -930,16 +892,12 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create two top-level runs for the same worktree
-        let _older = mgr
-            .create_run(Some("w1"), "Older task", None, None)
-            .unwrap();
-        let newer = mgr
-            .create_run(Some("w1"), "Newer task", None, None)
-            .unwrap();
+        let _older = mgr.create_run(Some("w1"), "Older task", None).unwrap();
+        let newer = mgr.create_run(Some("w1"), "Newer task", None).unwrap();
 
         // Also create a child of the newer run
         let _child = mgr
-            .create_child_run(Some("w1"), "Child of newer", None, None, &newer.id, None)
+            .create_child_run(Some("w1"), "Child of newer", None, &newer.id, None)
             .unwrap();
 
         let latest = mgr.latest_run_for_worktree("w1").unwrap().unwrap();
@@ -964,13 +922,11 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create a parent run on w1
-        let parent = mgr
-            .create_run(Some("w1"), "Parent task", None, None)
-            .unwrap();
+        let parent = mgr.create_run(Some("w1"), "Parent task", None).unwrap();
 
         // Create a child run on w2, parented to the w1 run
         let _child = mgr
-            .create_child_run(Some("w2"), "Child task", None, None, &parent.id, None)
+            .create_child_run(Some("w2"), "Child task", None, &parent.id, None)
             .unwrap();
 
         // w2 only has a child run — parent_run_id IS NULL filter should exclude it
@@ -987,13 +943,11 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create a parent run on w1
-        let parent = mgr
-            .create_run(Some("w1"), "Parent task", None, None)
-            .unwrap();
+        let parent = mgr.create_run(Some("w1"), "Parent task", None).unwrap();
 
         // Create a child run on w2, parented to the w1 run
         let child = mgr
-            .create_child_run(Some("w2"), "Child task", None, None, &parent.id, None)
+            .create_child_run(Some("w2"), "Child task", None, &parent.id, None)
             .unwrap();
 
         // latest_for_worktree sees all runs — returns the child
@@ -1018,13 +972,11 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create a top-level parent run on w1
-        let parent = mgr
-            .create_run(Some("w1"), "Parent task", None, None)
-            .unwrap();
+        let parent = mgr.create_run(Some("w1"), "Parent task", None).unwrap();
 
         // Create a child run on w1 (newer) parented to the same parent
         let child = mgr
-            .create_child_run(Some("w1"), "Child task", None, None, &parent.id, None)
+            .create_child_run(Some("w1"), "Child task", None, &parent.id, None)
             .unwrap();
 
         // latest_for_worktree sees all runs — returns the child (newest)
@@ -1066,16 +1018,10 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create runs across repos
-        let _r1_old = mgr
-            .create_run(Some("w1"), "Old r1 task", None, None)
-            .unwrap();
-        let r1_new = mgr
-            .create_run(Some("w1"), "New r1 task", None, None)
-            .unwrap();
-        let r1_w2 = mgr
-            .create_run(Some("w2"), "r1 w2 task", None, None)
-            .unwrap();
-        let _r2 = mgr.create_run(Some("w3"), "r2 task", None, None).unwrap();
+        let _r1_old = mgr.create_run(Some("w1"), "Old r1 task", None).unwrap();
+        let r1_new = mgr.create_run(Some("w1"), "New r1 task", None).unwrap();
+        let r1_w2 = mgr.create_run(Some("w2"), "r1 w2 task", None).unwrap();
+        let _r2 = mgr.create_run(Some("w3"), "r2 task", None).unwrap();
 
         // Repo r1 should only include w1 and w2
         let map = mgr.latest_runs_by_worktree_for_repo("r1").unwrap();
@@ -1096,14 +1042,10 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         // Create a repo-scoped run (no worktree)
-        let repo_run = mgr
-            .create_repo_run("r1", "Analyse the repo", None, None)
-            .unwrap();
+        let repo_run = mgr.create_repo_run("r1", "Analyse the repo", None).unwrap();
 
         // Create a worktree-scoped run (should not appear)
-        let _wt_run = mgr
-            .create_run(Some("w1"), "Fix the bug", None, None)
-            .unwrap();
+        let _wt_run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
 
         let runs = mgr.list_repo_scoped("r1").unwrap();
         assert_eq!(runs.len(), 1);
@@ -1125,12 +1067,8 @@ mod tests {
         let conn = setup_db();
         let mgr = AgentManager::new(&conn);
 
-        let _older = mgr
-            .create_repo_run("r1", "First question", None, None)
-            .unwrap();
-        let newer = mgr
-            .create_repo_run("r1", "Second question", None, None)
-            .unwrap();
+        let _older = mgr.create_repo_run("r1", "First question", None).unwrap();
+        let newer = mgr.create_repo_run("r1", "Second question", None).unwrap();
 
         // Set a session ID on the latest run so we can verify it's returned
         mgr.update_run_session_id(&newer.id, "sess-repo-latest")
@@ -1164,9 +1102,7 @@ mod tests {
         );
 
         // Create a completed run with a session ID
-        let run = mgr
-            .create_repo_run("r1", "Analyse the repo", None, None)
-            .unwrap();
+        let run = mgr.create_repo_run("r1", "Analyse the repo", None).unwrap();
         mgr.update_run_completed(
             &run.id,
             Some("sess-abc"),
@@ -1218,13 +1154,12 @@ mod tests {
         assert!(map.is_empty());
 
         // Create repo-scoped runs
-        let _r1_old = mgr.create_repo_run("r1", "Old prompt", None, None).unwrap();
-        let r1_new = mgr.create_repo_run("r1", "New prompt", None, None).unwrap();
-        let r2_only = mgr.create_repo_run("r2", "R2 prompt", None, None).unwrap();
+        let _r1_old = mgr.create_repo_run("r1", "Old prompt", None).unwrap();
+        let r1_new = mgr.create_repo_run("r1", "New prompt", None).unwrap();
+        let r2_only = mgr.create_repo_run("r2", "R2 prompt", None).unwrap();
 
         // Also create a worktree-scoped run — should NOT appear
-        mgr.create_run(Some("w1"), "Worktree task", None, None)
-            .unwrap();
+        mgr.create_run(Some("w1"), "Worktree task", None).unwrap();
 
         let map = mgr.latest_repo_scoped_runs_all().unwrap();
         assert_eq!(map.len(), 2);

--- a/conductor-core/src/agent/types.rs
+++ b/conductor-core/src/agent/types.rs
@@ -54,7 +54,6 @@ pub struct AgentRun {
     pub duration_ms: Option<i64>,
     pub started_at: String,
     pub ended_at: Option<String>,
-    pub tmux_window: Option<String>,
     pub log_file: Option<String>,
     /// The model used for this run (e.g. "claude-sonnet-4-6"). None means claude's default.
     pub model: Option<String>,

--- a/conductor-core/src/agent_runtime.rs
+++ b/conductor-core/src/agent_runtime.rs
@@ -1124,7 +1124,7 @@ mod tests {
     fn drain_stream_json_completed_on_result_event() {
         let conn = test_db();
         let mgr = crate::agent::AgentManager::new(&conn);
-        let run = mgr.create_run(None, "test prompt", None, None).unwrap();
+        let run = mgr.create_run(None, "test prompt", None).unwrap();
 
         let json_lines = concat!(
             "{\"type\":\"system\",\"subtype\":\"init\",\"model\":\"claude-test\",\"session_id\":\"sess-1\"}\n",
@@ -1145,7 +1145,7 @@ mod tests {
     fn drain_stream_json_no_result_returns_no_result() {
         let conn = test_db();
         let mgr = crate::agent::AgentManager::new(&conn);
-        let run = mgr.create_run(None, "test prompt", None, None).unwrap();
+        let run = mgr.create_run(None, "test prompt", None).unwrap();
 
         let json_lines =
             "{\"type\":\"system\",\"subtype\":\"init\",\"model\":\"claude-test\",\"session_id\":\"sess-1\"}\n";
@@ -1164,7 +1164,7 @@ mod tests {
     fn drain_stream_json_error_result_event() {
         let conn = test_db();
         let mgr = crate::agent::AgentManager::new(&conn);
-        let run = mgr.create_run(None, "test prompt", None, None).unwrap();
+        let run = mgr.create_run(None, "test prompt", None).unwrap();
 
         let json_lines =
             "{\"type\":\"result\",\"is_error\":true,\"result\":\"something went wrong\"}\n";
@@ -1185,7 +1185,7 @@ mod tests {
     fn drain_stream_json_token_update() {
         let conn = test_db();
         let mgr = crate::agent::AgentManager::new(&conn);
-        let run = mgr.create_run(None, "test prompt", None, None).unwrap();
+        let run = mgr.create_run(None, "test prompt", None).unwrap();
 
         let json_lines = concat!(
             "{\"type\":\"assistant\",\"message\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n",
@@ -1208,7 +1208,7 @@ mod tests {
     fn drain_stream_json_result_persists_cost_turns_duration() {
         let conn = test_db();
         let mgr = crate::agent::AgentManager::new(&conn);
-        let run = mgr.create_run(None, "test prompt", None, None).unwrap();
+        let run = mgr.create_run(None, "test prompt", None).unwrap();
 
         // Result event with cost, turns, duration, and final token usage
         let json_lines = concat!(

--- a/conductor-core/src/conversation/manager.rs
+++ b/conductor-core/src/conversation/manager.rs
@@ -201,7 +201,6 @@ impl<'a> ConversationManager<'a> {
         &self,
         conversation_id: &str,
         prompt: &str,
-        tmux_window: Option<&str>,
         model: Option<&str>,
     ) -> Result<(crate::agent::AgentRun, Option<String>)> {
         let conv = self.get(conversation_id)?.ok_or_else(|| {
@@ -221,14 +220,12 @@ impl<'a> ConversationManager<'a> {
             ConversationScope::Worktree => agent_mgr.create_run_for_conversation(
                 &conv.scope_id,
                 prompt,
-                tmux_window,
                 model,
                 conversation_id,
             )?,
             ConversationScope::Repo => agent_mgr.create_repo_run_for_conversation(
                 &conv.scope_id,
                 prompt,
-                tmux_window,
                 model,
                 conversation_id,
             )?,
@@ -367,7 +364,7 @@ mod tests {
         let conv = mgr.create(ConversationScope::Repo, "r1").unwrap();
 
         let (run, session_id) = mgr
-            .send_message(&conv.id, "What does this repo do?", None, None)
+            .send_message(&conv.id, "What does this repo do?", None)
             .unwrap();
 
         assert_eq!(run.conversation_id.as_deref(), Some(conv.id.as_str()));
@@ -381,7 +378,7 @@ mod tests {
 
         // Second message must be rejected — there's an active run.
         let err = mgr
-            .send_message(&conv.id, "Another message", None, None)
+            .send_message(&conv.id, "Another message", None)
             .unwrap_err();
         assert!(err.to_string().contains("active agent run"));
     }
@@ -396,7 +393,7 @@ mod tests {
 
         // Create two completed runs: the second (newer) should win.
         let run1 = agent_mgr
-            .create_repo_run_for_conversation("r1", "q1", None, None, &conv.id)
+            .create_repo_run_for_conversation("r1", "q1", None, &conv.id)
             .unwrap();
         agent_mgr
             .update_run_completed(
@@ -414,7 +411,7 @@ mod tests {
             .unwrap();
 
         let run2 = agent_mgr
-            .create_repo_run_for_conversation("r1", "q2", None, None, &conv.id)
+            .create_repo_run_for_conversation("r1", "q2", None, &conv.id)
             .unwrap();
         agent_mgr
             .update_run_completed(
@@ -466,7 +463,7 @@ mod tests {
         // Create a running agent run linked to this conversation.
         let agent_mgr = crate::agent::AgentManager::new(&conn);
         agent_mgr
-            .create_repo_run_for_conversation("r1", "hello", None, None, &conv.id)
+            .create_repo_run_for_conversation("r1", "hello", None, &conv.id)
             .unwrap();
 
         let err = mgr.delete(&conv.id).unwrap_err();
@@ -487,7 +484,7 @@ mod tests {
 
         // Create a run and immediately mark it completed so delete is not blocked.
         let run = agent_mgr
-            .create_repo_run_for_conversation("r1", "q", None, None, &conv.id)
+            .create_repo_run_for_conversation("r1", "q", None, &conv.id)
             .unwrap();
         agent_mgr
             .update_run_completed(
@@ -519,10 +516,10 @@ mod tests {
 
         let agent_mgr = crate::agent::AgentManager::new(&conn);
         let run1 = agent_mgr
-            .create_repo_run_for_conversation("r1", "first", None, None, &conv.id)
+            .create_repo_run_for_conversation("r1", "first", None, &conv.id)
             .unwrap();
         let run2 = agent_mgr
-            .create_repo_run_for_conversation("r1", "second", None, None, &conv.id)
+            .create_repo_run_for_conversation("r1", "second", None, &conv.id)
             .unwrap();
 
         let with_runs = mgr.get_with_runs(&conv.id).unwrap().unwrap();

--- a/conductor-core/src/db/migrations.rs
+++ b/conductor-core/src/db/migrations.rs
@@ -5,7 +5,7 @@ use crate::error::{ConductorError, Result};
 
 /// The highest migration version this binary knows about.
 /// **When adding a new migration, update this constant to match the new version.**
-pub const LATEST_SCHEMA_VERSION: u32 = 77;
+pub const LATEST_SCHEMA_VERSION: u32 = 78;
 
 /// Legacy plan step shape used only for migrating JSON data from agent_runs.plan.
 #[derive(Deserialize)]
@@ -1116,6 +1116,20 @@ pub fn run(conn: &Connection) -> Result<()> {
             }
         }
         bump_version(conn, 77)?;
+    }
+
+    // Migration 078: drop tmux_window column from agent_runs (CliRuntime no longer uses tmux).
+    if version < 78 {
+        let table_exists: bool = conn.prepare("SELECT 1 FROM agent_runs LIMIT 0").is_ok();
+        if table_exists {
+            let has_col: bool = conn
+                .prepare("SELECT tmux_window FROM agent_runs LIMIT 0")
+                .is_ok();
+            if has_col {
+                conn.execute_batch(include_str!("migrations/078_drop_tmux_window.sql"))?;
+            }
+        }
+        bump_version(conn, 78)?;
     }
 
     Ok(())

--- a/conductor-core/src/db/migrations/078_drop_tmux_window.sql
+++ b/conductor-core/src/db/migrations/078_drop_tmux_window.sql
@@ -1,0 +1,1 @@
+ALTER TABLE agent_runs DROP COLUMN tmux_window;

--- a/conductor-core/src/notify/tests.rs
+++ b/conductor-core/src/notify/tests.rs
@@ -1652,7 +1652,6 @@ fn make_agent_run(id: &str, status: AgentRunStatus) -> AgentRun {
         duration_ms: None,
         started_at: "2026-01-01T00:00:00Z".to_string(),
         ended_at: None,
-        tmux_window: None,
         log_file: None,
         model: None,
         plan: None,

--- a/conductor-core/src/runtime/claude.rs
+++ b/conductor-core/src/runtime/claude.rs
@@ -276,7 +276,6 @@ mod tests {
             duration_ms: None,
             started_at: "2024-01-01T00:00:00Z".to_string(),
             ended_at: None,
-            tmux_window: None,
             log_file: None,
             model: None,
             plan: None,

--- a/conductor-core/src/runtime/cli.rs
+++ b/conductor-core/src/runtime/cli.rs
@@ -8,7 +8,7 @@ use crate::error::{ConductorError, Result};
 
 use super::{AgentRuntime, PollError, RuntimeRequest};
 
-/// CliRuntime spawns any CLI agent via a tmux window with stdout redirected to a
+/// CliRuntime spawns any CLI agent as a headless subprocess with stdout redirected to a
 /// JSON output file. Supports prompt injection via arg substitution or stdin.
 pub struct CliRuntime {
     config: RuntimeConfig,
@@ -17,9 +17,9 @@ pub struct CliRuntime {
 }
 
 struct CliState {
-    exit_code_path: std::path::PathBuf,
+    child: std::process::Child,
+    pid: u32,
     output_path: std::path::PathBuf,
-    window_name: String,
     start: std::time::Instant,
 }
 
@@ -30,27 +30,6 @@ impl CliRuntime {
             state: std::sync::Mutex::new(None),
             db_path: std::sync::Mutex::new(crate::config::db_path()),
         }
-    }
-
-    fn shell_single_quote(s: &str) -> String {
-        format!("'{}'", s.replace('\'', "'\\''"))
-    }
-
-    /// Kill the tmux window (best-effort) and mark the run cancelled in the DB.
-    fn teardown_window(
-        agent_mgr: &crate::agent::AgentManager<'_>,
-        run_id: &str,
-        window_name: Option<&str>,
-    ) -> Result<()> {
-        if let Some(window) = window_name {
-            let result = std::process::Command::new("tmux")
-                .args(["kill-window", "-t", window])
-                .output();
-            if let Err(e) = result {
-                tracing::warn!("CliRuntime: tmux kill-window failed: {e}");
-            }
-        }
-        agent_mgr.update_run_cancelled(run_id)
     }
 }
 
@@ -75,7 +54,6 @@ impl AgentRuntime for CliRuntime {
             ConductorError::Agent(format!("CliRuntime: failed to create run dir: {e}"))
         })?;
         let output_path = run_dir.join("output.json");
-        let exit_code_path = run_dir.join("exit_code");
 
         let prompt_via = self.config.prompt_via.as_deref().unwrap_or("arg");
 
@@ -96,55 +74,43 @@ impl AgentRuntime for CliRuntime {
             .filter(|a| !a.is_empty())
             .collect();
 
-        let args_str = args
-            .iter()
-            .map(|a| Self::shell_single_quote(a))
-            .collect::<Vec<_>>()
-            .join(" ");
+        let output_file = std::fs::File::create(&output_path).map_err(|e| {
+            ConductorError::Agent(format!("CliRuntime: failed to create output file: {e}"))
+        })?;
 
-        // Quote all paths: binary for injection, output/exit paths for spaces in conductor_dir.
-        let binary_quoted = Self::shell_single_quote(binary);
-        let output_path_quoted = Self::shell_single_quote(&output_path.to_string_lossy());
-        let exit_code_path_quoted = Self::shell_single_quote(&exit_code_path.to_string_lossy());
-
-        let shell_cmd = if prompt_via == "stdin" {
-            let prompt_quoted = Self::shell_single_quote(&request.prompt);
-            format!(
-                "echo {prompt_quoted} | {binary_quoted} {args_str} > {output_path_quoted}; echo $? > {exit_code_path_quoted}"
-            )
+        let stdin_cfg = if prompt_via == "stdin" {
+            std::process::Stdio::piped()
         } else {
-            format!(
-                "{binary_quoted} {args_str} > {output_path_quoted}; echo $? > {exit_code_path_quoted}"
-            )
+            std::process::Stdio::null()
         };
 
-        let window_name = format!("cli-{}", &request.run_id[..8.min(request.run_id.len())]);
-        let status = std::process::Command::new("tmux")
-            .args([
-                "new-window",
-                "-n",
-                &window_name,
-                &format!("sh -c {}", Self::shell_single_quote(&shell_cmd)),
-            ])
-            .status()
-            .map_err(|e| ConductorError::Agent(format!("CliRuntime: tmux spawn failed: {e}")))?;
+        let mut cmd = std::process::Command::new(binary);
+        cmd.args(&args)
+            .stdout(std::process::Stdio::from(output_file))
+            .stderr(std::process::Stdio::null())
+            .stdin(stdin_cfg);
 
-        if !status.success() {
-            return Err(ConductorError::Agent(
-                "CliRuntime: tmux new-window failed".to_string(),
-            ));
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| ConductorError::Agent(format!("CliRuntime: spawn failed: {e}")))?;
+
+        if prompt_via == "stdin" {
+            if let Some(mut stdin) = child.stdin.take() {
+                use std::io::Write;
+                let _ = stdin.write_all(request.prompt.as_bytes());
+            }
         }
 
-        // Store the injected DB path for use in poll() and cancel().
-        if let Ok(mut guard) = self.db_path.lock() {
-            *guard = request.db_path.clone();
-        }
+        let pid = child.id();
 
-        // Persist runtime name and tmux window to DB so is_alive(), cancel(), and
-        // the orphan reaper can operate correctly on this run.
-        let conn = crate::db::open_database_compat(&request.db_path)
-            .map_err(|e| ConductorError::Agent(format!("CliRuntime: failed to open DB: {e}")))?;
+        let conn = crate::db::open_agent_db("CliRuntime")?;
         let agent_mgr = crate::agent::AgentManager::new(&conn);
+        if let Err(e) = agent_mgr.update_run_subprocess_pid(&request.run_id, pid) {
+            tracing::warn!(
+                "CliRuntime: failed to persist subprocess pid {pid} for run {}: {e}",
+                request.run_id
+            );
+        }
         if let Err(e) = agent_mgr.update_run_runtime(&request.run_id, &request.agent_def.runtime) {
             tracing::warn!(
                 "CliRuntime: failed to persist runtime '{}' for run {}: {e}",
@@ -152,17 +118,11 @@ impl AgentRuntime for CliRuntime {
                 request.run_id
             );
         }
-        if let Err(e) = agent_mgr.update_run_tmux_window(&request.run_id, &window_name) {
-            tracing::warn!(
-                "CliRuntime: failed to persist tmux window '{window_name}' for run {}: {e}",
-                request.run_id
-            );
-        }
 
         *self.state.lock().unwrap() = Some(CliState {
-            exit_code_path,
+            child,
+            pid,
             output_path,
-            window_name,
             start: std::time::Instant::now(),
         });
         Ok(())
@@ -174,7 +134,7 @@ impl AgentRuntime for CliRuntime {
         shutdown: Option<&Arc<AtomicBool>>,
         step_timeout: Duration,
     ) -> std::result::Result<AgentRun, PollError> {
-        let state = self
+        let mut state = self
             .state
             .lock()
             .unwrap()
@@ -190,101 +150,120 @@ impl AgentRuntime for CliRuntime {
         loop {
             if let Some(flag) = shutdown {
                 if flag.load(std::sync::atomic::Ordering::Relaxed) {
-                    if let Err(e) =
-                        Self::teardown_window(&agent_mgr, run_id, Some(&state.window_name))
-                    {
-                        tracing::warn!("CliRuntime: teardown_window failed during shutdown: {e}");
+                    crate::process_utils::cancel_subprocess(state.pid);
+                    if let Err(e) = agent_mgr.update_run_cancelled(run_id) {
+                        tracing::warn!("CliRuntime: failed to cancel run {run_id}: {e}");
                     }
                     return Err(PollError::Cancelled);
                 }
             }
 
             if poll_start.elapsed() > step_timeout {
-                if let Err(e) = Self::teardown_window(&agent_mgr, run_id, Some(&state.window_name))
-                {
-                    tracing::warn!("CliRuntime: teardown_window failed on timeout: {e}");
+                crate::process_utils::cancel_subprocess(state.pid);
+                if let Err(e) = agent_mgr.update_run_cancelled(run_id) {
+                    tracing::warn!("CliRuntime: failed to cancel run {run_id} on timeout: {e}");
                 }
                 return Err(PollError::NoResult);
             }
 
-            if state.exit_code_path.exists() {
-                let exit_code: i64 = std::fs::read_to_string(&state.exit_code_path)
-                    .ok()
-                    .and_then(|s| s.trim().parse().ok())
-                    .unwrap_or(1);
+            match state.child.try_wait() {
+                Ok(Some(exit_status)) => {
+                    let exit_code = exit_status.code().unwrap_or(1);
+                    let duration_ms = state.start.elapsed().as_millis() as i64;
+                    let is_error = exit_code != 0;
 
-                let duration_ms = state.start.elapsed().as_millis() as i64;
-                let is_error = exit_code != 0;
+                    let (result_text, input_tokens, output_tokens) =
+                        if let Ok(content) = std::fs::read_to_string(&state.output_path) {
+                            parse_output(&content, &self.config)
+                        } else {
+                            (
+                                if is_error {
+                                    Some(format!("process exited with code {exit_code}"))
+                                } else {
+                                    None
+                                },
+                                None,
+                                None,
+                            )
+                        };
 
-                let (result_text, input_tokens, output_tokens) =
-                    if let Ok(content) = std::fs::read_to_string(&state.output_path) {
-                        parse_output(&content, &self.config)
-                    } else {
-                        (
-                            if is_error {
-                                Some(format!("process exited with code {exit_code}"))
-                            } else {
-                                None
-                            },
-                            None,
-                            None,
-                        )
-                    };
-
-                if is_error {
-                    let err_msg = result_text
-                        .clone()
-                        .unwrap_or_else(|| format!("process exited with code {exit_code}"));
-                    if let Err(e) = agent_mgr.update_run_failed(run_id, &err_msg) {
-                        tracing::warn!("CliRuntime: failed to mark run {run_id} failed: {e}");
+                    if is_error {
+                        let err_msg = result_text
+                            .clone()
+                            .unwrap_or_else(|| format!("process exited with code {exit_code}"));
+                        if let Err(e) = agent_mgr.update_run_failed(run_id, &err_msg) {
+                            tracing::warn!("CliRuntime: failed to mark run {run_id} failed: {e}");
+                        }
+                    } else if let Err(e) = agent_mgr.update_run_completed(
+                        run_id,
+                        None,
+                        result_text.as_deref(),
+                        None,
+                        Some(1),
+                        Some(duration_ms),
+                        input_tokens,
+                        output_tokens,
+                        None,
+                        None,
+                    ) {
+                        tracing::warn!("CliRuntime: failed to mark run {run_id} completed: {e}");
                     }
-                } else if let Err(e) = agent_mgr.update_run_completed(
-                    run_id,
-                    None,
-                    result_text.as_deref(),
-                    None,
-                    Some(1),
-                    Some(duration_ms),
-                    input_tokens,
-                    output_tokens,
-                    None,
-                    None,
-                ) {
-                    tracing::warn!("CliRuntime: failed to mark run {run_id} completed: {e}");
+
+                    return agent_mgr
+                        .get_run(run_id)
+                        .map_err(|e| PollError::Failed(format!("DB error: {e}")))?
+                        .ok_or_else(|| {
+                            PollError::Failed(format!(
+                                "run {run_id} not found in DB after completion"
+                            ))
+                        });
                 }
-
-                return agent_mgr
-                    .get_run(run_id)
-                    .map_err(|e| PollError::Failed(format!("DB error: {e}")))?
-                    .ok_or_else(|| {
-                        PollError::Failed(format!("run {run_id} not found in DB after completion"))
-                    });
+                Ok(None) => {
+                    std::thread::sleep(Duration::from_millis(500));
+                }
+                Err(e) => {
+                    if let Err(db_e) = agent_mgr.update_run_failed(run_id, &e.to_string()) {
+                        tracing::warn!("CliRuntime: failed to mark run {run_id} failed: {db_e}");
+                    }
+                    return Err(PollError::Failed(format!("wait error: {e}")));
+                }
             }
-
-            std::thread::sleep(Duration::from_millis(500));
         }
     }
 
     fn is_alive(&self, run: &AgentRun) -> bool {
-        if let Some(ref window) = run.tmux_window {
-            let output = std::process::Command::new("tmux")
-                .args(["list-windows", "-a", "-F", "#{window_name}"])
-                .output()
-                .ok();
-            if let Some(out) = output {
-                let stdout = String::from_utf8_lossy(&out.stdout);
-                return stdout.lines().any(|l| l.trim() == window.as_str());
-            }
+        #[cfg(unix)]
+        if let Some(pid) = run.subprocess_pid {
+            return crate::process_utils::pid_is_alive(pid as u32);
         }
+        let _ = run;
         false
     }
 
     fn cancel(&self, run: &AgentRun) -> Result<()> {
-        let db_path = self.db_path.lock().unwrap().clone();
-        let conn = crate::db::open_database_compat(&db_path)
-            .map_err(|e| ConductorError::Agent(format!("CliRuntime: failed to open DB: {e}")))?;
+        // Take the child from the state so we can kill + reap it.
+        let child = self
+            .state
+            .lock()
+            .ok()
+            .and_then(|mut guard| guard.take())
+            .map(|s| s.child);
+
+        if let Some(mut c) = child {
+            // Kill directly via the Child handle: SIGKILL + wait() reaps the zombie.
+            let _ = c.kill();
+            let _ = c.wait();
+        } else {
+            // Fallback when we don't have the Child object (e.g. after a restart).
+            #[cfg(unix)]
+            if let Some(pid) = run.subprocess_pid {
+                crate::process_utils::cancel_subprocess(pid as u32);
+            }
+        }
+
+        let conn = crate::db::open_agent_db("CliRuntime::cancel")?;
         let agent_mgr = crate::agent::AgentManager::new(&conn);
-        Self::teardown_window(&agent_mgr, &run.id, run.tmux_window.as_deref())
+        agent_mgr.update_run_cancelled(&run.id)
     }
 }
 
@@ -325,10 +304,9 @@ mod tests {
         })
     }
 
-    fn make_test_run(tmux_window: Option<String>) -> AgentRun {
+    fn make_test_run(subprocess_pid: Option<i64>) -> AgentRun {
         AgentRun {
             id: "test".to_string(),
-            tmux_window,
             worktree_id: None,
             repo_id: None,
             claude_session_id: None,
@@ -350,19 +328,9 @@ mod tests {
             cache_creation_input_tokens: None,
             bot_name: None,
             conversation_id: None,
-            subprocess_pid: None,
+            subprocess_pid,
             runtime: "cli".to_string(),
         }
-    }
-
-    #[test]
-    fn shell_single_quote_basic() {
-        assert_eq!(CliRuntime::shell_single_quote("hello"), "'hello'");
-    }
-
-    #[test]
-    fn shell_single_quote_with_single_quote() {
-        assert_eq!(CliRuntime::shell_single_quote("it's"), "'it'\\''s'");
     }
 
     #[test]
@@ -388,30 +356,42 @@ mod tests {
         let config = RuntimeConfig::default();
         let json = r#"{"response": "hello"}"#;
         let (result, _, _) = parse_output(json, &config);
-        // Falls back to raw content
         assert!(result.is_some());
     }
 
     #[test]
-    fn binary_quoted_prevents_injection() {
-        // Ensure a binary path with spaces/special chars is single-quoted in the shell command.
-        let binary = "my binary; rm -rf ~/";
-        let quoted = CliRuntime::shell_single_quote(binary);
-        assert!(quoted.starts_with('\''));
-        assert!(!quoted.contains("rm -rf ~/;") || quoted.contains("\\'"));
-    }
-
-    #[test]
-    fn is_alive_returns_false_for_none_window() {
+    fn is_alive_returns_false_when_no_pid() {
         let runtime = make_runtime("echo");
         assert!(!runtime.is_alive(&make_test_run(None)));
     }
 
+    #[cfg(unix)]
     #[test]
-    fn is_alive_returns_false_for_nonexistent_window() {
+    fn is_alive_returns_true_for_self() {
         let runtime = make_runtime("echo");
-        // Either tmux isn't running (returns false) or window doesn't exist (returns false).
-        assert!(!runtime.is_alive(&make_test_run(Some("no-such-window-xyz-99999".to_string()))));
+        let run = make_test_run(Some(std::process::id() as i64));
+        assert!(runtime.is_alive(&run));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancel_with_dead_pid_returns_ok() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::env::set_var("CONDUCTOR_DB_PATH", tmp.path().to_str().unwrap());
+        let conn = crate::db::open_database(tmp.path()).unwrap();
+        conn.execute(
+            "INSERT INTO agent_runs (id, prompt, status, started_at, runtime) \
+             VALUES ('test', 'p', 'running', '2024-01-01T00:00:00Z', 'cli')",
+            [],
+        )
+        .unwrap();
+
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        child.wait().unwrap();
+        let dead_pid = child.id() as i64;
+        let runtime = make_runtime("echo");
+        let run = make_test_run(Some(dead_pid));
+        assert!(runtime.cancel(&run).is_ok());
     }
 
     #[test]

--- a/conductor-core/src/runtime/script.rs
+++ b/conductor-core/src/runtime/script.rs
@@ -161,7 +161,6 @@ mod tests {
     fn make_test_run() -> AgentRun {
         AgentRun {
             id: "test".to_string(),
-            tmux_window: None,
             worktree_id: None,
             repo_id: None,
             claude_session_id: None,

--- a/conductor-core/src/test_helpers.rs
+++ b/conductor-core/src/test_helpers.rs
@@ -95,7 +95,7 @@ pub fn make_provider_ctx<'a>(
 pub fn make_agent_parent_id(conn: &Connection) -> String {
     let agent_mgr = crate::agent::AgentManager::new(conn);
     agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
+        .create_run(Some("w1"), "workflow", None)
         .unwrap()
         .id
 }

--- a/conductor-core/src/workflow/engine.rs
+++ b/conductor-core/src/workflow/engine.rs
@@ -376,7 +376,7 @@ pub fn execute_workflow(input: &WorkflowExecInput<'_>) -> Result<WorkflowResult>
 
     // Create parent agent run (uses empty worktree_id for ephemeral PR runs).
     let parent_prompt = format!("Workflow: {} — {}", workflow.name, workflow.description);
-    let parent_run = agent_mgr.create_run(input.worktree_id, &parent_prompt, None, input.model)?;
+    let parent_run = agent_mgr.create_run(input.worktree_id, &parent_prompt, input.model)?;
 
     // Create workflow run record with snapshot and target FKs in a single INSERT
     let trigger_str = if input.triggered_by_hook {

--- a/conductor-core/src/workflow/executors/call.rs
+++ b/conductor-core/src/workflow/executors/call.rs
@@ -180,7 +180,6 @@ fn execute_call_with_schema(
         let child_run = state.agent_mgr.create_child_run(
             worktree_id.as_deref(),
             &prompt,
-            None,
             step_model,
             &state.parent_run_id,
             effective_bot_name,

--- a/conductor-core/src/workflow/executors/foreach/tests.rs
+++ b/conductor-core/src/workflow/executors/foreach/tests.rs
@@ -46,9 +46,7 @@ fn test_collect_ticket_items_unlabeled_scope() {
 
     // Build a minimal ExecutionState.
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -287,9 +285,7 @@ fn test_dispatch_params_tickets_clears_worktree_id() {
     let config: &'static crate::config::Config =
         Box::leak(Box::new(crate::config::Config::default()));
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -322,9 +318,7 @@ fn test_dispatch_params_repos_clears_worktree_id() {
     let config: &'static crate::config::Config =
         Box::leak(Box::new(crate::config::Config::default()));
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -357,9 +351,7 @@ fn test_dispatch_params_workflow_runs_passes_worktree_id_through() {
     let config: &'static crate::config::Config =
         Box::leak(Box::new(crate::config::Config::default()));
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -396,9 +388,7 @@ fn test_dispatch_params_worktrees_missing_worktree_falls_back_to_parent_dir() {
     let config: &'static crate::config::Config =
         Box::leak(Box::new(crate::config::Config::default()));
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -443,9 +433,7 @@ fn test_dispatch_params_worktrees_uses_child_worktree_path() {
         .unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -524,9 +512,7 @@ fn test_collect_worktree_items_matching_base_branch() {
         ).unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -610,7 +596,7 @@ fn test_collect_worktree_items_inferred_base_uses_worktree_branch_not_parent() {
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
     let parent = agent_mgr
-        .create_run(Some("wt-release"), "workflow", None, None)
+        .create_run(Some("wt-release"), "workflow", None)
         .unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
@@ -684,9 +670,7 @@ fn test_collect_worktree_items_has_open_pr_filter() {
         ).unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -861,9 +845,7 @@ fn test_foreach_does_not_fail_item_on_first_failed_observation() {
     crate::test_helpers::insert_test_worktree(&conn, "w1", "r1", "feat-test", "/tmp/ws");
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -872,9 +854,7 @@ fn test_foreach_does_not_fail_item_on_first_failed_observation() {
         .insert_step(&run.id, "foreach-step", "foreach", false, 0, 1)
         .unwrap();
 
-    let child_agent = agent_mgr
-        .create_run(Some("w1"), "child", None, None)
-        .unwrap();
+    let child_agent = agent_mgr.create_run(Some("w1"), "child", None).unwrap();
     let child_run = wf_mgr
         .create_workflow_run(
             "child-wf",
@@ -969,9 +949,7 @@ fn test_foreach_fails_item_after_two_consecutive_failed_observations() {
         Box::leak(Box::new(crate::config::Config::default()));
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -980,9 +958,7 @@ fn test_foreach_fails_item_after_two_consecutive_failed_observations() {
         .insert_step(&run.id, "foreach-step", "foreach", false, 0, 1)
         .unwrap();
 
-    let child_agent = agent_mgr
-        .create_run(Some("w1"), "child", None, None)
-        .unwrap();
+    let child_agent = agent_mgr.create_run(Some("w1"), "child", None).unwrap();
     let child_run = wf_mgr
         .create_workflow_run(
             "child-wf",
@@ -1046,9 +1022,7 @@ fn test_build_item_vars_worktrees_all_fields() {
         ).unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1126,9 +1100,7 @@ fn test_load_worktree_dep_edges_basic() {
 
     // Create a workflow run + step + fan_out_items for the two worktrees.
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1186,9 +1158,7 @@ fn test_load_worktree_dep_edges_no_tickets() {
     .unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1272,9 +1242,7 @@ fn test_load_worktree_dep_edges_mixed_some_with_tickets() {
         .unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1343,9 +1311,7 @@ fn test_load_ticket_dep_edges_basic() {
         .unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1409,9 +1375,7 @@ fn test_load_ticket_dep_edges_no_deps() {
         .unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1472,9 +1436,7 @@ fn test_load_ticket_dep_edges_filters_external_blocker() {
         .unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1516,9 +1478,7 @@ fn test_collect_worktree_items_no_repo_id_returns_error() {
         Box::leak(Box::new(crate::config::Config::default()));
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1568,9 +1528,7 @@ fn test_collect_worktree_items_no_scope_no_worktree_id_errors() {
         Box::leak(Box::new(crate::config::Config::default()));
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1628,9 +1586,7 @@ fn test_collect_worktree_items_infers_base_branch_from_context() {
         ).unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1694,9 +1650,7 @@ fn test_build_item_vars_worktrees_null_optional_fields() {
         .unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1764,9 +1718,7 @@ fn test_build_item_vars_worktrees_with_ticket_id() {
         .unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1810,9 +1762,7 @@ fn test_build_item_vars_worktrees_missing_worktree_falls_back() {
         Box::leak(Box::new(crate::config::Config::default()));
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1852,9 +1802,7 @@ fn test_build_item_vars_tickets_missing_ticket_falls_back() {
         Box::leak(Box::new(crate::config::Config::default()));
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1903,9 +1851,7 @@ fn test_foreach_resume_reuses_existing_step_and_resets_orphaned_items() {
         Box::leak(Box::new(crate::config::Config::default()));
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -1995,9 +1941,7 @@ fn test_foreach_resume_preserves_running_items_with_child_run_id() {
     let conn = setup_db();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -2062,9 +2006,7 @@ fn test_build_item_vars_repos_missing_repo_falls_back() {
         Box::leak(Box::new(crate::config::Config::default()));
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)

--- a/conductor-core/src/workflow/executors/parallel.rs
+++ b/conductor-core/src/workflow/executors/parallel.rs
@@ -160,7 +160,6 @@ pub fn execute_parallel(
         let child_run = state.agent_mgr.create_child_run(
             worktree_id.as_deref(),
             &prompt,
-            None,
             step_model,
             &state.parent_run_id,
             state.default_bot_name.as_deref(),

--- a/conductor-core/src/workflow/executors/tests.rs
+++ b/conductor-core/src/workflow/executors/tests.rs
@@ -1575,7 +1575,7 @@ fn test_parallel_drain_signal_race_condition_db_guard() {
 
     // Create an agent run (starts in `running` state by default)
     let run = agent_mgr
-        .create_run(None, "test prompt", None, None)
+        .create_run(None, "test prompt", None)
         .expect("create_run should succeed");
     assert_eq!(
         run.status,
@@ -1676,7 +1676,7 @@ fn test_parallel_drain_thread_panic_marks_run_failed() {
 
     // Create an agent run (starts in `running` state by default)
     let run = agent_mgr
-        .create_run(None, "test prompt", None, None)
+        .create_run(None, "test prompt", None)
         .expect("create_run should succeed");
     assert_eq!(
         run.status,

--- a/conductor-core/src/workflow/manager/recovery.rs
+++ b/conductor-core/src/workflow/manager/recovery.rs
@@ -1545,9 +1545,7 @@ mod tests {
     /// Insert an agent_run with an optional subprocess_pid; returns the agent run id.
     fn insert_agent_run_with_pid(conn: &rusqlite::Connection, pid: Option<i64>) -> String {
         let agent_mgr = crate::agent::AgentManager::new(conn);
-        let run = agent_mgr
-            .create_run(Some("w1"), "prompt", None, None)
-            .unwrap();
+        let run = agent_mgr.create_run(Some("w1"), "prompt", None).unwrap();
         if let Some(p) = pid {
             conn.execute(
                 "UPDATE agent_runs SET subprocess_pid = :pid WHERE id = :id",

--- a/conductor-core/src/workflow/manager/tests.rs
+++ b/conductor-core/src/workflow/manager/tests.rs
@@ -28,7 +28,7 @@ fn setup_db() -> rusqlite::Connection {
 
 fn make_parent_id(conn: &rusqlite::Connection, wt_id: &str) -> String {
     AgentManager::new(conn)
-        .create_run(Some(wt_id), "workflow", None, None)
+        .create_run(Some(wt_id), "workflow", None)
         .unwrap()
         .id
 }
@@ -1573,7 +1573,7 @@ fn test_cancel_run_kills_child_agent_subprocess() {
 
     // Create a child agent run with a fake subprocess_pid.
     let child_run = agent_mgr
-        .create_run(Some("w1"), "agent prompt", None, None)
+        .create_run(Some("w1"), "agent prompt", None)
         .unwrap();
     agent_mgr
         .update_run_subprocess_pid(&child_run.id, u32::MAX)
@@ -1697,7 +1697,7 @@ fn test_fail_workflow_run_returns_parent_id() {
     let wf_mgr = WorkflowManager::new(&conn);
 
     let parent_run = agent_mgr
-        .create_run(Some("w1"), "workflow parent", None, None)
+        .create_run(Some("w1"), "workflow parent", None)
         .unwrap();
     let wf_run = wf_mgr
         .create_workflow_run("wf", Some("w1"), &parent_run.id, false, "manual", None)

--- a/conductor-core/src/workflow/tests/common.rs
+++ b/conductor-core/src/workflow/tests/common.rs
@@ -90,9 +90,7 @@ pub(super) fn make_state_with_run<'a>(
     config: &'static Config,
 ) -> (ExecutionState<'a>, String) {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -162,9 +160,7 @@ pub(in crate::workflow) fn make_loop_test_state<'a>(
     config: &'a Config,
 ) -> ExecutionState<'a> {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -204,9 +200,7 @@ pub(super) fn make_empty_workflow() -> WorkflowDef {
 
 pub(super) fn create_child_run(conn: &Connection) -> (WorkflowManager<'_>, String) {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(conn);
     let run = wf_mgr
         .create_workflow_run("child-wf", Some("w1"), &parent.id, false, "manual", None)
@@ -217,9 +211,7 @@ pub(super) fn create_child_run(conn: &Connection) -> (WorkflowManager<'_>, Strin
 /// Helper: create a workflow run with steps in various statuses.
 pub(super) fn setup_run_with_steps(conn: &Connection) -> (String, WorkflowManager<'_>) {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let mgr = WorkflowManager::new(conn);
     let run = mgr
         .create_workflow_run("test-wf", Some("w1"), &parent.id, false, "manual", None)
@@ -373,7 +365,7 @@ pub(super) fn insert_workflow_run(
 ) {
     // Create a dummy agent_run so the FK on parent_run_id is satisfied.
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_runs \
          (id, workflow_name, worktree_id, parent_run_id, status, dry_run, trigger, started_at, \
@@ -402,7 +394,7 @@ pub(super) fn insert_workflow_run_with_targets(
     repo_id: Option<&str>,
 ) -> String {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     let mgr = WorkflowManager::new(conn);
     let run = mgr
         .create_workflow_run_with_targets(
@@ -432,7 +424,7 @@ pub(super) fn insert_waiting_run_with_gate(
     step_started_at: Option<&str>,
 ) -> String {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
 
     // Set the parent agent run to the requested status directly.
     conn.execute(
@@ -472,9 +464,7 @@ pub(super) fn make_workflow_run(
     conn: &Connection,
 ) -> (WorkflowManager<'_>, crate::agent::AgentRun, WorkflowRun) {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let mgr = WorkflowManager::new(conn);
     let run = mgr
         .create_workflow_run("test-wf", Some("w1"), &parent.id, false, "manual", None)
@@ -498,7 +488,7 @@ pub(super) fn setup_hooks_dir(config_toml: &str, workflows: &[(&str, &str)]) -> 
 pub(super) fn make_running_wf(conn: &Connection, name: &str) -> (String, String) {
     let agent_mgr = AgentManager::new(conn);
     let wf_mgr = WorkflowManager::new(conn);
-    let parent = agent_mgr.create_run(Some("w1"), name, None, None).unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), name, None).unwrap();
     let run = wf_mgr
         .create_workflow_run(name, Some("w1"), &parent.id, false, "manual", None)
         .unwrap();

--- a/conductor-core/src/workflow/tests/execution.rs
+++ b/conductor-core/src/workflow/tests/execution.rs
@@ -18,7 +18,7 @@ fn test_recover_stuck_steps_syncs_completed() {
     let wf_mgr = WorkflowManager::new(&conn);
 
     // Create a parent agent run and a workflow run
-    let parent = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
     let wf_run = wf_mgr
         .create_workflow_run("flow", Some("w1"), &parent.id, false, "manual", None)
         .unwrap();
@@ -28,7 +28,7 @@ fn test_recover_stuck_steps_syncs_completed() {
         .insert_step(&wf_run.id, "agent-step", "actor", false, 0, 0)
         .unwrap();
     let child = agent_mgr
-        .create_run(Some("w1"), "child-agent", None, None)
+        .create_run(Some("w1"), "child-agent", None)
         .unwrap();
     wf_mgr
         .update_step_status(
@@ -72,7 +72,7 @@ fn test_recover_stuck_steps_skips_still_running() {
     let agent_mgr = AgentManager::new(&conn);
     let wf_mgr = WorkflowManager::new(&conn);
 
-    let parent = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
     let wf_run = wf_mgr
         .create_workflow_run("flow", Some("w1"), &parent.id, false, "manual", None)
         .unwrap();
@@ -81,7 +81,7 @@ fn test_recover_stuck_steps_skips_still_running() {
         .insert_step(&wf_run.id, "agent-step", "actor", false, 0, 0)
         .unwrap();
     let child = agent_mgr
-        .create_run(Some("w1"), "child-agent", None, None)
+        .create_run(Some("w1"), "child-agent", None)
         .unwrap();
     wf_mgr
         .update_step_status(
@@ -109,7 +109,7 @@ fn test_recover_stuck_steps_failed_child_marks_step_failed() {
     let agent_mgr = AgentManager::new(&conn);
     let wf_mgr = WorkflowManager::new(&conn);
 
-    let parent = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
     let wf_run = wf_mgr
         .create_workflow_run("flow", Some("w1"), &parent.id, false, "manual", None)
         .unwrap();
@@ -118,7 +118,7 @@ fn test_recover_stuck_steps_failed_child_marks_step_failed() {
         .insert_step(&wf_run.id, "agent-step", "actor", false, 0, 0)
         .unwrap();
     let child = agent_mgr
-        .create_run(Some("w1"), "child-agent", None, None)
+        .create_run(Some("w1"), "child-agent", None)
         .unwrap();
     wf_mgr
         .update_step_status(
@@ -793,7 +793,7 @@ fn test_cannot_start_workflow_run_when_active() {
     let exec_config = WorkflowExecConfig::default();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
+        .create_run(Some("w1"), "workflow", None)
         .unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
@@ -824,7 +824,7 @@ fn test_force_bypasses_active_workflow_guard() {
     let exec_config = WorkflowExecConfig::default();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
+        .create_run(Some("w1"), "workflow", None)
         .unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
@@ -859,7 +859,7 @@ fn test_can_start_workflow_run_after_completion() {
     let exec_config = WorkflowExecConfig::default();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
+        .create_run(Some("w1"), "workflow", None)
         .unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
@@ -889,7 +889,7 @@ fn test_child_workflow_not_blocked_by_parent() {
     let exec_config = WorkflowExecConfig::default();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
+        .create_run(Some("w1"), "workflow", None)
         .unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
@@ -1843,7 +1843,7 @@ fn test_restore_completed_step_accumulates_costs() {
 
     // Create a child agent run with cost data
     let child_run = agent_mgr
-        .create_run(Some("w1"), "test agent", None, None)
+        .create_run(Some("w1"), "test agent", None)
         .unwrap();
     agent_mgr
         .update_run_completed(
@@ -2287,7 +2287,7 @@ fn test_condition_skipped_steps_not_in_completed_keys() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
+        .create_run(Some("w1"), "workflow", None)
         .unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr

--- a/conductor-core/src/workflow/tests/execution_misc.rs
+++ b/conductor-core/src/workflow/tests/execution_misc.rs
@@ -349,7 +349,7 @@ fn test_call_workflow_resume_failure_stops_without_new_child() {
 
     // Create parent workflow run.
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent_agent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent_agent = agent_mgr.create_run(None, "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let parent_run = wf_mgr
         .create_workflow_run("parent-wf", None, &parent_agent.id, false, "manual", None)
@@ -378,7 +378,7 @@ fn test_call_workflow_resume_failure_stops_without_new_child() {
     let child_snapshot = serde_json::to_string(&child_snap).unwrap();
 
     // Create child workflow run linked to the parent, with repo_id set.
-    let child_agent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let child_agent = agent_mgr.create_run(None, "workflow", None).unwrap();
     let child_run = wf_mgr
         .create_workflow_run_with_targets(
             "child",
@@ -440,7 +440,7 @@ fn test_call_workflow_resume_error_stops_without_new_child() {
 
     // Create parent workflow run.
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent_agent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent_agent = agent_mgr.create_run(None, "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let parent_run = wf_mgr
         .create_workflow_run("parent-wf", None, &parent_agent.id, false, "manual", None)
@@ -502,7 +502,7 @@ fn test_call_workflow_resume_failure_triggers_on_fail_agent() {
 
     // Create parent workflow run.
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent_agent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent_agent = agent_mgr.create_run(None, "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let parent_run = wf_mgr
         .create_workflow_run("parent-wf", None, &parent_agent.id, false, "manual", None)

--- a/conductor-core/src/workflow/tests/execution_recovery.rs
+++ b/conductor-core/src/workflow/tests/execution_recovery.rs
@@ -9,7 +9,7 @@ fn test_recover_stuck_steps_syncs_completed() {
     let wf_mgr = WorkflowManager::new(&conn);
 
     // Create a parent agent run and a workflow run
-    let parent = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
     let wf_run = wf_mgr
         .create_workflow_run("flow", Some("w1"), &parent.id, false, "manual", None)
         .unwrap();
@@ -19,7 +19,7 @@ fn test_recover_stuck_steps_syncs_completed() {
         .insert_step(&wf_run.id, "agent-step", "actor", false, 0, 0)
         .unwrap();
     let child = agent_mgr
-        .create_run(Some("w1"), "child-agent", None, None)
+        .create_run(Some("w1"), "child-agent", None)
         .unwrap();
     wf_mgr
         .update_step_status(
@@ -63,7 +63,7 @@ fn test_recover_stuck_steps_skips_still_running() {
     let agent_mgr = AgentManager::new(&conn);
     let wf_mgr = WorkflowManager::new(&conn);
 
-    let parent = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
     let wf_run = wf_mgr
         .create_workflow_run("flow", Some("w1"), &parent.id, false, "manual", None)
         .unwrap();
@@ -72,7 +72,7 @@ fn test_recover_stuck_steps_skips_still_running() {
         .insert_step(&wf_run.id, "agent-step", "actor", false, 0, 0)
         .unwrap();
     let child = agent_mgr
-        .create_run(Some("w1"), "child-agent", None, None)
+        .create_run(Some("w1"), "child-agent", None)
         .unwrap();
     wf_mgr
         .update_step_status(
@@ -100,7 +100,7 @@ fn test_recover_stuck_steps_failed_child_marks_step_failed() {
     let agent_mgr = AgentManager::new(&conn);
     let wf_mgr = WorkflowManager::new(&conn);
 
-    let parent = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
     let wf_run = wf_mgr
         .create_workflow_run("flow", Some("w1"), &parent.id, false, "manual", None)
         .unwrap();
@@ -109,7 +109,7 @@ fn test_recover_stuck_steps_failed_child_marks_step_failed() {
         .insert_step(&wf_run.id, "agent-step", "actor", false, 0, 0)
         .unwrap();
     let child = agent_mgr
-        .create_run(Some("w1"), "child-agent", None, None)
+        .create_run(Some("w1"), "child-agent", None)
         .unwrap();
     wf_mgr
         .update_step_status(
@@ -142,7 +142,7 @@ fn test_recover_stuck_steps_skips_step_with_purged_child_run() {
     let agent_mgr = AgentManager::new(&conn);
     let wf_mgr = WorkflowManager::new(&conn);
 
-    let parent = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
     let wf_run = wf_mgr
         .create_workflow_run("flow", Some("w1"), &parent.id, false, "manual", None)
         .unwrap();
@@ -461,7 +461,7 @@ fn test_restore_completed_step_accumulates_costs() {
 
     // Create a child agent run with cost data
     let child_run = agent_mgr
-        .create_run(Some("w1"), "test agent", None, None)
+        .create_run(Some("w1"), "test agent", None)
         .unwrap();
     agent_mgr
         .update_run_completed(
@@ -707,9 +707,7 @@ fn test_reap_finalization_child_run_not_reaped() {
     let (root_run_id, parent_agent_id) = make_running_wf(&conn, "root");
 
     // Create a child workflow run with parent_workflow_run_id set to root_run_id.
-    let child_agent = agent_mgr
-        .create_run(Some("w1"), "child", None, None)
-        .unwrap();
+    let child_agent = agent_mgr.create_run(Some("w1"), "child", None).unwrap();
     let child_run = wf_mgr
         .create_workflow_run_with_targets(
             "child",

--- a/conductor-core/src/workflow/tests/execution_steps.rs
+++ b/conductor-core/src/workflow/tests/execution_steps.rs
@@ -16,7 +16,7 @@ fn test_parallel_agent_completion_accumulates_tokens() {
 
     // Create two "completed" agent runs that simulate parallel agent results.
     let run_a = agent_mgr
-        .create_run(Some("w1"), "reviewer-a", None, None)
+        .create_run(Some("w1"), "reviewer-a", None)
         .unwrap();
     agent_mgr
         .update_run_completed(
@@ -34,7 +34,7 @@ fn test_parallel_agent_completion_accumulates_tokens() {
         .unwrap();
 
     let run_b = agent_mgr
-        .create_run(Some("w1"), "reviewer-b", None, None)
+        .create_run(Some("w1"), "reviewer-b", None)
         .unwrap();
     agent_mgr
         .update_run_completed(
@@ -52,9 +52,7 @@ fn test_parallel_agent_completion_accumulates_tokens() {
         .unwrap();
 
     // Build a state with a real workflow run so flush_metrics has a valid row.
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
@@ -523,9 +521,7 @@ fn test_if_step_not_found_skips() {
 fn test_condition_skipped_steps_not_in_completed_keys() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test-wf", Some("w1"), &parent.id, false, "manual", None)

--- a/conductor-core/src/workflow/tests/execution_workflow.rs
+++ b/conductor-core/src/workflow/tests/execution_workflow.rs
@@ -11,9 +11,7 @@ fn test_cannot_start_workflow_run_when_active() {
     let config = Config::default();
     let exec_config = WorkflowExecConfig::default();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("running-wf", Some("w1"), &parent.id, false, "manual", None)
@@ -47,9 +45,7 @@ fn test_can_start_workflow_run_after_completion() {
     let config = Config::default();
     let exec_config = WorkflowExecConfig::default();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("done-wf", Some("w1"), &parent.id, false, "manual", None)
@@ -84,9 +80,7 @@ fn test_child_workflow_not_blocked_by_parent() {
     let config = Config::default();
     let exec_config = WorkflowExecConfig::default();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("parent-wf", Some("w1"), &parent.id, false, "manual", None)
@@ -802,9 +796,7 @@ fn test_parent_step_id_writes_child_run_id_to_step() {
 
     // Set up a parent workflow run with a placeholder "call-child" step.
     let agent_mgr = AgentManager::new(&conn);
-    let parent_agent_run = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent_agent_run = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let parent_run = wf_mgr
         .create_workflow_run(

--- a/conductor-core/src/workflow/tests/gates.rs
+++ b/conductor-core/src/workflow/tests/gates.rs
@@ -7,9 +7,7 @@ use crate::agent::AgentManager;
 fn test_gate_approve() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -43,9 +41,7 @@ fn test_gate_approve() {
 fn test_gate_reject() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -117,9 +113,7 @@ fn test_gate_timeout_continue() {
 fn test_gate_pr_approval_approve() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -145,9 +139,7 @@ fn test_gate_pr_approval_approve() {
 fn test_gate_pr_approval_reject() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -176,9 +168,7 @@ fn test_gate_pr_approval_reject() {
 fn test_gate_pr_checks_approve() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -273,9 +263,7 @@ fn test_gate_timeout_zero_seconds() {
 fn test_gate_multiselect_options_and_approval() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -333,9 +321,7 @@ fn test_gate_multiselect_options_and_approval() {
 fn test_gate_approve_empty_selections() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr

--- a/conductor-core/src/workflow/tests/helpers.rs
+++ b/conductor-core/src/workflow/tests/helpers.rs
@@ -252,9 +252,7 @@ fn test_summary_labels_never_executed_failed_step() {
     let config = make_resume_config();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test-wf", Some("w1"), &parent.id, false, "manual", None)
@@ -298,9 +296,7 @@ fn test_summary_does_not_label_started_failed_step() {
     let config = make_resume_config();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test-wf", Some("w1"), &parent.id, false, "manual", None)

--- a/conductor-core/src/workflow/tests/manager.rs
+++ b/conductor-core/src/workflow/tests/manager.rs
@@ -9,9 +9,7 @@ use std::collections::HashMap;
 fn test_create_workflow_run() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -34,9 +32,7 @@ fn test_create_workflow_run() {
 fn test_create_workflow_run_with_snapshot() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -61,9 +57,7 @@ fn test_create_workflow_run_with_snapshot() {
 fn test_create_workflow_run_with_repo_id_round_trip() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -106,9 +100,7 @@ fn test_active_run_counts_by_repo_empty() {
 fn test_active_run_counts_by_repo_with_runs() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let mgr = WorkflowManager::new(&conn);
 
     // Create one pending and one running run for repo r1.
@@ -159,9 +151,7 @@ fn test_active_run_counts_by_repo_with_runs() {
 fn test_active_run_counts_by_repo_excludes_completed() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let mgr = WorkflowManager::new(&conn);
 
     let run = mgr
@@ -195,9 +185,7 @@ fn test_active_run_counts_by_repo_excludes_completed() {
 fn test_create_workflow_run_with_ticket_id_round_trip() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     insert_test_ticket(&conn, "tkt-rt-1", "r1");
 
@@ -231,9 +219,7 @@ fn test_create_workflow_run_with_ticket_id_round_trip() {
 fn test_insert_step_with_iteration() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -255,9 +241,7 @@ fn test_insert_step_with_iteration() {
 fn test_insert_step_running_is_atomic() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -287,9 +271,7 @@ fn test_insert_step_running_is_atomic() {
 fn test_update_step_with_markers() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -322,9 +304,7 @@ fn test_update_step_with_markers() {
 fn test_update_step_status_full_with_structured_output() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -358,9 +338,7 @@ fn test_update_step_status_full_with_structured_output() {
 fn test_update_step_status_full_without_structured_output() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -391,9 +369,7 @@ fn test_update_step_status_full_without_structured_output() {
 fn test_update_step_status_full_with_step_error() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -427,8 +403,8 @@ fn test_update_step_status_full_with_step_error() {
 fn test_list_workflow_runs() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None, None).unwrap();
-    let p2 = agent_mgr.create_run(Some("w1"), "wf2", None, None).unwrap();
+    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None).unwrap();
+    let p2 = agent_mgr.create_run(Some("w1"), "wf2", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     mgr.create_workflow_run("test-a", Some("w1"), &p1.id, false, "manual", None)
@@ -452,8 +428,8 @@ fn test_list_all_workflow_runs_cross_worktree() {
     .unwrap();
 
     let agent_mgr = AgentManager::new(&conn);
-    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None, None).unwrap();
-    let p2 = agent_mgr.create_run(Some("w2"), "wf2", None, None).unwrap();
+    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None).unwrap();
+    let p2 = agent_mgr.create_run(Some("w2"), "wf2", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     mgr.create_workflow_run("flow-a", Some("w1"), &p1.id, false, "manual", None)
@@ -477,7 +453,7 @@ fn test_list_all_workflow_runs_respects_limit() {
     let mgr = WorkflowManager::new(&conn);
     for i in 0..5 {
         let p = agent_mgr
-            .create_run(Some("w1"), &format!("wf{i}"), None, None)
+            .create_run(Some("w1"), &format!("wf{i}"), None)
             .unwrap();
         mgr.create_workflow_run(
             &format!("flow-{i}"),
@@ -509,15 +485,13 @@ fn test_list_all_workflow_runs_includes_ephemeral() {
     let mgr = WorkflowManager::new(&conn);
 
     // Create a normal run (with worktree)
-    let parent1 = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent1 = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     mgr.create_workflow_run("normal-wf", Some("w1"), &parent1.id, false, "manual", None)
         .unwrap();
 
     // Create an ephemeral run (no worktree)
     let parent2 = agent_mgr
-        .create_run(None, "ephemeral workflow", None, None)
+        .create_run(None, "ephemeral workflow", None)
         .unwrap();
     let ephemeral = mgr
         .create_workflow_run("ephemeral-wf", None, &parent2.id, false, "manual", None)
@@ -543,8 +517,8 @@ fn test_list_all_workflow_runs_excludes_merged_worktree() {
     .unwrap();
 
     let agent_mgr = AgentManager::new(&conn);
-    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None, None).unwrap();
-    let p2 = agent_mgr.create_run(Some("w2"), "wf2", None, None).unwrap();
+    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None).unwrap();
+    let p2 = agent_mgr.create_run(Some("w2"), "wf2", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     mgr.create_workflow_run("active-run", Some("w1"), &p1.id, false, "manual", None)
@@ -569,8 +543,8 @@ fn test_list_all_workflow_runs_excludes_abandoned_worktree() {
     .unwrap();
 
     let agent_mgr = AgentManager::new(&conn);
-    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None, None).unwrap();
-    let p2 = agent_mgr.create_run(Some("w2"), "wf2", None, None).unwrap();
+    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None).unwrap();
+    let p2 = agent_mgr.create_run(Some("w2"), "wf2", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     mgr.create_workflow_run("active-run", Some("w1"), &p1.id, false, "manual", None)
@@ -590,12 +564,12 @@ fn test_list_all_workflow_runs_includes_ephemeral_and_active() {
     let mgr = WorkflowManager::new(&conn);
 
     // Active worktree run
-    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None, None).unwrap();
+    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None).unwrap();
     mgr.create_workflow_run("active-run", Some("w1"), &p1.id, false, "manual", None)
         .unwrap();
 
     // Ephemeral run (no worktree)
-    let p2 = agent_mgr.create_run(None, "wf2", None, None).unwrap();
+    let p2 = agent_mgr.create_run(None, "wf2", None).unwrap();
     mgr.create_workflow_run("ephemeral-run", None, &p2.id, false, "manual", None)
         .unwrap();
 
@@ -613,12 +587,12 @@ fn test_list_all_workflow_runs_filtered_paginated_status_filter() {
     let mgr = WorkflowManager::new(&conn);
 
     // Create one run and leave it in Pending state.
-    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None, None).unwrap();
+    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None).unwrap();
     mgr.create_workflow_run("pending-run", Some("w1"), &p1.id, false, "manual", None)
         .unwrap();
 
     // Create a second run and advance it to Completed.
-    let p2 = agent_mgr.create_run(Some("w1"), "wf2", None, None).unwrap();
+    let p2 = agent_mgr.create_run(Some("w1"), "wf2", None).unwrap();
     let r2 = mgr
         .create_workflow_run("done-run", Some("w1"), &p2.id, false, "manual", None)
         .unwrap();
@@ -646,7 +620,7 @@ fn test_list_all_workflow_runs_filtered_paginated_offset() {
 
     for i in 0..4 {
         let p = agent_mgr
-            .create_run(Some("w1"), &format!("wf{i}"), None, None)
+            .create_run(Some("w1"), &format!("wf{i}"), None)
             .unwrap();
         mgr.create_workflow_run(
             &format!("flow-{i}"),
@@ -690,8 +664,8 @@ fn test_list_workflow_runs_by_repo_id_excludes_merged_worktree() {
     .unwrap();
 
     let agent_mgr = AgentManager::new(&conn);
-    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None, None).unwrap();
-    let p2 = agent_mgr.create_run(Some("w2"), "wf2", None, None).unwrap();
+    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None).unwrap();
+    let p2 = agent_mgr.create_run(Some("w2"), "wf2", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     // Use create_workflow_run_with_targets to set repo_id so the query can filter by it
@@ -738,8 +712,8 @@ fn test_list_workflow_runs_for_scope_scoped() {
     .unwrap();
 
     let agent_mgr = AgentManager::new(&conn);
-    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None, None).unwrap();
-    let p2 = agent_mgr.create_run(Some("w2"), "wf2", None, None).unwrap();
+    let p1 = agent_mgr.create_run(Some("w1"), "wf1", None).unwrap();
+    let p2 = agent_mgr.create_run(Some("w2"), "wf2", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     mgr.create_workflow_run("only-w1", Some("w1"), &p1.id, false, "manual", None)
@@ -764,7 +738,7 @@ fn test_list_workflow_runs_for_scope_global_limit() {
     let mgr = WorkflowManager::new(&conn);
     for i in 0..5 {
         let p = agent_mgr
-            .create_run(Some("w1"), &format!("wf{i}"), None, None)
+            .create_run(Some("w1"), &format!("wf{i}"), None)
             .unwrap();
         mgr.create_workflow_run(
             &format!("flow-{i}"),
@@ -792,9 +766,7 @@ fn test_get_workflow_run_not_found() {
 fn test_get_step_by_id() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -820,10 +792,10 @@ fn test_get_step_by_id() {
 fn test_purge_all_terminal_statuses() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let a1 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
-    let a2 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
-    let a3 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
-    let a4 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let a1 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
+    let a2 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
+    let a3 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
+    let a4 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let r_completed = mgr
@@ -865,8 +837,8 @@ fn test_purge_all_terminal_statuses() {
 fn test_purge_single_status_filter() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let a1 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
-    let a2 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let a1 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
+    let a2 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let r_completed = mgr
@@ -907,8 +879,8 @@ fn test_purge_repo_scoped() {
     .unwrap();
 
     let agent_mgr = AgentManager::new(&conn);
-    let a1 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
-    let a2 = agent_mgr.create_run(Some("w2"), "wf", None, None).unwrap();
+    let a1 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
+    let a2 = agent_mgr.create_run(Some("w2"), "wf", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run_r1 = mgr
@@ -935,7 +907,7 @@ fn test_purge_repo_scoped() {
 fn test_purge_cascade_deletes_steps() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let a1 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let a1 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -958,8 +930,8 @@ fn test_purge_cascade_deletes_steps() {
 fn test_purge_count_matches_purge() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let a1 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
-    let a2 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let a1 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
+    let a2 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let r1 = mgr
@@ -985,7 +957,7 @@ fn test_purge_count_matches_purge() {
 fn test_purge_noop_when_no_matches() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let a1 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let a1 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -1022,8 +994,8 @@ fn test_purge_repo_scoped_does_not_delete_global_runs() {
     let agent_mgr = AgentManager::new(&conn);
 
     // Create a global run (no worktree) and a run scoped to w1.
-    let a_global = agent_mgr.create_run(None, "wf", None, None).unwrap();
-    let a_w1 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let a_global = agent_mgr.create_run(None, "wf", None).unwrap();
+    let a_w1 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run_global = mgr
@@ -1157,9 +1129,7 @@ fn test_delete_run_recursive_removes_child_runs() {
     let conn = setup_db();
     // Create parent run
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent_agent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent_agent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let mgr = WorkflowManager::new(&conn);
     let parent_run = mgr
         .create_workflow_run(
@@ -1173,9 +1143,7 @@ fn test_delete_run_recursive_removes_child_runs() {
         .unwrap();
 
     // Create a child run (parent_workflow_run_id points to parent_run)
-    let child_agent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let child_agent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let child_run = mgr
         .create_workflow_run_with_targets(
             "child-wf",
@@ -1208,8 +1176,8 @@ fn test_delete_run_recursive_removes_child_runs() {
 fn test_delete_run_does_not_affect_sibling_runs() {
     let conn = setup_db();
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let a1 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
-    let a2 = agent_mgr.create_run(Some("w1"), "wf", None, None).unwrap();
+    let a1 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
+    let a2 = agent_mgr.create_run(Some("w1"), "wf", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run1 = mgr
@@ -1257,7 +1225,7 @@ fn test_cancel_run_running_with_active_steps() {
     // Insert a Running step with a child agent run
     let child_agent_mgr = AgentManager::new(&conn);
     let child = child_agent_mgr
-        .create_run(Some("w1"), "child-step", None, None)
+        .create_run(Some("w1"), "child-step", None)
         .unwrap();
 
     let step_id = mgr
@@ -1450,8 +1418,8 @@ fn test_find_resumable_child_run_picks_most_recent() {
 
     // Insert two failed child runs with distinct timestamps
     let agent_mgr = AgentManager::new(&conn);
-    let p1 = agent_mgr.create_run(None, "workflow", None, None).unwrap();
-    let p2 = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let p1 = agent_mgr.create_run(None, "workflow", None).unwrap();
+    let p2 = agent_mgr.create_run(None, "workflow", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_runs \
          (id, workflow_name, worktree_id, parent_run_id, status, dry_run, trigger, started_at, \
@@ -1666,9 +1634,7 @@ fn insert_running_script_step_with_pid(
 /// Helper: create a workflow_run and return its id.
 fn make_workflow_run_id(conn: &Connection) -> String {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let mgr = WorkflowManager::new(conn);
     let run = mgr
         .create_workflow_run("test-wf", Some("w1"), &parent.id, false, "manual", None)
@@ -1761,9 +1727,7 @@ fn test_reap_orphaned_script_steps_skips_agent_step() {
     // Insert an actor step with child_run_id set — simulates an agent step.
     let step_id = crate::new_id();
     let agent_mgr = AgentManager::new(&conn);
-    let child_run = agent_mgr
-        .create_run(Some("w1"), "agent", None, None)
-        .unwrap();
+    let child_run = agent_mgr.create_run(Some("w1"), "agent", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_run_steps \
          (id, workflow_run_id, step_name, role, position, status, iteration, \
@@ -1843,7 +1807,7 @@ fn test_list_workflow_runs_paginated_limit_and_offset() {
     // Create 5 runs for worktree w1
     for i in 0..5 {
         let p = agent_mgr
-            .create_run(Some("w1"), &format!("wf-paginated-{i}"), None, None)
+            .create_run(Some("w1"), &format!("wf-paginated-{i}"), None)
             .unwrap();
         mgr.create_workflow_run(
             &format!("paginated-flow-{i}"),
@@ -1894,12 +1858,8 @@ fn test_list_workflow_runs_paginated_filters_by_worktree() {
     let agent_mgr = AgentManager::new(&conn);
     let mgr = WorkflowManager::new(&conn);
 
-    let p1 = agent_mgr
-        .create_run(Some("w1"), "wf-w1", None, None)
-        .unwrap();
-    let p2 = agent_mgr
-        .create_run(Some("w2"), "wf-w2", None, None)
-        .unwrap();
+    let p1 = agent_mgr.create_run(Some("w1"), "wf-w1", None).unwrap();
+    let p2 = agent_mgr.create_run(Some("w2"), "wf-w2", None).unwrap();
     mgr.create_workflow_run("run-w1", Some("w1"), &p1.id, false, "manual", None)
         .unwrap();
     mgr.create_workflow_run("run-w2", Some("w2"), &p2.id, false, "manual", None)
@@ -1923,7 +1883,7 @@ fn test_list_workflow_runs_by_repo_id_offset_pagination() {
     // Create 4 runs for repo r1 (all on active worktree w1)
     for i in 0..4 {
         let p = agent_mgr
-            .create_run(Some("w1"), &format!("wf-repo-{i}"), None, None)
+            .create_run(Some("w1"), &format!("wf-repo-{i}"), None)
             .unwrap();
         mgr.create_workflow_run_with_targets(
             &format!("repo-flow-{i}"),
@@ -2293,9 +2253,7 @@ fn test_backfill_migration_sets_repo_id_on_historical_runs() {
 
     // Create a workflow run with worktree_id but NULL repo_id (historical data).
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_runs \
          (id, workflow_name, worktree_id, parent_run_id, status, dry_run, trigger, started_at) \
@@ -2377,9 +2335,7 @@ fn test_backfill_migration_leaves_null_when_worktree_deleted() {
     let conn = setup_db();
 
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     // Insert a run referencing worktree w1, then orphan it by pointing
     // worktree_id at a non-existent ID (simulating a deleted worktree row).
@@ -2518,9 +2474,7 @@ fn test_get_steps_for_runs_multiple_runs() {
     let (mgr, _p1, run1) = make_workflow_run(&conn);
 
     let agent_mgr = AgentManager::new(&conn);
-    let p2 = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let p2 = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let run2 = mgr
         .create_workflow_run("wf2", Some("w1"), &p2.id, false, "manual", None)
         .unwrap();
@@ -2589,7 +2543,7 @@ fn test_get_active_steps_for_runs_empty_ids() {
 /// Insert a workflow run in 'running' status with no parent_workflow_run_id.
 fn insert_running_root_run(conn: &Connection, run_id: &str) {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_runs \
          (id, workflow_name, worktree_id, parent_run_id, status, dry_run, trigger, \
@@ -2734,7 +2688,7 @@ fn test_reap_stuck_workflow_runs_skips_sub_workflow() {
     .unwrap();
     // Insert a sub-workflow with parent_workflow_run_id set.
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_runs \
          (id, workflow_name, worktree_id, parent_run_id, status, dry_run, trigger, \
@@ -2831,7 +2785,7 @@ fn insert_running_root_run_with_label(
     target_label: Option<&str>,
 ) {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_runs \
          (id, workflow_name, worktree_id, parent_run_id, status, dry_run, trigger, \
@@ -2920,7 +2874,7 @@ fn test_detect_stale_workflow_runs_skips_sub_workflows() {
     insert_running_root_run_with_label(&conn, "root-run", "parent-wf", None);
     // Insert a sub-workflow with old running step.
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_runs \
          (id, workflow_name, worktree_id, parent_run_id, status, dry_run, trigger, \
@@ -2959,7 +2913,7 @@ fn insert_child_workflow_run(
     status: &str,
 ) {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_runs \
          (id, workflow_name, worktree_id, parent_run_id, status, dry_run, trigger, \
@@ -3118,9 +3072,7 @@ fn test_reap_stale_reaps_dead_agent() {
     insert_running_root_run_with_label(&conn, "stale-run", "deploy", Some("repo/wt"));
     // Create a child agent run — no live subprocess.
     let agent_mgr = AgentManager::new(&conn);
-    let child = agent_mgr
-        .create_run(None, "step prompt", None, None)
-        .unwrap();
+    let child = agent_mgr.create_run(None, "step prompt", None).unwrap();
     // Insert step referencing that child agent run (no subprocess_pid → treated as dead).
     conn.execute(
         "INSERT INTO workflow_run_steps \
@@ -3153,9 +3105,7 @@ fn test_reap_stale_skips_live_agent() {
     let conn = setup_db();
     insert_running_root_run_with_label(&conn, "alive-run", "deploy", None);
     let agent_mgr = AgentManager::new(&conn);
-    let child = agent_mgr
-        .create_run(None, "step prompt", None, None)
-        .unwrap();
+    let child = agent_mgr.create_run(None, "step prompt", None).unwrap();
     // Set subprocess_pid to current process PID (alive).
     let live_pid = std::process::id() as i64;
     conn.execute(
@@ -3183,9 +3133,7 @@ fn test_reap_stale_reaps_step_with_no_pid() {
     insert_running_root_run_with_label(&conn, "no-pid-run", "deploy", None);
     // Child agent run with no subprocess PID → treated as dead.
     let agent_mgr = AgentManager::new(&conn);
-    let child = agent_mgr
-        .create_run(None, "step prompt", None, None)
-        .unwrap();
+    let child = agent_mgr.create_run(None, "step prompt", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_run_steps \
          (id, workflow_run_id, step_name, role, position, status, iteration, \
@@ -3215,7 +3163,7 @@ fn test_detect_stuck_finds_run_with_only_terminal_steps() {
     let conn = setup_db();
     // Insert a running root run whose only step is completed (old ended_at).
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_runs \
          (id, workflow_name, worktree_id, parent_run_id, status, dry_run, trigger, \
@@ -3243,7 +3191,7 @@ fn test_detect_stuck_finds_run_with_only_terminal_steps() {
 fn test_detect_stuck_skips_run_with_active_steps() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_runs \
          (id, workflow_name, worktree_id, parent_run_id, status, dry_run, trigger, \
@@ -3275,7 +3223,7 @@ fn test_detect_stuck_skips_run_with_active_steps() {
 fn test_recover_stuck_steps_fixes_step_with_terminal_child() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     conn.execute(
         "INSERT INTO workflow_runs \
          (id, workflow_name, worktree_id, parent_run_id, status, dry_run, trigger, \
@@ -3287,9 +3235,7 @@ fn test_recover_stuck_steps_fixes_step_with_terminal_child() {
     .unwrap();
 
     // Create a child agent run and mark it completed via SQL.
-    let child = agent_mgr
-        .create_run(None, "step prompt", None, None)
-        .unwrap();
+    let child = agent_mgr.create_run(None, "step prompt", None).unwrap();
     conn.execute(
         "UPDATE agent_runs SET status = 'completed' WHERE id = :id",
         named_params! { ":id": child.id },
@@ -3572,9 +3518,7 @@ fn create_agent_step(
     subprocess_pid: i64,
 ) -> (String, String) {
     let agent_mgr = AgentManager::new(conn);
-    let agent = agent_mgr
-        .create_run(Some("w1"), step_name, None, None)
-        .unwrap();
+    let agent = agent_mgr.create_run(Some("w1"), step_name, None).unwrap();
     conn.execute(
         "UPDATE agent_runs SET subprocess_pid = :pid WHERE id = :id",
         named_params! { ":pid": subprocess_pid, ":id": agent.id },
@@ -3783,7 +3727,7 @@ fn insert_orphaned_root_run(
     last_heartbeat: Option<&str>,
 ) -> String {
     let agent_mgr = AgentManager::new(conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     let id = crate::new_id();
     conn.execute(
         "INSERT INTO workflow_runs \
@@ -3939,7 +3883,7 @@ fn test_reap_heartbeat_stuck_sub_workflow_excluded() {
 
     // First create a parent run (to satisfy FK).
     let parent_agent = AgentManager::new(&conn)
-        .create_run(None, "workflow", None, None)
+        .create_run(None, "workflow", None)
         .unwrap();
     let parent_run_id = crate::new_id();
     conn.execute(
@@ -3953,7 +3897,7 @@ fn test_reap_heartbeat_stuck_sub_workflow_excluded() {
 
     // Now create a sub-workflow run with parent_workflow_run_id set.
     let child_agent = AgentManager::new(&conn)
-        .create_run(None, "workflow", None, None)
+        .create_run(None, "workflow", None)
         .unwrap();
     let child_run_id = crate::new_id();
     conn.execute(
@@ -3990,9 +3934,7 @@ fn test_reap_heartbeat_stuck_sub_workflow_excluded() {
 fn test_step_error_persisted_on_schema_validation_failure() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr

--- a/conductor-core/src/workflow/tests/on_fail_continue.rs
+++ b/conductor-core/src/workflow/tests/on_fail_continue.rs
@@ -216,9 +216,7 @@ fn test_script_on_fail_continue_skips_step() {
     std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
@@ -281,9 +279,7 @@ fn test_script_no_on_fail_still_fails_workflow() {
     std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
 
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)

--- a/conductor-core/src/workflow/tests/resumption.rs
+++ b/conductor-core/src/workflow/tests/resumption.rs
@@ -15,9 +15,7 @@ fn test_get_active_run_for_worktree_none_when_empty() {
 fn test_get_active_run_for_worktree_returns_active() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -36,9 +34,7 @@ fn test_get_active_run_for_worktree_returns_active() {
 fn test_get_active_run_for_worktree_none_after_completion() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -62,9 +58,7 @@ fn test_get_active_run_for_worktree_ignores_other_worktree() {
     .unwrap();
 
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w2"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w2"), "workflow", None).unwrap();
 
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
@@ -128,9 +122,7 @@ fn test_resume_rejects_completed_run() {
     let conn = setup_db();
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
@@ -167,9 +159,7 @@ fn test_resume_rejects_cancelled_run() {
     let conn = setup_db();
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
@@ -215,9 +205,7 @@ fn test_resume_rejects_restart_and_from_step_together() {
     let conn = setup_db();
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
@@ -255,9 +243,7 @@ fn test_resume_rejects_missing_snapshot() {
     let conn = setup_db();
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     // Create run with no definition_snapshot
     let run = wf_mgr
@@ -308,9 +294,7 @@ fn test_resume_rejects_nonexistent_from_step() {
     let conn = setup_db();
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
@@ -366,9 +350,7 @@ fn test_resume_workflow_falls_back_to_repo_root_when_worktree_path_missing() {
     let conn = setup_db();
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
 
     // Serialize a valid empty WorkflowDef as the snapshot so resume can deserialize it.
@@ -415,9 +397,7 @@ fn test_resume_workflow_falls_back_to_repo_root_when_worktree_path_missing() {
 fn test_set_workflow_run_inputs_round_trip() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
@@ -456,9 +436,7 @@ fn test_set_workflow_run_inputs_round_trip() {
 fn test_set_workflow_run_default_bot_name_round_trip() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
@@ -498,9 +476,7 @@ fn test_default_bot_name_persists_through_suspend_and_resume() {
     // exercises the full store → retrieve invariant for multi-stage bot identity.
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
@@ -544,9 +520,7 @@ fn test_default_bot_name_persists_through_suspend_and_resume() {
 fn test_row_to_workflow_run_malformed_inputs_json_returns_empty() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
@@ -628,9 +602,7 @@ fn test_restart_resets_all_steps() {
 fn test_from_step_skip_set_and_step_map() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
         .create_workflow_run("test-wf", Some("w1"), &parent.id, false, "manual", None)
@@ -775,9 +747,7 @@ fn test_resume_allows_restart_on_completed_run() {
     let conn = setup_db();
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
@@ -890,7 +860,7 @@ fn test_resume_workflow_ephemeral_run_rejected() {
     let conn = setup_db();
     let config = Config::default();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+    let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
     let snapshot = serde_json::to_string(&make_empty_workflow()).unwrap();
     let run = wf_mgr
@@ -1034,9 +1004,7 @@ fn test_resume_deletes_orphaned_pending_steps() {
     let conn = setup_db();
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let wf_mgr = WorkflowManager::new(&conn);
 
     let snapshot = serde_json::to_string(&make_empty_workflow()).unwrap();

--- a/conductor-core/src/workflow/tests/types.rs
+++ b/conductor-core/src/workflow/tests/types.rs
@@ -220,9 +220,7 @@ fn test_workflow_step_summary_empty_chain() {
 fn test_is_triggered_by_hook_true() {
     let conn = setup_db();
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let mgr = WorkflowManager::new(&conn);
     let mut run = mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "hook", None)
@@ -235,9 +233,7 @@ fn test_is_triggered_by_hook_true() {
 fn test_is_triggered_by_hook_false() {
     let conn = setup_db();
     let agent_mgr = crate::agent::AgentManager::new(&conn);
-    let parent = agent_mgr
-        .create_run(Some("w1"), "workflow", None, None)
-        .unwrap();
+    let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
     let mgr = WorkflowManager::new(&conn);
     let run = mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)

--- a/conductor-core/src/workflow_ephemeral.rs
+++ b/conductor-core/src/workflow_ephemeral.rs
@@ -354,7 +354,7 @@ mod tests {
         let conn = setup_db();
         let agent_mgr = AgentManager::new(&conn);
         // Create an ephemeral parent agent run (empty worktree_id → stored as NULL)
-        let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+        let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
 
         let mgr = WorkflowManager::new(&conn);
         // Create an ephemeral workflow run with worktree_id = None and a definition snapshot
@@ -402,7 +402,7 @@ mod tests {
         let conn = setup_db();
         let agent_mgr = AgentManager::new(&conn);
         // Ephemeral runs pass "" as worktree_id to agent_runs (stored as NULL after migration 027)
-        let parent = agent_mgr.create_run(None, "workflow", None, None).unwrap();
+        let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
 
         let mgr = WorkflowManager::new(&conn);
         let run = mgr

--- a/conductor-core/tests/cli_runtime_integration.rs
+++ b/conductor-core/tests/cli_runtime_integration.rs
@@ -1,11 +1,10 @@
 //! Integration tests for CliRuntime.
 //!
-//! Uses a mock shell script to simulate a CLI agent. Requires tmux to be
-//! available on the system; tests are skipped when tmux is absent.
+//! Uses a mock shell script to simulate a CLI agent. No tmux dependency.
 
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::{atomic::AtomicBool, Arc, Mutex};
 use std::time::Duration;
 
 use conductor_core::agent_config::{AgentDef, AgentRole};
@@ -14,14 +13,8 @@ use conductor_core::config::RuntimeConfig;
 use conductor_core::runtime::cli::CliRuntime;
 use conductor_core::runtime::{AgentRuntime, RuntimeRequest};
 
-fn tmux_available() -> bool {
-    // tmux must be installed AND have an active server session
-    std::process::Command::new("tmux")
-        .arg("info")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
+// Serializes tests that mutate CONDUCTOR_DB_PATH so they don't race.
+static DB_PATH_LOCK: Mutex<()> = Mutex::new(());
 
 fn make_mock_script(json_body: &str, exit_code: i32) -> (tempfile::NamedTempFile, String) {
     let mut f = tempfile::Builder::new()
@@ -90,12 +83,11 @@ fn assert_run_cancelled(db_guard: &tempfile::NamedTempFile, run_id: &str) {
     );
 }
 
-fn setup_test_db(run_id: &str) -> tempfile::NamedTempFile {
+fn setup_test_db(run_id: &str) -> (tempfile::NamedTempFile, std::sync::MutexGuard<'static, ()>) {
+    let lock = DB_PATH_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let tmp = tempfile::NamedTempFile::new().expect("temp db file");
     let path = tmp.path().to_string_lossy().to_string();
 
-    // Point CliRuntime at our test DB for this process (test threads are
-    // serialised by cargo test when using env vars in a single binary).
     std::env::set_var("CONDUCTOR_DB_PATH", &path);
 
     let conn = conductor_core::db::open_database(tmp.path()).expect("open test db");
@@ -108,22 +100,17 @@ fn setup_test_db(run_id: &str) -> tempfile::NamedTempFile {
     )
     .expect("insert run");
 
-    tmp
+    (tmp, lock)
 }
 
 #[test]
 fn test_cli_runtime_success() {
-    if !tmux_available() {
-        eprintln!("skipping cli_runtime test: tmux not available");
-        return;
-    }
-
     let json_body = r#"{"response":"hello world","stats":{"total_tokens":42}}"#;
     let (_guard, script_path) = make_mock_script(json_body, 0);
     let runtime = make_runtime(&script_path, "response", Some("stats.total_tokens"));
 
     let run_id = format!("test-cli-{}", ulid::Ulid::new());
-    let _db_guard = setup_test_db(&run_id);
+    let (_db_guard, _lock) = setup_test_db(&run_id);
 
     let req = RuntimeRequest {
         run_id: run_id.clone(),
@@ -150,8 +137,8 @@ fn test_cli_runtime_success() {
         conductor_core::agent::AgentRunStatus::Completed
     );
     assert!(
-        result.tmux_window.is_some(),
-        "tmux_window must be persisted so is_alive() and orphan reaper can track the run"
+        result.subprocess_pid.is_some(),
+        "subprocess_pid must be persisted so is_alive() and orphan reaper can track the run"
     );
     assert_eq!(
         result.input_tokens,
@@ -162,17 +149,12 @@ fn test_cli_runtime_success() {
 
 /// Assert that a non-zero exit code causes the run to be marked `Failed`.
 fn assert_nonzero_exit_maps_to_failed(exit_code: i32, run_id_prefix: &str) {
-    if !tmux_available() {
-        eprintln!("skipping cli_runtime test: tmux not available");
-        return;
-    }
-
     let json_body = r#"{"response":"error"}"#;
     let (_guard, script_path) = make_mock_script(json_body, exit_code);
     let runtime = make_runtime(&script_path, "response", None);
 
     let run_id = format!("{}-{}", run_id_prefix, ulid::Ulid::new());
-    let _db_guard = setup_test_db(&run_id);
+    let (_db_guard, _lock) = setup_test_db(&run_id);
 
     let req = RuntimeRequest {
         run_id: run_id.clone(),
@@ -217,11 +199,6 @@ fn test_cli_runtime_exit_code_53_is_error() {
 
 #[test]
 fn test_cli_runtime_stdin_mode() {
-    if !tmux_available() {
-        eprintln!("skipping cli_runtime stdin test: tmux not available");
-        return;
-    }
-
     // Script that reads stdin and echoes it as JSON output.
     let mut f = tempfile::Builder::new()
         .suffix(".sh")
@@ -248,7 +225,7 @@ exit 0"#
     });
 
     let run_id = format!("test-stdin-{}", ulid::Ulid::new());
-    let _db_guard = setup_test_db(&run_id);
+    let (_db_guard, _lock) = setup_test_db(&run_id);
 
     let req = RuntimeRequest {
         run_id: run_id.clone(),
@@ -278,7 +255,7 @@ exit 0"#
 
 /// Spawn a slow-sleeping script via CliRuntime and return the handles needed
 /// to call `poll()` in the test.  Returns `(script_guard, db_guard, runtime,
-/// run_id)` — callers must keep all guards alive for the duration of the test.
+/// run_id, lock)` — callers must keep all guards alive for the duration of the test.
 fn spawn_slow_script(
     id_prefix: &str,
 ) -> (
@@ -286,6 +263,7 @@ fn spawn_slow_script(
     tempfile::NamedTempFile,
     CliRuntime,
     String,
+    std::sync::MutexGuard<'static, ()>,
 ) {
     let mut f = tempfile::Builder::new()
         .suffix(".sh")
@@ -303,7 +281,7 @@ fn spawn_slow_script(
     });
 
     let run_id = format!("{}-{}", id_prefix, ulid::Ulid::new());
-    let db_guard = setup_test_db(&run_id);
+    let (db_guard, lock) = setup_test_db(&run_id);
 
     let req = RuntimeRequest {
         run_id: run_id.clone(),
@@ -320,17 +298,12 @@ fn spawn_slow_script(
 
     runtime.spawn(&req).expect("spawn must succeed");
 
-    (f, db_guard, runtime, run_id)
+    (f, db_guard, runtime, run_id, lock)
 }
 
 #[test]
 fn test_cli_runtime_timeout_returns_no_result() {
-    if !tmux_available() {
-        eprintln!("skipping cli_runtime timeout test: tmux not available");
-        return;
-    }
-
-    let (_script, _db, runtime, run_id) = spawn_slow_script("test-timeout");
+    let (_script, _db, runtime, run_id, _lock) = spawn_slow_script("test-timeout");
     let result = runtime.poll(&run_id, None, Duration::from_millis(200));
     assert!(
         matches!(result, Err(conductor_core::runtime::PollError::NoResult)),
@@ -340,12 +313,7 @@ fn test_cli_runtime_timeout_returns_no_result() {
 
 #[test]
 fn test_cli_runtime_shutdown_flag_cancels_poll() {
-    if !tmux_available() {
-        eprintln!("skipping cli_runtime shutdown test: tmux not available");
-        return;
-    }
-
-    let (_script, _db, runtime, run_id) = spawn_slow_script("test-shutdown");
+    let (_script, _db, runtime, run_id, _lock) = spawn_slow_script("test-shutdown");
     // Pre-set the shutdown flag so poll() exits on the first iteration.
     let shutdown = Arc::new(AtomicBool::new(true));
     let result = runtime.poll(&run_id, Some(&shutdown), Duration::from_secs(10));
@@ -356,15 +324,10 @@ fn test_cli_runtime_shutdown_flag_cancels_poll() {
 }
 
 #[test]
-fn test_cli_runtime_cancel_kills_window_and_marks_cancelled() {
-    if !tmux_available() {
-        eprintln!("skipping cli_runtime cancel test: tmux not available");
-        return;
-    }
+fn test_cli_runtime_cancel_kills_process_and_marks_cancelled() {
+    let (_script, db_guard, runtime, run_id, _lock) = spawn_slow_script("test-cancel");
 
-    let (_script, db_guard, runtime, run_id) = spawn_slow_script("test-cancel");
-
-    // Fetch the run from DB to get tmux_window name.
+    // Fetch the run from DB to get subprocess_pid.
     let conn =
         conductor_core::db::open_database(db_guard.path()).expect("open test db for cancel test");
     let agent_mgr = conductor_core::agent::AgentManager::new(&conn);
@@ -374,14 +337,14 @@ fn test_cli_runtime_cancel_kills_window_and_marks_cancelled() {
         .expect("run must exist in DB");
 
     assert!(
-        run.tmux_window.is_some(),
-        "tmux_window must be set after spawn"
+        run.subprocess_pid.is_some(),
+        "subprocess_pid must be set after spawn"
     );
     assert!(runtime.is_alive(&run), "run must be alive before cancel");
 
     runtime.cancel(&run).expect("cancel must succeed");
 
-    // Window should be gone.
+    // Process should be gone.
     assert!(
         !runtime.is_alive(&run),
         "run must not be alive after cancel"
@@ -392,9 +355,9 @@ fn test_cli_runtime_cancel_kills_window_and_marks_cancelled() {
 }
 
 #[test]
-fn test_cli_runtime_cancel_with_no_tmux_window_marks_cancelled() {
-    let run_id = format!("cancel-no-tmux-{}", ulid::Ulid::new());
-    let db_guard = setup_test_db(&run_id);
+fn test_cli_runtime_cancel_with_no_pid_marks_cancelled() {
+    let run_id = format!("cancel-no-pid-{}", ulid::Ulid::new());
+    let (db_guard, _lock) = setup_test_db(&run_id);
 
     let conn =
         conductor_core::db::open_database(db_guard.path()).expect("open test db for cancel test");
@@ -406,14 +369,14 @@ fn test_cli_runtime_cancel_with_no_tmux_window_marks_cancelled() {
         .expect("run must exist in DB");
 
     assert!(
-        run.tmux_window.is_none(),
-        "tmux_window must be None for this test"
+        run.subprocess_pid.is_none(),
+        "subprocess_pid must be None for this test"
     );
 
     let runtime = make_runtime("/bin/echo", "response", None);
     runtime
         .cancel(&run)
-        .expect("cancel must succeed when tmux_window is None");
+        .expect("cancel must succeed when subprocess_pid is None");
 
     assert_run_cancelled(&db_guard, &run_id);
 }

--- a/conductor-tui/src/app/agent_execution.rs
+++ b/conductor-tui/src/app/agent_execution.rs
@@ -477,7 +477,7 @@ impl App {
         prompt: String,
         worktree_id: String,
         worktree_path: String,
-        worktree_slug: String,
+        _worktree_slug: String,
         resume_session_id: Option<String>,
         model: Option<String>,
     ) {
@@ -501,12 +501,7 @@ impl App {
             };
             let mgr = AgentManager::new(&conn);
 
-            let run = match mgr.create_run(
-                Some(&worktree_id),
-                &prompt,
-                Some(&worktree_slug),
-                model.as_deref(),
-            ) {
+            let run = match mgr.create_run(Some(&worktree_id), &prompt, model.as_deref()) {
                 Ok(r) => r,
                 Err(e) => {
                     let _ = tx.send(Action::AgentLaunchComplete {
@@ -653,7 +648,7 @@ impl App {
             };
             let mgr = AgentManager::new(&conn);
 
-            let run = match mgr.create_repo_run(&repo_id, &prompt, None, None) {
+            let run = match mgr.create_repo_run(&repo_id, &prompt, None) {
                 Ok(r) => r,
                 Err(e) => {
                     let _ = tx.send(Action::RepoAgentLaunched {

--- a/conductor-tui/src/app/tests/action_handler_tests.rs
+++ b/conductor-tui/src/app/tests/action_handler_tests.rs
@@ -461,7 +461,6 @@ fn show_confirm_quit_with_running_agents_includes_count() {
             duration_ms: None,
             started_at: "2024-01-01T00:00:00Z".into(),
             ended_at: None,
-            tmux_window: None,
             log_file: None,
             model: None,
             plan: None,

--- a/conductor-web/src/main.rs
+++ b/conductor-web/src/main.rs
@@ -820,7 +820,6 @@ mod tests {
             duration_ms: None,
             started_at: String::new(),
             ended_at: None,
-            tmux_window: None,
             log_file: None,
             model: None,
             plan: None,

--- a/conductor-web/src/routes/agents.rs
+++ b/conductor-web/src/routes/agents.rs
@@ -436,13 +436,12 @@ pub async fn start_agent(
             agent_mgr.create_child_run(
                 Some(&worktree_id),
                 &body.prompt,
-                None,
                 model.as_deref(),
                 parent_id,
                 None,
             )?
         } else {
-            agent_mgr.create_run(Some(&worktree_id), &body.prompt, None, model.as_deref())?
+            agent_mgr.create_run(Some(&worktree_id), &body.prompt, model.as_deref())?
         };
 
         (
@@ -1215,7 +1214,7 @@ pub async fn start_repo_agent(
                 .and_then(|run| run.claude_session_id)
         };
 
-        let run = agent_mgr.create_repo_run(&repo_id, &body.prompt, None, model.as_deref())?;
+        let run = agent_mgr.create_repo_run(&repo_id, &body.prompt, model.as_deref())?;
 
         (run, repo.local_path.clone(), resume_session_id, model)
     };
@@ -1587,7 +1586,7 @@ mod tests {
             "/tmp/ws/feat-test",
         );
         let run = AgentManager::new(&conn)
-            .create_run(Some("w1"), "test prompt", None, None)
+            .create_run(Some("w1"), "test prompt", None)
             .expect("create run");
         let run_id = run.id.clone();
         let state = AppState {
@@ -1600,7 +1599,7 @@ mod tests {
         };
 
         // wire_headless_drain returns Ok quickly (persists PID, spawns tasks).
-        super::wire_headless_drain(&state, &run_id, handle, None, None)
+        super::wire_headless_drain(&state, &run_id, handle, None)
             .await
             .expect("wire_headless_drain should return Ok");
 
@@ -1683,7 +1682,7 @@ mod tests {
             "/tmp/ws/feat-test",
         );
         let run = AgentManager::new(&real_conn)
-            .create_run(Some("w1"), "test prompt", None, None)
+            .create_run(Some("w1"), "test prompt", None)
             .expect("create run");
         let run_id = run.id.clone();
         drop(real_conn);
@@ -1704,7 +1703,7 @@ mod tests {
         };
 
         // wire_headless_drain should return Err quickly (PID-persist fails).
-        let result = super::wire_headless_drain(&state, &run_id, handle, None, None).await;
+        let result = super::wire_headless_drain(&state, &run_id, handle, None).await;
         assert!(
             result.is_err(),
             "wire_headless_drain should return Err when PID persist fails"
@@ -1788,7 +1787,7 @@ mod tests {
             "/tmp/ws/feat-test",
         );
         let run = AgentManager::new(&conn)
-            .create_run(Some("w1"), "test prompt", None, None)
+            .create_run(Some("w1"), "test prompt", None)
             .expect("create run");
         let run_id = run.id.clone();
         let state = AppState {
@@ -1800,7 +1799,7 @@ mod tests {
         };
 
         // wire_headless_drain returns Ok quickly (persists PID, spawns tasks).
-        super::wire_headless_drain(&state, &run_id, handle, None, None)
+        super::wire_headless_drain(&state, &run_id, handle, None)
             .await
             .expect("wire_headless_drain should return Ok");
 

--- a/conductor-web/src/routes/conversations.rs
+++ b/conductor-web/src/routes/conversations.rs
@@ -247,7 +247,7 @@ pub async fn send_message(
         // metadata updates to ConversationManager::send_message.
         // The original prompt (without attachment paths) is stored in the DB.
         let (run, resume_session_id) =
-            conv_mgr.send_message(&conversation_id, &prompt, None, model.as_deref())?;
+            conv_mgr.send_message(&conversation_id, &prompt, model.as_deref())?;
 
         (run, resume_session_id, working_dir, permission_mode, model)
     };
@@ -389,7 +389,7 @@ mod tests {
 
         let conv1 = mgr.create(ConversationScope::Repo, "r1").unwrap();
         let run1 = agent_mgr
-            .create_repo_run_for_conversation("r1", "q1", None, None, &conv1.id)
+            .create_repo_run_for_conversation("r1", "q1", None, &conv1.id)
             .unwrap();
         let fb1 = agent_mgr
             .request_feedback(&run1.id, "approve?", None)
@@ -397,7 +397,7 @@ mod tests {
 
         let conv2 = mgr.create(ConversationScope::Repo, "r1").unwrap();
         let run2 = agent_mgr
-            .create_repo_run_for_conversation("r1", "q2", None, None, &conv2.id)
+            .create_repo_run_for_conversation("r1", "q2", None, &conv2.id)
             .unwrap();
         let fb2 = agent_mgr
             .request_feedback(&run2.id, "approve?", None)

--- a/conductor-web/src/routes/workflows.rs
+++ b/conductor-web/src/routes/workflows.rs
@@ -715,7 +715,7 @@ pub async fn post_workflow_run(
             } else {
                 // Repo-only path: no worktree context
                 // TODO: add get_active_run_for_repo() guard when WorkflowManager supports it
-                (repo.local_path.clone(), repo.slug.clone(), None, None)
+                (repo.local_path.clone(), repo.slug.clone(), None, None, None)
             };
 
         // Validate workflow exists (def is reused by the spawn below — no double load)
@@ -1134,11 +1134,11 @@ pub async fn list_all_workflow_runs_handler(
                                 None,
                             )
                         }
-                        None => (None, None, None, None, None),
+                        None => (None, None, None, None, None, None),
                     }
                 }
             } else {
-                (None, None, None, None, None)
+                (None, None, None, None, None, None)
             };
             WorkflowRunResponse {
                 run,

--- a/conductor-web/src/routes/workflows.rs
+++ b/conductor-web/src/routes/workflows.rs
@@ -715,7 +715,7 @@ pub async fn post_workflow_run(
             } else {
                 // Repo-only path: no worktree context
                 // TODO: add get_active_run_for_repo() guard when WorkflowManager supports it
-                (repo.local_path.clone(), repo.slug.clone(), None, None, None)
+                (repo.local_path.clone(), repo.slug.clone(), None, None)
             };
 
         // Validate workflow exists (def is reused by the spawn below — no double load)
@@ -1134,11 +1134,11 @@ pub async fn list_all_workflow_runs_handler(
                                 None,
                             )
                         }
-                        None => (None, None, None, None, None, None),
+                        None => (None, None, None, None, None),
                     }
                 }
             } else {
-                (None, None, None, None, None, None)
+                (None, None, None, None, None)
             };
             WorkflowRunResponse {
                 run,
@@ -2804,7 +2804,7 @@ mod tests {
         use conductor_core::agent::AgentManager;
         let mgr = AgentManager::new(db);
         let run = mgr
-            .create_run(Some(worktree_id), prompt, None, None)
+            .create_run(Some(worktree_id), prompt, None)
             .expect("create agent run");
         mgr.update_run_log_file(&run.id, log_file)
             .expect("set log_file");

--- a/conductor-web/tests/api_tests.rs
+++ b/conductor-web/tests/api_tests.rs
@@ -699,8 +699,7 @@ async fn setup_repo_agent_run() -> (String, String, String) {
             )
             .unwrap();
         let mgr = AgentManager::new(conn);
-        mgr.create_repo_run(&repo.id, "test prompt", None, None)
-            .unwrap();
+        mgr.create_repo_run(&repo.id, "test prompt", None).unwrap();
     })
     .await;
 
@@ -807,8 +806,7 @@ fn seed_repo_and_worktree(conn: &Connection) {
 fn seed_agent_run(conn: &Connection) {
     seed_repo_and_worktree(conn);
     let mgr = AgentManager::new(conn);
-    mgr.create_run(Some("w1"), "test prompt", None, None)
-        .unwrap();
+    mgr.create_run(Some("w1"), "test prompt", None).unwrap();
 }
 
 /// Seed a worktree agent run with `subprocess_pid` set to a non-existent PID.
@@ -819,9 +817,7 @@ fn seed_agent_run(conn: &Connection) {
 fn seed_agent_run_with_subprocess_pid(conn: &Connection) {
     seed_repo_and_worktree(conn);
     let mgr = AgentManager::new(conn);
-    let run = mgr
-        .create_run(Some("w1"), "test prompt", None, None)
-        .unwrap();
+    let run = mgr.create_run(Some("w1"), "test prompt", None).unwrap();
     // Use a PID that definitely does not exist (far above any realistic pid_max).
     mgr.update_run_subprocess_pid(&run.id, 999_999_999).unwrap();
 }
@@ -842,7 +838,7 @@ fn seed_test_repo(conn: &Connection) -> conductor_core::repo::Repo {
 fn seed_repo_agent_run(conn: &Connection) {
     let repo = seed_test_repo(conn);
     AgentManager::new(conn)
-        .create_repo_run(&repo.id, "repo prompt", None, None)
+        .create_repo_run(&repo.id, "repo prompt", None)
         .unwrap();
 }
 
@@ -851,9 +847,7 @@ fn seed_repo_agent_run(conn: &Connection) {
 fn seed_repo_agent_run_with_subprocess_pid(conn: &Connection) {
     let repo = seed_test_repo(conn);
     let mgr = AgentManager::new(conn);
-    let run = mgr
-        .create_repo_run(&repo.id, "repo prompt", None, None)
-        .unwrap();
+    let run = mgr.create_repo_run(&repo.id, "repo prompt", None).unwrap();
     mgr.update_run_subprocess_pid(&run.id, 999_999_999).unwrap();
 }
 


### PR DESCRIPTION
…ocess (#2412)

Replace tmux-based agent execution in CliRuntime with direct headless subprocess management using std::process::Command, child.try_wait(), and PID-based liveness/cancel — eliminating the tmux runtime dependency for CLI agents.

Key changes:
- Rewrite CliRuntime::spawn() to use Command::spawn() with stdout redirected to the output file; store child PID via update_run_subprocess_pid()
- Rewrite CliRuntime::poll() to use child.try_wait() instead of polling an exit-code file; mark runs Failed on non-zero exit
- Rewrite CliRuntime::is_alive() to use pid_is_alive() instead of tmux window checks
- Rewrite CliRuntime::cancel() to kill+wait the Child handle directly, then fall back to cancel_subprocess() for runs without a live child reference
- Add migration 078: DROP COLUMN tmux_window from agent_runs
- Remove tmux_window field from AgentRun and all DB layer code
- Remove tmux_window parameter from all create_run/create_repo_run/ create_child_run/create_run_for_conversation/create_repo_run_for_conversation methods across conductor-core, conductor-cli, conductor-tui, conductor-web
- Rewrite integration tests to run without tmux; serialize CONDUCTOR_DB_PATH mutations via a mutex to prevent test races