### PR TITLE
fix(ci): gate schema diagram jobs on migration file changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       web: ${{ steps.filter.outputs.web }}
       workflows: ${{ steps.filter.outputs.workflows }}
       desktop: ${{ steps.filter.outputs.desktop }}
+      migrations: ${{ steps.filter.outputs.migrations }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -50,6 +51,8 @@ jobs:
               - 'conductor-desktop/**'
             workflows:
               - '.conductor/**'
+            migrations:
+              - 'conductor-core/src/db/migrations/**'
 
   fmt:
     name: Format
@@ -132,6 +135,8 @@ jobs:
 
   schema-diagram-count:
     name: Schema Diagram Count
+    needs: [changes]
+    if: needs.changes.outputs.migrations == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -147,6 +152,8 @@ jobs:
 
   schema-diagram-sync:
     name: Schema Diagram Sync
+    needs: [changes]
+    if: needs.changes.outputs.migrations == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds a `migrations` path filter to the `changes` job watching `conductor-core/src/db/migrations/**`
- Gates `Schema Diagram Count` and `Schema Diagram Sync` on `migrations == 'true'` so both jobs are skipped entirely on PRs that don't touch migration files

**Why:** Both schema diagram jobs ran unconditionally on every PR, causing spurious CI failures on doc-only or non-schema PRs (e.g. #2455). The diagram only needs to be in sync when a migration is actually added.

## Test plan
- [ ] Verify this PR itself passes CI (no migration files changed → both schema jobs skipped)
- [ ] Verify a PR that adds a `.sql` migration still triggers both schema jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)