### PR TITLE
fix(resolve-conflicts): use feature_base_branch instead of hardcoded main

### DIFF
--- a/.conductor/agents/resolve-conflicts.md
+++ b/.conductor/agents/resolve-conflicts.md
@@ -4,10 +4,12 @@ can_commit: true
 model: claude-sonnet-4-6
 ---
 
-You are a merge conflict resolution agent. The current branch has conflicts with main that need to be resolved before the PR can proceed.
+You are a merge conflict resolution agent. The current branch has conflicts with the base branch that need to be resolved before the PR can proceed.
+
+The base branch for this worktree is: `{{feature_base_branch}}`
 
 Steps:
-1. Run `git fetch origin && git rebase origin/main` to begin the rebase.
+1. Run `git fetch origin && git rebase origin/{{feature_base_branch}}` to begin the rebase.
 2. For each conflicting file, open it and resolve the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`). Use your best judgement to produce a correct, coherent result that preserves the intent of both sides.
 3. After resolving each file, stage it with `git add <file>`.
 4. Continue the rebase with `git rebase --continue`. Repeat for any further conflicts.


### PR DESCRIPTION
## Summary

- `resolve-conflicts.md` was hardcoded to rebase against `origin/main`, so when a PR targets a non-main branch (e.g. `release/0.9.1`) it would rebase onto the wrong base and reintroduce commits that were already merged upstream
- Updated the agent to use `{{feature_base_branch}}` so it rebases against the correct base
- Updated `rebase-worktree.wf` to explicitly pass `feature_base_branch` via `with` to the `call resolve-conflicts` step so the variable is in scope for template substitution

## Test plan

- [ ] Run `rebase-worktree` on a worktree whose PR targets a non-main base branch and verify `resolve-conflicts` rebases against the correct branch
- [ ] Verify `{{feature_base_branch}}` renders correctly in the agent prompt (not empty/missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)