### PR TITLE
feat(submit-review): include blocking findings count in section heading

### DIFF
--- a/.conductor/scripts/submit-review.sh
+++ b/.conductor/scripts/submit-review.sh
@@ -180,7 +180,7 @@ REVIEW_BODY="${HEADING}
 # Append blocking findings section if any
 if [ "${HAS_BLOCKING_CHECK}" = "true" ]; then
   BLOCKING_SECTION=$(echo "${PRIOR_OUTPUT}" | jq -r '
-    "\n### Blocking findings\n",
+    "\n### Blocking findings (\(.blocking_findings // [] | length))\n",
     (
       [(.blocking_findings // []) | group_by(.reviewer)[] |
         . as $group |


### PR DESCRIPTION
## Summary
- Changes `### Blocking findings` to `### Blocking findings (N)` in the PR review body, where N is the total count of blocking findings.

## Test plan
- [ ] Run a review workflow on a PR with blocking findings and verify the heading shows the correct count.
- [ ] Verify the heading still renders correctly when there are no blocking findings (section is omitted anyway when count is 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)