### PR TITLE
perf(review-test-coverage): prohibit cargo build/test commands in scope constraint

### DIFF
--- a/.conductor/agents/review-test-coverage.md
+++ b/.conductor/agents/review-test-coverage.md
@@ -22,7 +22,7 @@ Do NOT flag:
 
 ## Scope constraint
 
-**Work from the git diff only — do NOT open or read source files.**
+**Work from the git diff only — do NOT open or read source files, and do NOT run any shell commands** (`cargo build`, `cargo test`, `grep`, `find`, or anything else). The diff is the only input you need.
 
 If a new `pub fn`, `pub struct`, or `pub enum` appears in `+` lines but no corresponding `#[test]`, `#[cfg(test)]`, or `#[tokio::test]` block appears anywhere in the same diff, flag it as missing a test — unless it meets the "Do NOT flag" criteria above.
 


### PR DESCRIPTION
## Summary

- Analysis of run `01KQ0BW6SS6QCJW6VM9SYENFFE` revealed the agent was making **7 `cargo build`/`cargo test` invocations** per review run despite the diff-only scope constraint added in #2565
- The agent interpreted "check test coverage" as "run the tests empirically" — a multi-second operation each time — rather than static diff analysis
- This PR extends the scope constraint to explicitly prohibit all shell commands

## What changed

`.conductor/agents/review-test-coverage.md` — one line added to the scope constraint:

> do NOT run any shell commands (`cargo build`, `cargo test`, `grep`, `find`, or anything else). The diff is the only input you need.

## Root cause

The prior constraint said "do NOT open or read source files" but left shell execution unrestricted. The agent's tool call sequence from the run:
```
[11] Bash: cargo build -p conductor-core --lib
[12] Bash: cargo build --lib conductor-core
[13] Bash: cargo test -p conductor-cli --lib
[14] Bash: cargo test -p conductor-cli mcp::tools::runs --lib
[15] Bash: cargo test -p conductor-web
[18] Bash: cargo test -p conductor-core
[21] Bash: cargo test -p conductor-core
```

## Test plan

- [ ] Run `review-pr` on a PR with new public functions — confirm no `cargo` tool calls in the step log
- [ ] Verify the agent still correctly flags missing tests from diff-only analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)