### PR TITLE
fix(workflow): use prior_contexts markers for verdict detection in qualify-ticket-comment

### DIFF
--- a/.conductor/scripts/comment-ticket-assessment.sh
+++ b/.conductor/scripts/comment-ticket-assessment.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PRIOR_OUTPUT="${PRIOR_OUTPUT:-}"
+PRIOR_CONTEXTS="${PRIOR_CONTEXTS:-}"
+PRIOR_CONTENT="${PRIOR_CONTENT:-}"
 TICKET_URL="${TICKET_URL:-}"
 TICKET_SOURCE_ID="${TICKET_SOURCE_ID:-}"
 
@@ -27,33 +28,39 @@ emit_output() {
   printf '<<<CONDUCTOR_OUTPUT>>>\n%s\n<<<END_CONDUCTOR_OUTPUT>>>\n' "$output"
 }
 
-# Detect verdict — check SHOULD CLOSE before NOT READY before READY to avoid substring collisions
+# Detect verdict from markers in {{prior_contexts}} JSON array.
+# prior_contexts is an array of ContextEntry objects, each with a "markers" array.
+# We scan all entries for the verdict marker set by assess-ticket-readiness.
+has_marker() {
+  echo "$PRIOR_CONTEXTS" | jq -e --arg m "$1" '[.[].markers[]] | index($m) != null' > /dev/null 2>&1
+}
+
 tmp=$(mktemp)
 trap 'rm -f "$tmp"' EXIT
 
-if echo "$PRIOR_OUTPUT" | grep -q "SHOULD CLOSE"; then
+if has_marker "should_close"; then
   VERDICT="SHOULD_CLOSE"
   LABEL="pending-close"
   LABEL_COLOR="d93f0b"
   LABEL_DESC="Ticket is invalid, resolved, or no longer actionable"
   MARKERS='["should_close"]'
-  printf '## ⚠️ Pending Close\n\n%s\n' "$PRIOR_OUTPUT" > "$tmp"
-elif echo "$PRIOR_OUTPUT" | grep -q "NOT READY"; then
+  printf '## ⚠️ Pending Close\n\n%s\n' "$PRIOR_CONTENT" > "$tmp"
+elif has_marker "has_open_questions"; then
   VERDICT="NOT_READY"
   LABEL="needs-work"
   LABEL_COLOR="e4e669"
   LABEL_DESC="Ticket requires clarification before implementation"
   MARKERS='["has_open_questions"]'
-  printf '## ❓ Open Questions\n\nThe following questions or issues must be resolved before this ticket can be handed off to an autonomous agent:\n\n%s\n' "$PRIOR_OUTPUT" > "$tmp"
-elif echo "$PRIOR_OUTPUT" | grep -q "READY"; then
+  printf '## ❓ Open Questions\n\nThe following questions or issues must be resolved before this ticket can be handed off to an autonomous agent:\n\n%s\n' "$PRIOR_CONTENT" > "$tmp"
+elif has_marker "ticket_ready"; then
   VERDICT="READY"
   LABEL="qualified"
   LABEL_COLOR="0075ca"
   LABEL_DESC="Ticket is ready for autonomous implementation"
   MARKERS='["ticket_ready"]'
-  printf '## ✅ Ready for Implementation\n\n%s\n' "$PRIOR_OUTPUT" > "$tmp"
+  printf '## ✅ Ready for Implementation\n\n%s\n' "$PRIOR_CONTENT" > "$tmp"
 else
-  emit_output '[]' "Could not determine verdict from prior output — no SHOULD CLOSE, NOT READY, or READY found"
+  emit_output '[]' "Could not determine verdict — no should_close, has_open_questions, or ticket_ready marker found in prior_contexts: ${PRIOR_CONTEXTS}"
   exit 0
 fi
 

--- a/.conductor/workflows/qualify-ticket-comment.wf
+++ b/.conductor/workflows/qualify-ticket-comment.wf
@@ -16,7 +16,8 @@ workflow qualify-ticket-comment {
   script comment-ticket-assessment {
     run = ".conductor/scripts/comment-ticket-assessment.sh"
     env = {
-      PRIOR_OUTPUT     = "{{prior_context}}"
+      PRIOR_CONTEXTS   = "{{prior_contexts}}"
+      PRIOR_CONTENT    = "{{prior_context}}"
       TICKET_URL       = "{{ticket_url}}"
       TICKET_SOURCE_ID = "{{ticket_source_id}}"
     }


### PR DESCRIPTION
## Summary

The `comment-ticket-assessment` script was detecting the verdict by grepping free-form agent text, which failed in practice:

- `{{prior_result}}` — not a real conductor template variable
- `{{prior_output}}` — always `None` for `call` steps; `interpret_agent_output` only populates structured output when an explicit output schema is defined
- `{{prior_context}}` — compact summary that doesn't consistently include the verdict keyword (e.g. `"Confirmed false positive…"` contains no `"SHOULD CLOSE"`)

## Fix

Use `{{prior_contexts}}`, a JSON array of `ContextEntry` objects that includes the `markers` field from every completed step. The `has_marker()` helper scans all entries with `jq`, so detection is reliable regardless of agent phrasing.

- **Workflow**: passes `PRIOR_CONTEXTS={{prior_contexts}}` (for detection) and `PRIOR_CONTENT={{prior_context}}` (for comment body)
- **Script**: replaces grep-based text matching with `jq` marker scan across all context entries

No agent prompt changes needed — `assess-ticket-readiness` already emits `ticket_ready`, `has_open_questions`, or `should_close` markers correctly.

## Test plan

- [x] Verified end-to-end with run `01KPRJ73DTG8E7QEFQYM6J0Z98` — ticket #2423 was correctly labeled after this fix
- [ ] Run `qualify-ticket-comment` against a ticket that should close and verify `pending-close` label is applied