### PR TITLE
chore: bump workspace version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-desktop"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-tui"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-web"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4517,7 +4517,7 @@ dependencies = [
 
 [[package]]
 name = "runkon-flow"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["conductor-core", "conductor-cli", "conductor-tui", "conductor-web", 
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/devinrosen/conductor-ai"


### PR DESCRIPTION
## Summary

- Bumps `[workspace.package] version` from `0.8.0` → `0.9.0` in the root `Cargo.toml`
- All member crates inherit via `version.workspace = true` so no other files needed changing

## Test plan

- [x] `cargo build --bin conductor` passes at `0.9.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)