### PR TITLE
fix(plan-agent): always fetch full GitHub issue including comments

### DIFF
--- a/.conductor/agents/plan.md
+++ b/.conductor/agents/plan.md
@@ -10,7 +10,13 @@ The ticket is: {{ticket_id}}
 Prior step context: {{prior_context}}
 
 Steps:
-1. Read the linked ticket (check `gh issue view` or the ticket metadata provided in the worktree context).
+1. Fetch the full ticket content, including any comments or discussion:
+   - If `{{ticket_source_type}}` is `github`:
+     ```
+     gh issue view {{ticket_source_id}} --json title,body,labels,milestone,assignees,comments,state
+     ```
+   - Otherwise, use the ticket body and prior context already provided (`{{prior_context}}`).
+   Incorporate any comments that add requirements, constraints, or resolution decisions into your understanding of the ticket.
 2. Review the relevant areas of the codebase that will be affected.
 3. Produce a structured plan that includes:
    - A summary of what needs to be built or changed


### PR DESCRIPTION
## Summary

- The `plan` agent previously relied on `{{prior_context}}` from `qualify-ticket` to see issue comments
- When running `ticket-to-pr` with `qualify=false` (the common path for pre-qualified tickets), comments posted by humans or resolution decisions written after ticket creation were invisible to the plan agent
- Now the plan agent always fetches the full issue via `gh issue view --json ...,comments,...` for GitHub tickets, and falls back to `prior_context` for other source types (Jira, Vantage, Linear)

## Test plan

- [ ] Run `ticket-to-pr` with `qualify=false` on a GitHub ticket that has a comment — verify the plan agent's output reflects the comment content
- [ ] Run against a non-GitHub ticket — verify no `gh` call is attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)