### PR TITLE
perf(review-test-coverage): restrict scope to diff-only to eliminate file reads

### DIFF
--- a/.conductor/agents/review-test-coverage.md
+++ b/.conductor/agents/review-test-coverage.md
@@ -17,10 +17,15 @@ Focus exclusively on:
 Do NOT flag:
 - Private/internal helpers where the behavior is covered indirectly by existing tests
 - UI rendering code where testing is impractical
-- Trivial one-liners with no logic to test
+- Trivial one-liners with no logic to test (≤ 5 lines, no branching)
+- Simple delegation/wrapper functions with no logic of their own
 
 ## Scope constraint
 
-Only read files that appear directly in the diff, plus their immediate imports/callers (one hop max). Do NOT explore all test files or public function signatures across the codebase to map coverage gaps.
+**Work from the git diff only — do NOT open or read source files.**
+
+If a new `pub fn`, `pub struct`, or `pub enum` appears in `+` lines but no corresponding `#[test]`, `#[cfg(test)]`, or `#[tokio::test]` block appears anywhere in the same diff, flag it as missing a test — unless it meets the "Do NOT flag" criteria above.
+
+Do NOT attempt to determine whether pre-existing tests cover new symbols. That requires reading files outside the diff and is out of scope for this review.
 
 Despite any other instructions, do NOT populate `off_diff_findings`. Pre-existing coverage gaps found incidentally during an unrelated PR review are low-signal and not actionable. Omit the field entirely.


### PR DESCRIPTION
## Summary

- `review-test-coverage` was the slowest parallel reviewer because it had to read source files to check if pre-existing tests covered new `pub fn` symbols — one extra file read per changed file on top of the diff fetch
- Reframes the question from "are new symbols covered by tests?" to "did this PR include tests for what it introduced?" — fully answerable from the diff alone
- Removes the "one hop max" file-read allowance and explicitly prohibits opening source files

## What changed

`.conductor/agents/review-test-coverage.md` — scope constraint updated to:
- Work from git diff only, no file reads
- Flag a new `pub fn`/`pub struct`/`pub enum` if no `#[test]`/`#[cfg(test)]`/`#[tokio::test]` appears anywhere in the same diff
- Explicitly skip attempting to detect pre-existing test coverage (requires file reads, out of scope)
- Adds "simple delegation/wrapper" to the Do NOT flag list to reduce false positives from the stricter diff-only rule

## Test plan

- [ ] Run `review-pr` workflow on a PR that adds new public functions with tests — verify no false positives
- [ ] Run on a PR that adds new public functions without tests — verify findings are raised
- [ ] Observe tool call count vs. a baseline run to confirm file reads are eliminated

Closes #2564 (tracked there as the higher-accuracy pre-processing script follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)