### PR TITLE
chore: commit Cargo.lock for v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.2.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-core"
-version = "0.2.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-desktop"
-version = "0.2.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-tui"
-version = "0.2.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-web"
-version = "0.2.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
Cargo.lock had uncommitted changes after the v0.7.1 release merge. This commits them to keep the lockfile in sync.