### PR TITLE
fix(workflow): remove iteration filter from predecessor_completed to fix do-while loop (#2448)

### DIFF
--- a/conductor-core/src/workflow/executors/call_workflow.rs
+++ b/conductor-core/src/workflow/executors/call_workflow.rs
@@ -50,7 +50,7 @@ pub fn execute_call_workflow(
     if pos > 0
         && !state
             .wf_mgr
-            .predecessor_completed(&state.workflow_run_id, pos, iteration as i64)?
+            .predecessor_completed(&state.workflow_run_id, pos)?
     {
         tracing::warn!(
             "call_workflow '{}': predecessor at position {} is not completed; \

--- a/conductor-core/src/workflow/manager/steps.rs
+++ b/conductor-core/src/workflow/manager/steps.rs
@@ -298,21 +298,19 @@ impl<'a> WorkflowManager<'a> {
         &self,
         workflow_run_id: &str,
         position: i64,
-        iteration: i64,
     ) -> Result<bool> {
         if position == 0 {
             return Ok(true);
         }
         let mut stmt = self.conn.prepare(
             "SELECT 1 FROM workflow_run_steps \
-             WHERE workflow_run_id = :wrid AND position = :pos AND iteration = :iter \
+             WHERE workflow_run_id = :wrid AND position = :pos \
              AND status = 'completed' LIMIT 1",
         )?;
         let exists = stmt
             .exists(named_params![
                 ":wrid": workflow_run_id,
                 ":pos": position - 1,
-                ":iter": iteration,
             ])
             .map_err(ConductorError::Database)?;
         Ok(exists)

--- a/conductor-core/src/workflow/manager/steps.rs
+++ b/conductor-core/src/workflow/manager/steps.rs
@@ -294,11 +294,7 @@ impl<'a> WorkflowManager<'a> {
 
     /// Returns true if the predecessor step (position - 1) has status 'completed'.
     /// Always returns true when position == 0 (no predecessor).
-    pub fn predecessor_completed(
-        &self,
-        workflow_run_id: &str,
-        position: i64,
-    ) -> Result<bool> {
+    pub fn predecessor_completed(&self, workflow_run_id: &str, position: i64) -> Result<bool> {
         if position == 0 {
             return Ok(true);
         }

--- a/conductor-core/src/workflow/tests/manager.rs
+++ b/conductor-core/src/workflow/tests/manager.rs
@@ -4314,31 +4314,35 @@ fn test_predecessor_completed_false_when_no_prev_row() {
 
 #[test]
 fn test_regression_2448_predecessor_completed_cross_iteration() {
-    // Regression: predecessor_completed must find a step stored in iteration 0
-    // when checking from iteration 1. position is globally unique per run so
-    // the iteration filter was incorrect and caused sub-workflow steps to be
-    // silently skipped in do-while loop iterations > 0.
+    // Regression: predecessor_completed must find steps stored in iteration 0
+    // when the next step is at a higher position that belongs to iteration 1.
+    // Before the fix, the query included `AND iteration = :iter` which caused
+    // position 5 (iteration=0) to be invisible when checking from position 6
+    // (iteration=1), silently skipping every sub-workflow step in the loop.
     let conn = setup_db();
     let (mgr, _parent, run) = make_workflow_run(&conn);
-    // Insert step at position=0, iteration=0 and mark it completed.
-    let step_id = mgr
-        .insert_step(&run.id, "step-a", "actor", false, 0, 0)
+    // Simulate do-while iteration 0: insert and complete steps at positions 0–5
+    // all with iteration=0.
+    for pos in 0..6i64 {
+        let step_id = mgr
+            .insert_step(&run.id, "step-a", "actor", false, pos, 0)
+            .unwrap();
+        mgr.update_step_status(
+            &step_id,
+            WorkflowStepStatus::Completed,
+            None,
+            None,
+            None,
+            None,
+            Some(0),
+        )
         .unwrap();
-    mgr.update_step_status(
-        &step_id,
-        WorkflowStepStatus::Completed,
-        None,
-        None,
-        None,
-        None,
-        Some(0),
-    )
-    .unwrap();
-    // Cross-iteration check: position 1 predecessor (pos 0) was stored in
-    // iteration 0 — must still return true regardless of current iteration.
+    }
+    // Iteration 1 starts at position 6. Guard A checks whether position 5
+    // (stored with iteration=0) is completed. Must return true.
     assert!(
-        mgr.predecessor_completed(&run.id, 1).unwrap(),
-        "predecessor_completed must find a completed step across iteration boundaries"
+        mgr.predecessor_completed(&run.id, 6).unwrap(),
+        "predecessor_completed must find a step from iteration 0 when checking position 6 in iteration 1"
     );
 }
 

--- a/conductor-core/src/workflow/tests/manager.rs
+++ b/conductor-core/src/workflow/tests/manager.rs
@@ -4260,7 +4260,7 @@ fn test_predecessor_completed_pos_zero_always_true() {
     let conn = setup_db();
     let (mgr, _parent, run) = make_workflow_run(&conn);
     // No rows at all — pos 0 should always return true.
-    assert!(mgr.predecessor_completed(&run.id, 0, 0).unwrap());
+    assert!(mgr.predecessor_completed(&run.id, 0).unwrap());
 }
 
 #[test]
@@ -4281,7 +4281,7 @@ fn test_predecessor_completed_true_when_prev_completed() {
     )
     .unwrap();
     // Predecessor at pos 0 is completed → pos 1 check should return true.
-    assert!(mgr.predecessor_completed(&run.id, 1, 0).unwrap());
+    assert!(mgr.predecessor_completed(&run.id, 1).unwrap());
 }
 
 #[test]
@@ -4301,7 +4301,7 @@ fn test_predecessor_completed_false_when_prev_running() {
         None,
     )
     .unwrap();
-    assert!(!mgr.predecessor_completed(&run.id, 1, 0).unwrap());
+    assert!(!mgr.predecessor_completed(&run.id, 1).unwrap());
 }
 
 #[test]
@@ -4309,7 +4309,37 @@ fn test_predecessor_completed_false_when_no_prev_row() {
     let conn = setup_db();
     let (mgr, _parent, run) = make_workflow_run(&conn);
     // No step at position 0, iteration 0 → pos 1 predecessor check returns false.
-    assert!(!mgr.predecessor_completed(&run.id, 1, 0).unwrap());
+    assert!(!mgr.predecessor_completed(&run.id, 1).unwrap());
+}
+
+#[test]
+fn test_regression_2448_predecessor_completed_cross_iteration() {
+    // Regression: predecessor_completed must find a step stored in iteration 0
+    // when checking from iteration 1. position is globally unique per run so
+    // the iteration filter was incorrect and caused sub-workflow steps to be
+    // silently skipped in do-while loop iterations > 0.
+    let conn = setup_db();
+    let (mgr, _parent, run) = make_workflow_run(&conn);
+    // Insert step at position=0, iteration=0 and mark it completed.
+    let step_id = mgr
+        .insert_step(&run.id, "step-a", "actor", false, 0, 0)
+        .unwrap();
+    mgr.update_step_status(
+        &step_id,
+        WorkflowStepStatus::Completed,
+        None,
+        None,
+        None,
+        None,
+        Some(0),
+    )
+    .unwrap();
+    // Cross-iteration check: position 1 predecessor (pos 0) was stored in
+    // iteration 0 — must still return true regardless of current iteration.
+    assert!(
+        mgr.predecessor_completed(&run.id, 1).unwrap(),
+        "predecessor_completed must find a completed step across iteration boundaries"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -4449,7 +4479,7 @@ fn test_active_step_exists_true_for_completed() {
 /// step (implement, pos 1) was still `running`, which previously caused the
 /// engine to advance and insert a duplicate `workflow:lint-fix` row at pos 2.
 ///
-/// Guard A: predecessor_completed(run_id, 2, 0) must return false while pos 1
+/// Guard A: predecessor_completed(run_id, 2) must return false while pos 1
 ///          is still running → the engine should bail out before inserting.
 /// Guard B: if a premature row was somehow inserted, active_step_exists must
 ///          return true → the engine bails out before inserting a second row.
@@ -4475,7 +4505,7 @@ fn test_regression_2406_guards_prevent_duplicate_call_workflow_step() {
 
     // Guard A: predecessor at pos 1 is running → pos 2 predecessor check is false.
     assert!(
-        !mgr.predecessor_completed(&run.id, 2, 0).unwrap(),
+        !mgr.predecessor_completed(&run.id, 2).unwrap(),
         "Guard A: predecessor_completed must be false while implement is running"
     );
 
@@ -4515,7 +4545,7 @@ fn test_regression_2406_guards_prevent_duplicate_call_workflow_step() {
     )
     .unwrap();
     assert!(
-        mgr.predecessor_completed(&run.id, 2, 0).unwrap(),
+        mgr.predecessor_completed(&run.id, 2).unwrap(),
         "predecessor_completed must be true once implement is completed"
     );
     assert!(


### PR DESCRIPTION
Guard A in execute_call_workflow checked (position, iteration) to find a predecessor, but state.position is monotonically increasing across do-while iterations so a predecessor from iteration N is never found when checking from iteration N+1. Dropping the redundant iteration filter makes the lookup correct across loop boundaries.