### PR TITLE
fix(qualify-ticket): use worktree base branch instead of hardcoded main

### DIFF
--- a/.conductor/agents/fetch-ticket-context.md
+++ b/.conductor/agents/fetch-ticket-context.md
@@ -38,7 +38,7 @@ gh pr list --search "closes:#{{ticket_source_id}}" --json number,baseRefName,hea
 ```
 
 - If one or more PRs are found, use the `baseRefName` of the first result as `base_branch`.
-- If no PRs are found, default `base_branch` to `main`.
+- If no PRs are found, use `{{feature_base_branch}}` as `base_branch` (the worktree's configured target branch).
 
 ## Step 4 — Scan the codebase
 
@@ -61,7 +61,7 @@ If the fetch fails, fall back to `git log --oneline -20`.
 Emit `<<<CONDUCTOR_OUTPUT>>>` with a `context` string containing:
 - Full ticket title and body
 - Summary of all linked/blocking issues and their states
-- The resolved `base_branch` (from linked PR or defaulted to `main`)
+- The resolved `base_branch` (from linked PR, or the worktree's configured target branch)
 - List of codebase symbols/paths referenced in the ticket and whether each was found
 - Any recent commits that appear related
 - Any comments from the ticket thread that add requirements or constraints


### PR DESCRIPTION
## Summary

- `fetch-ticket-context` now falls back to `{{feature_base_branch}}` when no linked PR exists, instead of hardcoding `main`
- `{{feature_base_branch}}` is already injected by the workflow engine from the worktree's configured `base_branch` (or repo default if unset), so this works correctly for worktrees targeting release branches, feature stacks, etc.
- The Step 6 output description is updated to reflect the change

## Why

Tickets linked to worktrees that target non-`main` branches (e.g. `release/1.x`, a parent feature branch) were having their git history scoped to `main`, making the context and readiness assessment incorrect.

## Test plan

- [ ] Run `qualify-ticket` against a worktree whose `base_branch` is set to something other than `main` — confirm the resolved `base_branch` in the step output matches the worktree's target, not `main`
- [ ] Run against a worktree with a linked PR — confirm the PR's `baseRefName` still takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)