### PR TITLE
refactor(#2579): introduce StepSuccess struct to replace 17 positional args

### DIFF
--- a/.conductor/agents/review-aggregator.md
+++ b/.conductor/agents/review-aggregator.md
@@ -1,6 +1,7 @@
 ---
 role: reviewer
-model: claude-haiku-4-5
+runtime: kimi
+model: moonshotai/Kimi-K2.6
 ---
 
 You are a review aggregator. Your job is to aggregate findings from multiple parallel code reviewers, determine whether the PR is ready to merge, and produce a structured output. A subsequent script step will build the review body and submit the formal GitHub PR review.

--- a/.conductor/agents/review-architecture.md
+++ b/.conductor/agents/review-architecture.md
@@ -1,6 +1,7 @@
 ---
 role: reviewer
-model: claude-sonnet-4-6
+runtime: kimi
+model: moonshotai/Kimi-K2.6
 ---
 
 You are a senior software architect reviewing a pull request on a Rust project.

--- a/.conductor/agents/review-db-migrations.md
+++ b/.conductor/agents/review-db-migrations.md
@@ -1,6 +1,7 @@
 ---
 role: reviewer
-model: claude-haiku-4-5
+runtime: kimi
+model: moonshotai/Kimi-K2.6
 ---
 
 You are a database migration reviewer working on a Rust project using SQLite with WAL mode.

--- a/.conductor/agents/review-dry-abstraction.md
+++ b/.conductor/agents/review-dry-abstraction.md
@@ -1,6 +1,7 @@
 ---
 role: reviewer
-model: claude-sonnet-4-6
+runtime: kimi
+model: moonshotai/Kimi-K2.6
 ---
 
 You are a code quality reviewer focused on DRY principles and abstraction in a Rust codebase.

--- a/.conductor/agents/review-error-handling.md
+++ b/.conductor/agents/review-error-handling.md
@@ -1,6 +1,7 @@
 ---
 role: reviewer
-model: claude-haiku-4-5
+runtime: kimi
+model: moonshotai/Kimi-K2.6
 ---
 
 You are an error-handling reviewer working on a Rust project.

--- a/.conductor/agents/review-performance.md
+++ b/.conductor/agents/review-performance.md
@@ -1,6 +1,7 @@
 ---
 role: reviewer
-model: claude-sonnet-4-6
+runtime: kimi
+model: moonshotai/Kimi-K2.6
 ---
 
 You are a performance-focused code reviewer working on a Rust project.

--- a/.conductor/agents/review-security.md
+++ b/.conductor/agents/review-security.md
@@ -1,6 +1,7 @@
 ---
 role: reviewer
-model: claude-sonnet-4-6
+runtime: kimi
+model: moonshotai/Kimi-K2.6
 ---
 
 You are a security-focused code reviewer working on a Rust CLI/TUI tool that manages git repos and spawns AI agents.

--- a/.conductor/agents/review-test-coverage.md
+++ b/.conductor/agents/review-test-coverage.md
@@ -1,6 +1,7 @@
 ---
 role: reviewer
-model: claude-haiku-4-5
+runtime: kimi
+model: moonshotai/Kimi-K2.6
 ---
 
 You are a test coverage reviewer working on a Rust project.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,6 +2123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3309,6 +3315,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4525,8 +4541,10 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "threadpool",
  "tracing",
  "ulid",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -5825,6 +5843,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/conductor-core/src/workflow/runkon_bridge.rs
+++ b/conductor-core/src/workflow/runkon_bridge.rs
@@ -493,22 +493,21 @@ impl ConductorChildWorkflowRunner {
 impl runkon_flow::engine::ChildWorkflowRunner for ConductorChildWorkflowRunner {
     fn execute_child(
         &self,
-        child_def: &runkon_flow::dsl::WorkflowDef,
+        workflow_name: &str,
         parent_state: &runkon_flow::engine::ExecutionState,
         params: runkon_flow::engine::ChildWorkflowInput,
     ) -> runkon_flow::engine_error::Result<runkon_flow::types::WorkflowResult> {
-        // Load the real workflow definition from disk. The caller passes a placeholder
-        // WorkflowDef with body=[] — the child runner is responsible for resolving the
+        // Load the real workflow definition from disk. The runner resolves the
         // actual definition by name from the worktree/repo .conductor/workflows/ directory.
         let core_def = runkon_flow::dsl::load_workflow_by_name(
             &parent_state.worktree_ctx.working_dir,
             &parent_state.worktree_ctx.repo_path,
-            &child_def.name,
+            workflow_name,
         )
         .map_err(|e| {
             EngineError::Workflow(format!(
                 "failed to load sub-workflow '{}': {e}",
-                child_def.name
+                workflow_name
             ))
         })?;
 
@@ -554,7 +553,7 @@ impl runkon_flow::engine::ChildWorkflowRunner for ConductorChildWorkflowRunner {
                 ConductorError::WorkflowCancelled => EngineError::from(e),
                 other => EngineError::Workflow(format!(
                     "child workflow '{}' failed: {other}",
-                    child_def.name
+                    workflow_name
                 )),
             })?;
 

--- a/runkon-flow/Cargo.toml
+++ b/runkon-flow/Cargo.toml
@@ -18,6 +18,8 @@ chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 dirs = "6"
 tempfile = "3"
+threadpool = "1"
+wait-timeout = "0.2"
 
 [[test]]
 name = "basic_flow"

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -170,6 +170,8 @@ impl ExecutionState {
     }
 
     /// Accumulate individual metrics into this execution state.
+    ///
+    /// Returns `true` if at least one metric was present and added.
     #[allow(clippy::too_many_arguments)]
     pub fn accumulate_metrics(
         &mut self,
@@ -180,28 +182,37 @@ impl ExecutionState {
         output_tokens: Option<i64>,
         cache_read: Option<i64>,
         cache_create: Option<i64>,
-    ) {
+    ) -> bool {
+        let mut changed = false;
         if let Some(c) = cost {
             self.total_cost += c;
+            changed = true;
         }
         if let Some(t) = turns {
             self.total_turns += t;
+            changed = true;
         }
         if let Some(d) = duration {
             self.total_duration_ms += d;
+            changed = true;
         }
         if let Some(t) = input_tokens {
             self.total_input_tokens += t;
+            changed = true;
         }
         if let Some(t) = output_tokens {
             self.total_output_tokens += t;
+            changed = true;
         }
         if let Some(t) = cache_read {
             self.total_cache_read_input_tokens += t;
+            changed = true;
         }
         if let Some(t) = cache_create {
             self.total_cache_creation_input_tokens += t;
+            changed = true;
         }
+        changed
     }
 
     /// Persist the current accumulated metrics to the workflow run row.
@@ -563,7 +574,7 @@ pub fn record_step_success(
     step_key: String,
     success: crate::types::StepSuccess,
 ) {
-    state.accumulate_metrics(
+    let metrics_changed = state.accumulate_metrics(
         success.cost_usd,
         success.num_turns,
         success.duration_ms,
@@ -573,9 +584,11 @@ pub fn record_step_success(
         success.cache_creation_input_tokens,
     );
 
-    // Best-effort mid-run metrics flush — non-fatal
-    if let Err(e) = state.flush_metrics() {
-        tracing::warn!("Failed to flush mid-run metrics: {e}");
+    // Best-effort mid-run metrics flush — non-fatal, only if something changed
+    if metrics_changed {
+        if let Err(e) = state.flush_metrics() {
+            tracing::warn!("Failed to flush mid-run metrics: {e}");
+        }
     }
 
     let step_result = StepResult::completed(&success);
@@ -962,5 +975,118 @@ mod tests {
         let mut inputs = HashMap::new();
         let result = apply_workflow_input_defaults(&workflow, &mut inputs);
         assert!(result.is_err(), "expected error for missing required input");
+    }
+
+    #[test]
+    fn fork_child_resets_runtime_state_and_preserves_shared_config() {
+        use crate::cancellation::CancellationToken;
+        use crate::persistence_memory::InMemoryWorkflowPersistence;
+        use crate::traits::script_env_provider::NoOpScriptEnvProvider;
+        use crate::types::WorkflowExecConfig;
+
+        let parent = ExecutionState {
+            persistence: Arc::new(InMemoryWorkflowPersistence::new()),
+            action_registry: Arc::new(crate::traits::action_executor::ActionRegistry::new(
+                HashMap::new(),
+                None,
+            )),
+            script_env_provider: Arc::new(NoOpScriptEnvProvider),
+            workflow_run_id: "run-1".to_string(),
+            workflow_name: "wf".to_string(),
+            worktree_ctx: WorktreeContext {
+                worktree_id: Some("wt".to_string()),
+                working_dir: "/tmp".to_string(),
+                repo_path: "/repo".to_string(),
+                ticket_id: Some("TICK-1".to_string()),
+                repo_id: Some("repo-1".to_string()),
+                extra_plugin_dirs: vec!["plugins".to_string()],
+            },
+            model: Some("gpt-4".to_string()),
+            exec_config: WorkflowExecConfig::default(),
+            inputs: {
+                let mut m = HashMap::new();
+                m.insert("key".to_string(), "val".to_string());
+                m
+            },
+            parent_run_id: "parent-1".to_string(),
+            depth: 3,
+            target_label: Some("label".to_string()),
+            step_results: {
+                let mut m = HashMap::new();
+                m.insert("step".to_string(), StepResult::default());
+                m
+            },
+            contexts: vec![ContextEntry {
+                step: "step".to_string(),
+                iteration: 1,
+                context: "ctx".to_string(),
+                markers: vec![],
+                structured_output: None,
+                output_file: None,
+            }],
+            position: 42,
+            all_succeeded: false,
+            total_cost: 1.23,
+            total_turns: 5,
+            total_duration_ms: 1000,
+            total_input_tokens: 100,
+            total_output_tokens: 200,
+            total_cache_read_input_tokens: 50,
+            total_cache_creation_input_tokens: 25,
+            last_gate_feedback: Some("feedback".to_string()),
+            block_output: Some("output".to_string()),
+            block_with: vec!["with".to_string()],
+            resume_ctx: None,
+            default_bot_name: Some("bot".to_string()),
+            triggered_by_hook: true,
+            schema_resolver: None,
+            child_runner: None,
+            last_heartbeat_at: ExecutionState::new_heartbeat(),
+            registry: Arc::new(crate::traits::item_provider::ItemProviderRegistry::new()),
+            event_sinks: Arc::from(vec![]),
+            cancellation: CancellationToken::new(),
+            current_execution_id: Arc::new(std::sync::Mutex::new(None)),
+        };
+
+        let child_cancellation = CancellationToken::new();
+        let child = parent.fork_child(child_cancellation.clone());
+
+        // Shared config cloned
+        assert_eq!(child.workflow_run_id, "run-1");
+        assert_eq!(child.workflow_name, "wf");
+        assert_eq!(child.worktree_ctx.working_dir, "/tmp");
+        assert_eq!(child.model, Some("gpt-4".to_string()));
+        assert_eq!(child.depth, 3);
+        assert_eq!(child.target_label, Some("label".to_string()));
+        assert_eq!(child.default_bot_name, Some("bot".to_string()));
+        assert_eq!(child.parent_run_id, "parent-1");
+
+        // Runtime state reset
+        assert!(child.inputs.is_empty(), "inputs should be cleared");
+        assert!(child.step_results.is_empty(), "step_results should be cleared");
+        assert!(child.contexts.is_empty(), "contexts should be cleared");
+        assert_eq!(child.position, 0);
+        assert!(child.all_succeeded);
+        assert_eq!(child.total_cost, 0.0);
+        assert_eq!(child.total_turns, 0);
+        assert_eq!(child.total_duration_ms, 0);
+        assert_eq!(child.total_input_tokens, 0);
+        assert_eq!(child.total_output_tokens, 0);
+        assert_eq!(child.total_cache_read_input_tokens, 0);
+        assert_eq!(child.total_cache_creation_input_tokens, 0);
+        assert!(child.last_gate_feedback.is_none());
+        assert!(child.block_output.is_none());
+        assert!(child.block_with.is_empty());
+        assert!(child.resume_ctx.is_none());
+        assert!(!child.triggered_by_hook);
+        assert!(child.schema_resolver.is_none());
+        assert!(child.child_runner.is_none());
+
+        // Cancellation replaced
+        assert!(!child.cancellation.is_cancelled());
+        assert!(std::sync::Arc::ptr_eq(
+            &child.current_execution_id,
+            &child.current_execution_id
+        ));
     }
 }

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -771,17 +771,13 @@ pub fn restore_completed_step(
         state.last_gate_feedback = Some(feedback.clone());
     }
 
-    let success = crate::types::StepSuccess {
-        step_name: step_key.to_string(),
-        result_text: step.result_text.clone(),
+    let success = crate::types::StepSuccess::from_workflow_run_step(
+        step_key.to_string(),
+        step,
         markers,
         context,
-        child_run_id: step.child_run_id.clone(),
-        structured_output: step.structured_output.clone(),
-        output_file: step.output_file.clone(),
         iteration,
-        ..crate::types::StepSuccess::default()
-    };
+    );
     let step_result = StepResult::completed_without_metrics(&success);
     state.step_results.insert(step_key.to_string(), step_result);
 
@@ -826,16 +822,13 @@ pub fn fetch_child_completion_data(
         .map(|s| {
             let markers = parse_markers_out(s.markers_out.as_deref(), &s.step_name);
             let context = s.context_out.clone().unwrap_or_default();
-            let success = crate::types::StepSuccess {
-                step_name: s.step_name.clone(),
-                result_text: s.result_text.clone(),
+            let success = crate::types::StepSuccess::from_workflow_run_step(
+                s.step_name.clone(),
+                &s,
                 markers,
                 context,
-                child_run_id: s.child_run_id.clone(),
-                structured_output: s.structured_output.clone(),
-                output_file: s.output_file.clone(),
-                ..crate::types::StepSuccess::default()
-            };
+                0,
+            );
             let result = StepResult::completed_without_metrics(&success);
             (s.step_name, result)
         })

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -531,24 +531,8 @@ pub fn record_step_success(
         tracing::warn!("Failed to flush mid-run metrics: {e}");
     }
 
-    // Build StepResult and ContextEntry directly to avoid double-cloning
-    // the potentially-large context/structured_output/output_file fields.
-    state.step_results.insert(
-        step_key,
-        StepResult {
-            step_name: success.step_name.clone(),
-            status: WorkflowStepStatus::Completed,
-            result_text: success.result_text.clone(),
-            cost_usd: success.cost_usd,
-            num_turns: success.num_turns,
-            duration_ms: success.duration_ms,
-            markers: success.markers.clone(),
-            context: success.context.clone(),
-            child_run_id: success.child_run_id.clone(),
-            structured_output: success.structured_output.clone(),
-            output_file: success.output_file.clone(),
-        },
-    );
+    let step_result = StepResult::completed(&success);
+    state.step_results.insert(step_key, step_result);
 
     state.contexts.push(success.into());
 }

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -527,39 +527,20 @@ pub fn record_step_success(state: &mut ExecutionState, success: &crate::types::S
         tracing::warn!("Failed to flush mid-run metrics: {e}");
     }
 
-    let markers_for_ctx = success.markers.clone();
-    let structured_output_for_ctx = success.structured_output.clone();
-    let output_file_for_ctx = success.output_file.clone();
     let step_result = StepResult::completed(&success.step_name, success);
     state.step_results.insert(success.step_key.clone(), step_result);
 
-    push_context_entry(
-        state,
-        &success.step_name,
-        success.iteration,
-        success.context.clone(),
-        markers_for_ctx,
-        structured_output_for_ctx,
-        output_file_for_ctx,
-    );
+    push_context_entry(state, success);
 }
 
-fn push_context_entry(
-    state: &mut ExecutionState,
-    step_name: &str,
-    iteration: u32,
-    context: String,
-    markers: Vec<String>,
-    structured_output: Option<String>,
-    output_file: Option<String>,
-) {
+fn push_context_entry(state: &mut ExecutionState, success: &crate::types::StepSuccess) {
     state.contexts.push(ContextEntry {
-        step: step_name.to_string(),
-        iteration,
-        context,
-        markers,
-        structured_output,
-        output_file,
+        step: success.step_name.clone(),
+        iteration: success.iteration,
+        context: success.context.clone(),
+        markers: success.markers.clone(),
+        structured_output: success.structured_output.clone(),
+        output_file: success.output_file.clone(),
     });
 }
 
@@ -737,27 +718,22 @@ pub fn restore_completed_step(
         state.last_gate_feedback = Some(feedback.clone());
     }
 
-    let markers_for_ctx = markers.clone();
-    let step_result = StepResult::completed_without_metrics(
-        step_key,
-        step.result_text.clone(),
+    let success = crate::types::StepSuccess {
+        step_key: step_key.to_string(),
+        step_name: step_key.to_string(),
+        result_text: step.result_text.clone(),
         markers,
-        context.clone(),
-        step.child_run_id.clone(),
-        step.structured_output.clone(),
-        step.output_file.clone(),
-    );
+        context: context.clone(),
+        child_run_id: step.child_run_id.clone(),
+        structured_output: step.structured_output.clone(),
+        output_file: step.output_file.clone(),
+        iteration,
+        ..crate::types::StepSuccess::default()
+    };
+    let step_result = StepResult::completed_without_metrics(step_key, &success);
     state.step_results.insert(step_key.to_string(), step_result);
 
-    push_context_entry(
-        state,
-        step_key,
-        iteration,
-        context,
-        markers_for_ctx,
-        step.structured_output.clone(),
-        step.output_file.clone(),
-    );
+    push_context_entry(state, &success);
 }
 
 /// Fetch both the final step output (markers + context) and all completed step
@@ -798,15 +774,17 @@ pub fn fetch_child_completion_data(
         .map(|s| {
             let markers = parse_markers_out(s.markers_out.as_deref(), &s.step_name);
             let context = s.context_out.clone().unwrap_or_default();
-            let result = StepResult::completed_without_metrics(
-                &s.step_name,
-                s.result_text.clone(),
+            let success = crate::types::StepSuccess {
+                step_name: s.step_name.clone(),
+                result_text: s.result_text.clone(),
                 markers,
                 context,
-                s.child_run_id.clone(),
-                s.structured_output.clone(),
-                s.output_file.clone(),
-            );
+                child_run_id: s.child_run_id.clone(),
+                structured_output: s.structured_output.clone(),
+                output_file: s.output_file.clone(),
+                ..crate::types::StepSuccess::default()
+            };
+            let result = StepResult::completed_without_metrics(&s.step_name, &success);
             (s.step_name, result)
         })
         .collect();

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -538,26 +538,19 @@ pub fn record_step_success(
         StepResult {
             step_name: success.step_name.clone(),
             status: WorkflowStepStatus::Completed,
-            result_text: success.result_text,
+            result_text: success.result_text.clone(),
             cost_usd: success.cost_usd,
             num_turns: success.num_turns,
             duration_ms: success.duration_ms,
             markers: success.markers.clone(),
             context: success.context.clone(),
-            child_run_id: success.child_run_id,
+            child_run_id: success.child_run_id.clone(),
             structured_output: success.structured_output.clone(),
             output_file: success.output_file.clone(),
         },
     );
 
-    state.contexts.push(ContextEntry {
-        step: success.step_name,
-        iteration: success.iteration,
-        context: success.context,
-        markers: success.markers,
-        structured_output: success.structured_output,
-        output_file: success.output_file,
-    });
+    state.contexts.push(success.into());
 }
 
 /// Resolve child workflow inputs: substitute variables, apply defaults, and
@@ -738,7 +731,7 @@ pub fn restore_completed_step(
         step_name: step_key.to_string(),
         result_text: step.result_text.clone(),
         markers,
-        context: context.clone(),
+        context,
         child_run_id: step.child_run_id.clone(),
         structured_output: step.structured_output.clone(),
         output_file: step.output_file.clone(),
@@ -748,14 +741,7 @@ pub fn restore_completed_step(
     let step_result = StepResult::completed_without_metrics(&success);
     state.step_results.insert(step_key.to_string(), step_result);
 
-    state.contexts.push(ContextEntry {
-        step: success.step_name,
-        iteration: success.iteration,
-        context: success.context,
-        markers: success.markers,
-        structured_output: success.structured_output,
-        output_file: success.output_file,
-    });
+    state.contexts.push(success.into());
 }
 
 /// Fetch both the final step output (markers + context) and all completed step
@@ -796,17 +782,19 @@ pub fn fetch_child_completion_data(
         .map(|s| {
             let markers = parse_markers_out(s.markers_out.as_deref(), &s.step_name);
             let context = s.context_out.clone().unwrap_or_default();
-            let success = crate::types::StepSuccess {
+            let result = StepResult {
                 step_name: s.step_name.clone(),
-                result_text: s.result_text.clone(),
+                status: WorkflowStepStatus::Completed,
+                result_text: s.result_text,
+                cost_usd: None,
+                num_turns: None,
+                duration_ms: None,
                 markers,
                 context,
-                child_run_id: s.child_run_id.clone(),
-                structured_output: s.structured_output.clone(),
-                output_file: s.output_file.clone(),
-                ..crate::types::StepSuccess::default()
+                child_run_id: s.child_run_id,
+                structured_output: s.structured_output,
+                output_file: s.output_file,
             };
-            let result = StepResult::completed_without_metrics(&success);
             (s.step_name, result)
         })
         .collect();

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -766,19 +766,17 @@ pub fn fetch_child_completion_data(
         .map(|s| {
             let markers = parse_markers_out(s.markers_out.as_deref(), &s.step_name);
             let context = s.context_out.clone().unwrap_or_default();
-            let result = StepResult {
+            let success = crate::types::StepSuccess {
                 step_name: s.step_name.clone(),
-                status: WorkflowStepStatus::Completed,
-                result_text: s.result_text,
-                cost_usd: None,
-                num_turns: None,
-                duration_ms: None,
+                result_text: s.result_text.clone(),
                 markers,
                 context,
-                child_run_id: s.child_run_id,
-                structured_output: s.structured_output,
-                output_file: s.output_file,
+                child_run_id: s.child_run_id.clone(),
+                structured_output: s.structured_output.clone(),
+                output_file: s.output_file.clone(),
+                ..crate::types::StepSuccess::default()
             };
+            let result = StepResult::completed_without_metrics(&success);
             (s.step_name, result)
         })
         .collect();

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -30,12 +30,14 @@ pub struct WorktreeContext {
 }
 
 /// Pre-loaded context for resuming a workflow run.
+#[derive(Clone)]
 pub struct ResumeContext {
     /// Completed step records keyed by step key, for O(1) skip check and restore.
     pub step_map: HashMap<StepKey, WorkflowRunStep>,
 }
 
 /// Mutable runtime state for a workflow execution — no conductor-core deps.
+#[derive(Clone)]
 pub struct ExecutionState {
     pub persistence: Arc<dyn WorkflowPersistence>,
     pub action_registry: Arc<ActionRegistry>,
@@ -120,6 +122,51 @@ impl ExecutionState {
     /// Create a fresh heartbeat counter, initialized to 0 so the first tick fires immediately.
     pub fn new_heartbeat() -> Arc<AtomicI64> {
         Arc::new(AtomicI64::new(0))
+    }
+
+    /// Fork a child execution state from this parent.
+    ///
+    /// Copies shared configuration (persistence, registries, workflow identity) and resets all
+    /// runtime accumulators so the child starts with a clean slate.
+    pub fn fork_child(&self, cancellation: CancellationToken) -> ExecutionState {
+        Self {
+            persistence: Arc::clone(&self.persistence),
+            action_registry: Arc::clone(&self.action_registry),
+            script_env_provider: Arc::clone(&self.script_env_provider),
+            workflow_run_id: self.workflow_run_id.clone(),
+            workflow_name: self.workflow_name.clone(),
+            worktree_ctx: self.worktree_ctx.clone(),
+            model: self.model.clone(),
+            exec_config: self.exec_config.clone(),
+            inputs: HashMap::new(),
+            parent_run_id: self.parent_run_id.clone(),
+            depth: self.depth,
+            target_label: self.target_label.clone(),
+            step_results: HashMap::new(),
+            contexts: vec![],
+            position: 0,
+            all_succeeded: true,
+            total_cost: 0.0,
+            total_turns: 0,
+            total_duration_ms: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_read_input_tokens: 0,
+            total_cache_creation_input_tokens: 0,
+            last_gate_feedback: None,
+            block_output: None,
+            block_with: vec![],
+            resume_ctx: None,
+            default_bot_name: self.default_bot_name.clone(),
+            triggered_by_hook: false,
+            schema_resolver: self.schema_resolver.clone(),
+            child_runner: self.child_runner.as_ref().map(Arc::clone),
+            last_heartbeat_at: Self::new_heartbeat(),
+            registry: Arc::clone(&self.registry),
+            event_sinks: Arc::clone(&self.event_sinks),
+            cancellation,
+            current_execution_id: Arc::new(std::sync::Mutex::new(None)),
+        }
     }
 
     /// Accumulate individual metrics into this execution state.

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -984,6 +984,28 @@ mod tests {
         use crate::traits::script_env_provider::NoOpScriptEnvProvider;
         use crate::types::WorkflowExecConfig;
 
+        struct DummyChildRunner;
+        impl ChildWorkflowRunner for DummyChildRunner {
+            fn execute_child(
+                &self,
+                _workflow_name: &str,
+                _parent_state: &ExecutionState,
+                _params: ChildWorkflowInput,
+            ) -> Result<crate::types::WorkflowResult> {
+                unimplemented!()
+            }
+            fn resume_child(&self, _workflow_run_id: &str, _model: Option<&str>) -> Result<crate::types::WorkflowResult> {
+                unimplemented!()
+            }
+            fn find_resumable_child(
+                &self,
+                _parent_run_id: &str,
+                _workflow_name: &str,
+            ) -> Result<Option<crate::types::WorkflowRun>> {
+                unimplemented!()
+            }
+        }
+
         let parent = ExecutionState {
             persistence: Arc::new(InMemoryWorkflowPersistence::new()),
             action_registry: Arc::new(crate::traits::action_executor::ActionRegistry::new(
@@ -1040,7 +1062,7 @@ mod tests {
             default_bot_name: Some("bot".to_string()),
             triggered_by_hook: true,
             schema_resolver: None,
-            child_runner: None,
+            child_runner: Some(Arc::new(DummyChildRunner)),
             last_heartbeat_at: ExecutionState::new_heartbeat(),
             registry: Arc::new(crate::traits::item_provider::ItemProviderRegistry::new()),
             event_sinks: Arc::from(vec![]),
@@ -1080,7 +1102,7 @@ mod tests {
         assert!(child.resume_ctx.is_none());
         assert!(!child.triggered_by_hook);
         assert!(child.schema_resolver.is_none());
-        assert!(child.child_runner.is_none());
+        assert!(child.child_runner.is_some(), "child_runner should be cloned from parent");
 
         // Cancellation replaced
         assert!(!child.cancellation.is_cancelled());

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -129,44 +129,28 @@ impl ExecutionState {
     /// Copies shared configuration (persistence, registries, workflow identity) and resets all
     /// runtime accumulators so the child starts with a clean slate.
     pub fn fork_child(&self, cancellation: CancellationToken) -> ExecutionState {
-        Self {
-            persistence: Arc::clone(&self.persistence),
-            action_registry: Arc::clone(&self.action_registry),
-            script_env_provider: Arc::clone(&self.script_env_provider),
-            workflow_run_id: self.workflow_run_id.clone(),
-            workflow_name: self.workflow_name.clone(),
-            worktree_ctx: self.worktree_ctx.clone(),
-            model: self.model.clone(),
-            exec_config: self.exec_config.clone(),
-            inputs: HashMap::new(),
-            parent_run_id: self.parent_run_id.clone(),
-            depth: self.depth,
-            target_label: self.target_label.clone(),
-            step_results: HashMap::new(),
-            contexts: vec![],
-            position: 0,
-            all_succeeded: true,
-            total_cost: 0.0,
-            total_turns: 0,
-            total_duration_ms: 0,
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-            total_cache_read_input_tokens: 0,
-            total_cache_creation_input_tokens: 0,
-            last_gate_feedback: None,
-            block_output: None,
-            block_with: vec![],
-            resume_ctx: None,
-            default_bot_name: self.default_bot_name.clone(),
-            triggered_by_hook: false,
-            schema_resolver: self.schema_resolver.clone(),
-            child_runner: self.child_runner.as_ref().map(Arc::clone),
-            last_heartbeat_at: Self::new_heartbeat(),
-            registry: Arc::clone(&self.registry),
-            event_sinks: Arc::clone(&self.event_sinks),
-            cancellation,
-            current_execution_id: Arc::new(std::sync::Mutex::new(None)),
-        }
+        let mut child = self.clone();
+        child.inputs.clear();
+        child.step_results.clear();
+        child.contexts.clear();
+        child.position = 0;
+        child.all_succeeded = true;
+        child.total_cost = 0.0;
+        child.total_turns = 0;
+        child.total_duration_ms = 0;
+        child.total_input_tokens = 0;
+        child.total_output_tokens = 0;
+        child.total_cache_read_input_tokens = 0;
+        child.total_cache_creation_input_tokens = 0;
+        child.last_gate_feedback = None;
+        child.block_output = None;
+        child.block_with.clear();
+        child.resume_ctx = None;
+        child.triggered_by_hook = false;
+        child.last_heartbeat_at = Self::new_heartbeat();
+        child.cancellation = cancellation;
+        child.current_execution_id = Arc::new(std::sync::Mutex::new(None));
+        child
     }
 
     /// Accumulate individual metrics into this execution state.

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -511,34 +511,15 @@ pub fn record_step_skipped(state: &mut ExecutionState, step_key: String, step_la
 }
 
 /// Record a successful step: accumulate stats, insert StepResult, push context.
-#[allow(clippy::too_many_arguments)]
-pub fn record_step_success(
-    state: &mut ExecutionState,
-    step_key: String,
-    step_name: &str,
-    result_text: Option<String>,
-    cost_usd: Option<f64>,
-    num_turns: Option<i64>,
-    duration_ms: Option<i64>,
-    input_tokens: Option<i64>,
-    output_tokens: Option<i64>,
-    cache_read_input_tokens: Option<i64>,
-    cache_creation_input_tokens: Option<i64>,
-    markers: Vec<String>,
-    context: String,
-    child_run_id: Option<String>,
-    iteration: u32,
-    structured_output: Option<String>,
-    output_file: Option<String>,
-) {
+pub fn record_step_success(state: &mut ExecutionState, success: &crate::types::StepSuccess) {
     state.accumulate_metrics(
-        cost_usd,
-        num_turns,
-        duration_ms,
-        input_tokens,
-        output_tokens,
-        cache_read_input_tokens,
-        cache_creation_input_tokens,
+        success.cost_usd,
+        success.num_turns,
+        success.duration_ms,
+        success.input_tokens,
+        success.output_tokens,
+        success.cache_read_input_tokens,
+        success.cache_creation_input_tokens,
     );
 
     // Best-effort mid-run metrics flush — non-fatal
@@ -546,28 +527,17 @@ pub fn record_step_success(
         tracing::warn!("Failed to flush mid-run metrics: {e}");
     }
 
-    let markers_for_ctx = markers.clone();
-    let structured_output_for_ctx = structured_output.clone();
-    let output_file_for_ctx = output_file.clone();
-    let step_result = StepResult::completed(
-        step_name,
-        result_text,
-        cost_usd,
-        num_turns,
-        duration_ms,
-        markers,
-        context.clone(),
-        child_run_id,
-        structured_output,
-        output_file,
-    );
-    state.step_results.insert(step_key, step_result);
+    let markers_for_ctx = success.markers.clone();
+    let structured_output_for_ctx = success.structured_output.clone();
+    let output_file_for_ctx = success.output_file.clone();
+    let step_result = StepResult::completed(&success.step_name, success);
+    state.step_results.insert(success.step_key.clone(), step_result);
 
     push_context_entry(
         state,
-        step_name,
-        iteration,
-        context,
+        &success.step_name,
+        success.iteration,
+        success.context.clone(),
         markers_for_ctx,
         structured_output_for_ctx,
         output_file_for_ctx,

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -102,7 +102,7 @@ pub struct ChildWorkflowInput {
 pub trait ChildWorkflowRunner: Send + Sync {
     fn execute_child(
         &self,
-        child_def: &WorkflowDef,
+        workflow_name: &str,
         parent_state: &ExecutionState,
         params: ChildWorkflowInput,
     ) -> Result<WorkflowResult>;
@@ -511,7 +511,11 @@ pub fn record_step_skipped(state: &mut ExecutionState, step_key: String, step_la
 }
 
 /// Record a successful step: accumulate stats, insert StepResult, push context.
-pub fn record_step_success(state: &mut ExecutionState, success: &crate::types::StepSuccess) {
+pub fn record_step_success(
+    state: &mut ExecutionState,
+    step_key: String,
+    success: crate::types::StepSuccess,
+) {
     state.accumulate_metrics(
         success.cost_usd,
         success.num_turns,
@@ -527,20 +531,32 @@ pub fn record_step_success(state: &mut ExecutionState, success: &crate::types::S
         tracing::warn!("Failed to flush mid-run metrics: {e}");
     }
 
-    let step_result = StepResult::completed(success);
-    state.step_results.insert(success.step_key.clone(), step_result);
+    // Build StepResult and ContextEntry directly to avoid double-cloning
+    // the potentially-large context/structured_output/output_file fields.
+    state.step_results.insert(
+        step_key,
+        StepResult {
+            step_name: success.step_name.clone(),
+            status: WorkflowStepStatus::Completed,
+            result_text: success.result_text,
+            cost_usd: success.cost_usd,
+            num_turns: success.num_turns,
+            duration_ms: success.duration_ms,
+            markers: success.markers.clone(),
+            context: success.context.clone(),
+            child_run_id: success.child_run_id,
+            structured_output: success.structured_output.clone(),
+            output_file: success.output_file.clone(),
+        },
+    );
 
-    push_context_entry(state, success);
-}
-
-fn push_context_entry(state: &mut ExecutionState, success: &crate::types::StepSuccess) {
     state.contexts.push(ContextEntry {
-        step: success.step_name.clone(),
+        step: success.step_name,
         iteration: success.iteration,
-        context: success.context.clone(),
-        markers: success.markers.clone(),
-        structured_output: success.structured_output.clone(),
-        output_file: success.output_file.clone(),
+        context: success.context,
+        markers: success.markers,
+        structured_output: success.structured_output,
+        output_file: success.output_file,
     });
 }
 
@@ -719,7 +735,6 @@ pub fn restore_completed_step(
     }
 
     let success = crate::types::StepSuccess {
-        step_key: step_key.to_string(),
         step_name: step_key.to_string(),
         result_text: step.result_text.clone(),
         markers,
@@ -733,7 +748,14 @@ pub fn restore_completed_step(
     let step_result = StepResult::completed_without_metrics(&success);
     state.step_results.insert(step_key.to_string(), step_result);
 
-    push_context_entry(state, &success);
+    state.contexts.push(ContextEntry {
+        step: success.step_name,
+        iteration: success.iteration,
+        context: success.context,
+        markers: success.markers,
+        structured_output: success.structured_output,
+        output_file: success.output_file,
+    });
 }
 
 /// Fetch both the final step output (markers + context) and all completed step

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -527,7 +527,7 @@ pub fn record_step_success(state: &mut ExecutionState, success: &crate::types::S
         tracing::warn!("Failed to flush mid-run metrics: {e}");
     }
 
-    let step_result = StepResult::completed(&success.step_name, success);
+    let step_result = StepResult::completed(success);
     state.step_results.insert(success.step_key.clone(), step_result);
 
     push_context_entry(state, success);
@@ -730,7 +730,7 @@ pub fn restore_completed_step(
         iteration,
         ..crate::types::StepSuccess::default()
     };
-    let step_result = StepResult::completed_without_metrics(step_key, &success);
+    let step_result = StepResult::completed_without_metrics(&success);
     state.step_results.insert(step_key.to_string(), step_result);
 
     push_context_entry(state, &success);
@@ -784,7 +784,7 @@ pub fn fetch_child_completion_data(
                 output_file: s.output_file.clone(),
                 ..crate::types::StepSuccess::default()
             };
-            let result = StepResult::completed_without_metrics(&s.step_name, &success);
+            let result = StepResult::completed_without_metrics(&success);
             (s.step_name, result)
         })
         .collect();

--- a/runkon-flow/src/executors/call_workflow.rs
+++ b/runkon-flow/src/executors/call_workflow.rs
@@ -71,8 +71,8 @@ pub fn execute_call_workflow(
 
         record_step_success(
             state,
-            &crate::types::StepSuccess {
-                step_key: step_key.clone(),
+            step_key.clone(),
+            crate::types::StepSuccess {
                 step_name: node.workflow.clone(),
                 result_text: Some(format!(
                     "Sub-workflow '{}' completed successfully",
@@ -238,23 +238,9 @@ pub fn execute_call_workflow(
         // Actually, the better approach is: child_runner gets the workflow name via the step
         // and loads it itself. We'll pass inputs as-is.
 
-        // Build a minimal dummy WorkflowDef with the name only — the runner must load the real one.
-        let placeholder_def = crate::dsl::WorkflowDef {
-            name: node.workflow.clone(),
-            title: None,
-            description: String::new(),
-            trigger: crate::dsl::WorkflowTrigger::Manual,
-            targets: vec![],
-            group: None,
-            inputs: vec![],
-            body: vec![],
-            always: vec![],
-            source_path: String::new(),
-        };
-
-        // Resolve child inputs against the placeholder (no decls → just pass through substituted vars)
+        // Resolve child inputs against an empty inputs map (no decls → just pass through substituted vars)
         let resolved_inputs =
-            match resolve_child_inputs(&raw_child_inputs, &vars, &placeholder_def.inputs) {
+            match resolve_child_inputs(&raw_child_inputs, &vars, &[]) {
                 Ok(inputs) => inputs,
                 Err(missing) => {
                     let msg = format!(
@@ -271,9 +257,9 @@ pub fn execute_call_workflow(
                 }
             };
 
-        // Use the child_runner to execute — it knows about conductor-core types
+        // Use the child_runner to execute — it resolves the real def by name
         match child_runner.execute_child(
-            &placeholder_def,
+            &node.workflow,
             state,
             crate::engine::ChildWorkflowInput {
                 inputs: resolved_inputs,

--- a/runkon-flow/src/executors/call_workflow.rs
+++ b/runkon-flow/src/executors/call_workflow.rs
@@ -296,7 +296,13 @@ pub fn execute_call_workflow(
                     return Ok(());
                 } else {
                     let msg = format!("Sub-workflow '{}' failed", node.workflow);
-                    tracing::warn!("{} (attempt {}/{})", msg, attempt + 1, max_attempts);
+                    tracing::warn!(
+                        "{} (attempt {}/{}) [child_run_id={}]",
+                        msg,
+                        attempt + 1,
+                        max_attempts,
+                        result.workflow_run_id,
+                    );
                     state
                         .persistence
                         .update_step(

--- a/runkon-flow/src/executors/call_workflow.rs
+++ b/runkon-flow/src/executors/call_workflow.rs
@@ -71,25 +71,27 @@ pub fn execute_call_workflow(
 
         record_step_success(
             state,
-            step_key.clone(),
-            &node.workflow,
-            Some(format!(
-                "Sub-workflow '{}' completed successfully",
-                node.workflow
-            )),
-            Some(result.total_cost),
-            Some(result.total_turns),
-            Some(result.total_duration_ms),
-            Some(result.total_input_tokens),
-            Some(result.total_output_tokens),
-            Some(result.total_cache_read_input_tokens),
-            Some(result.total_cache_creation_input_tokens),
-            markers,
-            context,
-            Some(result.workflow_run_id.clone()),
-            iteration,
-            None,
-            None,
+            &crate::types::StepSuccess {
+                step_key: step_key.clone(),
+                step_name: node.workflow.clone(),
+                result_text: Some(format!(
+                    "Sub-workflow '{}' completed successfully",
+                    node.workflow
+                )),
+                cost_usd: Some(result.total_cost),
+                num_turns: Some(result.total_turns),
+                duration_ms: Some(result.total_duration_ms),
+                input_tokens: Some(result.total_input_tokens),
+                output_tokens: Some(result.total_output_tokens),
+                cache_read_input_tokens: Some(result.total_cache_read_input_tokens),
+                cache_creation_input_tokens: Some(result.total_cache_creation_input_tokens),
+                markers,
+                context,
+                child_run_id: Some(result.workflow_run_id.clone()),
+                iteration,
+                structured_output: None,
+                output_file: None,
+            },
         );
 
         for (key, value) in child_steps {

--- a/runkon-flow/src/executors/foreach.rs
+++ b/runkon-flow/src/executors/foreach.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{mpsc, Arc};
-use std::thread;
 use std::time::Duration;
 
 use crate::cancellation::CancellationToken;
@@ -340,6 +339,8 @@ pub fn execute_foreach(
         ready.len() + waiting.len(),
     );
 
+    let pool = threadpool::ThreadPool::new(max_slots);
+
     loop {
         // 1. When threads are in-flight, block briefly on the first result to yield
         //    the CPU instead of spinning. Then drain any additional ready results.
@@ -404,6 +405,7 @@ pub fn execute_foreach(
             }
 
             terminal_ids.insert(item_id.clone());
+            let mut newly_terminal = vec![item_id.clone()];
 
             if !succeeded {
                 match node.on_child_fail {
@@ -431,6 +433,7 @@ pub fn execute_foreach(
                                     .map_err(p_err)?;
                             }
                             terminal_ids.insert(skip_id.clone());
+                            newly_terminal.push(skip_id.clone());
                         }
                         ready.retain(|i| !to_skip.contains(&i.item_id));
                         waiting.retain(|i| !to_skip.contains(&i.item_id));
@@ -447,16 +450,30 @@ pub fn execute_foreach(
                 }
             }
 
-            // After recording a terminal item, promote newly eligible waiting items to ready.
-            let mut still_waiting = Vec::new();
-            for item in waiting.drain(..) {
-                if is_eligible(&item.item_id, &dep_map, &terminal_ids) {
-                    ready.push_back(item);
-                } else {
-                    still_waiting.push(item);
+            // After recording terminal items, promote newly eligible waiting items to ready.
+            // Only check items that are dependents of the newly terminal items — an item
+            // can only become eligible when one of its dependencies becomes terminal.
+            if !waiting.is_empty() {
+                let mut candidates = HashSet::new();
+                for tid in &newly_terminal {
+                    if let Some(deps) = dependents_map.get(tid) {
+                        candidates.extend(deps.iter().cloned());
+                    }
+                }
+                if !candidates.is_empty() {
+                    let mut still_waiting = Vec::new();
+                    for item in waiting.drain(..) {
+                        if candidates.contains(&item.item_id)
+                            && is_eligible(&item.item_id, &dep_map, &terminal_ids)
+                        {
+                            ready.push_back(item);
+                        } else {
+                            still_waiting.push(item);
+                        }
+                    }
+                    waiting = still_waiting;
                 }
             }
-            waiting = still_waiting;
         }
 
         // 2. Check parent cancellation.
@@ -510,7 +527,7 @@ pub fn execute_foreach(
                 let tx_clone = tx.clone();
                 let depth = state.depth;
 
-                thread::spawn(move || {
+                pool.execute(move || {
                     let child_state = ctx.make_child_state(child_cancellation.clone());
                     let succeeded = ctx
                         .child_runner

--- a/runkon-flow/src/executors/foreach.rs
+++ b/runkon-flow/src/executors/foreach.rs
@@ -233,22 +233,16 @@ pub fn execute_foreach(
 
     if total_items == 0 {
         let context = format!("foreach {}: no items to process", node.name);
-        state
-            .persistence
-            .update_step(
-                &step_id,
-                StepUpdate {
-                    status: WorkflowStepStatus::Completed,
-                    child_run_id: None,
-                    result_text: Some(context.clone()),
-                    context_out: Some(context.clone()),
-                    markers_out: None,
-                    retry_count: Some(0),
-                    structured_output: None,
-                    step_error: None,
-                },
-            )
-            .map_err(p_err)?;
+        super::persist_completed_step(
+            state,
+            &step_id,
+            None,
+            Some(context.clone()),
+            Some(context.clone()),
+            None,
+            0,
+            None,
+        )?;
 
         record_foreach_step_success(state, step_key, &node.name, context, iteration);
         return Ok(());

--- a/runkon-flow/src/executors/foreach.rs
+++ b/runkon-flow/src/executors/foreach.rs
@@ -157,8 +157,8 @@ fn record_foreach_step_success(
 ) {
     record_step_success(
         state,
-        &crate::types::StepSuccess {
-            step_key,
+        step_key,
+        crate::types::StepSuccess {
             step_name: step_name.to_string(),
             result_text: Some(context.clone()),
             context,
@@ -369,20 +369,6 @@ pub fn execute_foreach(
     // Clone node.inputs once outside the dispatch loop to avoid re-cloning on every iteration.
     let base_inputs = node.inputs.clone();
 
-    // Build the placeholder WorkflowDef once — same for every item.
-    let placeholder_def = crate::dsl::WorkflowDef {
-        name: node.workflow.clone(),
-        title: None,
-        description: String::new(),
-        trigger: crate::dsl::WorkflowTrigger::Manual,
-        targets: vec![],
-        group: None,
-        inputs: vec![],
-        body: vec![],
-        always: vec![],
-        source_path: String::new(),
-    };
-
     // Seed terminal counts from items that were already terminal before this dispatch
     // (e.g. partially-resumed runs).  New completions/failures/skips are tracked
     // incrementally below so the final phase can skip a DB re-query.
@@ -582,7 +568,7 @@ pub fn execute_foreach(
                 child_inputs.insert("item.ref".to_string(), item.item_ref.clone());
 
                 let ctx = Arc::clone(&parent_ctx);
-                let def = placeholder_def.clone();
+                let workflow_name = node.workflow.clone();
                 let inputs = child_inputs;
                 let item_db_id = item.id.clone();
                 let child_cancellation = state.cancellation.child();
@@ -594,7 +580,7 @@ pub fn execute_foreach(
                     let succeeded = ctx
                         .child_runner
                         .execute_child(
-                            &def,
+                            &workflow_name,
                             &child_state,
                             ChildWorkflowInput {
                                 inputs,

--- a/runkon-flow/src/executors/foreach.rs
+++ b/runkon-flow/src/executors/foreach.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
 
@@ -7,17 +7,15 @@ use crate::cancellation::CancellationToken;
 use crate::dsl::{ForEachNode, OnChildFail};
 use crate::engine::{
     emit_event, record_step_failure, record_step_success, restore_step, should_skip,
-    ChildWorkflowInput, ExecutionState, WorktreeContext,
+    ChildWorkflowInput, ExecutionState,
 };
 use crate::engine_error::{EngineError, Result};
 use crate::events::EngineEvent;
 use crate::status::WorkflowStepStatus;
-use crate::traits::action_executor::ActionRegistry;
-use crate::traits::item_provider::{ItemProviderRegistry, ProviderContext};
+use crate::traits::item_provider::ProviderContext;
 use crate::traits::persistence::{
-    FanOutItemStatus, FanOutItemUpdate, NewStep, StepUpdate, WorkflowPersistence,
+    FanOutItemStatus, FanOutItemUpdate, NewStep, StepUpdate,
 };
-use crate::traits::script_env_provider::ScriptEnvProvider;
 
 use super::p_err;
 
@@ -27,21 +25,8 @@ use super::p_err;
 /// the parent `ExecutionState` are kept, so the main thread retains full `&mut`
 /// access throughout the dispatch loop.
 struct ForeachParentCtx {
-    persistence: Arc<dyn WorkflowPersistence>,
-    action_registry: Arc<ActionRegistry>,
-    script_env_provider: Arc<dyn ScriptEnvProvider>,
-    registry: Arc<ItemProviderRegistry>,
-    event_sinks: Arc<[Arc<dyn crate::events::EventSink>]>,
+    parent_state: ExecutionState,
     child_runner: Arc<dyn crate::engine::ChildWorkflowRunner>,
-    workflow_run_id: String,
-    workflow_name: String,
-    model: Option<String>,
-    exec_config: crate::types::WorkflowExecConfig,
-    parent_run_id: String,
-    depth: u32,
-    target_label: Option<String>,
-    default_bot_name: Option<String>,
-    worktree_ctx: WorktreeContext,
 }
 
 impl ForeachParentCtx {
@@ -50,63 +35,13 @@ impl ForeachParentCtx {
         child_runner: Arc<dyn crate::engine::ChildWorkflowRunner>,
     ) -> Self {
         Self {
-            persistence: Arc::clone(&state.persistence),
-            action_registry: Arc::clone(&state.action_registry),
-            script_env_provider: Arc::clone(&state.script_env_provider),
-            registry: Arc::clone(&state.registry),
-            event_sinks: Arc::clone(&state.event_sinks),
+            parent_state: state.clone(),
             child_runner,
-            workflow_run_id: state.workflow_run_id.clone(),
-            workflow_name: state.workflow_name.clone(),
-            model: state.model.clone(),
-            exec_config: state.exec_config.clone(),
-            parent_run_id: state.parent_run_id.clone(),
-            depth: state.depth,
-            target_label: state.target_label.clone(),
-            default_bot_name: state.default_bot_name.clone(),
-            worktree_ctx: state.worktree_ctx.clone(),
         }
     }
 
     fn make_child_state(&self, cancellation: CancellationToken) -> ExecutionState {
-        ExecutionState {
-            persistence: Arc::clone(&self.persistence),
-            action_registry: Arc::clone(&self.action_registry),
-            script_env_provider: Arc::clone(&self.script_env_provider),
-            workflow_run_id: self.workflow_run_id.clone(),
-            workflow_name: self.workflow_name.clone(),
-            worktree_ctx: self.worktree_ctx.clone(),
-            model: self.model.clone(),
-            exec_config: self.exec_config.clone(),
-            inputs: HashMap::new(),
-            parent_run_id: self.parent_run_id.clone(),
-            depth: self.depth,
-            target_label: self.target_label.clone(),
-            step_results: HashMap::new(),
-            contexts: vec![],
-            position: 0,
-            all_succeeded: true,
-            total_cost: 0.0,
-            total_turns: 0,
-            total_duration_ms: 0,
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-            total_cache_read_input_tokens: 0,
-            total_cache_creation_input_tokens: 0,
-            last_gate_feedback: None,
-            block_output: None,
-            block_with: vec![],
-            resume_ctx: None,
-            default_bot_name: self.default_bot_name.clone(),
-            triggered_by_hook: false,
-            schema_resolver: None,
-            child_runner: Some(Arc::clone(&self.child_runner)),
-            last_heartbeat_at: ExecutionState::new_heartbeat(),
-            registry: Arc::clone(&self.registry),
-            event_sinks: Arc::clone(&self.event_sinks),
-            cancellation,
-            current_execution_id: Arc::new(Mutex::new(None)),
-        }
+        self.parent_state.fork_child(cancellation)
     }
 }
 

--- a/runkon-flow/src/executors/foreach.rs
+++ b/runkon-flow/src/executors/foreach.rs
@@ -24,7 +24,8 @@ use super::p_err;
 /// the parent `ExecutionState` are kept, so the main thread retains full `&mut`
 /// access throughout the dispatch loop.
 struct ForeachParentCtx {
-    parent_state: ExecutionState,
+    /// Pre-forked template with empty runtime collections — cheap to clone.
+    template: ExecutionState,
     child_runner: Arc<dyn crate::engine::ChildWorkflowRunner>,
 }
 
@@ -33,14 +34,20 @@ impl ForeachParentCtx {
         state: &ExecutionState,
         child_runner: Arc<dyn crate::engine::ChildWorkflowRunner>,
     ) -> Self {
+        // fork_child creates a state with all runtime collections already empty,
+        // so cloning the template later is cheap.
+        let mut template = state.fork_child(crate::cancellation::CancellationToken::new());
+        template.child_runner = Some(Arc::clone(&child_runner));
         Self {
-            parent_state: state.clone(),
+            template,
             child_runner,
         }
     }
 
     fn make_child_state(&self, cancellation: CancellationToken) -> ExecutionState {
-        self.parent_state.fork_child(cancellation)
+        let mut child = self.template.clone();
+        child.cancellation = cancellation;
+        child
     }
 }
 

--- a/runkon-flow/src/executors/foreach.rs
+++ b/runkon-flow/src/executors/foreach.rs
@@ -145,9 +145,9 @@ fn is_eligible(
 
 /// Record a successful foreach step with the standard set of defaulted arguments.
 ///
-/// `record_step_success` takes 17 arguments; all of the foreach-specific ones
-/// default to `None` / `vec![]`.  This wrapper narrows the call site to the
-/// three values that actually vary: `step_key`, `step_name`, and `context`.
+/// All of the foreach-specific fields default to `None` / `vec![]`.
+/// This wrapper narrows the call site to the three values that actually vary:
+/// `step_key`, `step_name`, and `context`.
 fn record_foreach_step_success(
     state: &mut ExecutionState,
     step_key: String,
@@ -157,22 +157,14 @@ fn record_foreach_step_success(
 ) {
     record_step_success(
         state,
-        step_key,
-        step_name,
-        Some(context.clone()),
-        None,   // cost_usd
-        None,   // num_turns
-        None,   // duration_ms
-        None,   // input_tokens
-        None,   // output_tokens
-        None,   // cache_read_input_tokens
-        None,   // cache_creation_input_tokens
-        vec![], // markers
-        context,
-        None, // child_run_id
-        iteration,
-        None, // structured_output
-        None, // output_file
+        &crate::types::StepSuccess {
+            step_key,
+            step_name: step_name.to_string(),
+            result_text: Some(context.clone()),
+            context,
+            iteration,
+            ..crate::types::StepSuccess::default()
+        },
     );
 }
 

--- a/runkon-flow/src/executors/mod.rs
+++ b/runkon-flow/src/executors/mod.rs
@@ -181,8 +181,8 @@ pub(super) fn record_dispatch_success(
     )?;
     crate::engine::record_step_success(
         state,
-        &crate::types::StepSuccess {
-            step_key: step_key.to_string(),
+        step_key.to_string(),
+        crate::types::StepSuccess {
             step_name: agent_label.to_string(),
             result_text: output.result_text.clone(),
             cost_usd: output.cost_usd,

--- a/runkon-flow/src/executors/mod.rs
+++ b/runkon-flow/src/executors/mod.rs
@@ -12,8 +12,10 @@ use std::sync::Arc;
 use crate::engine_error::EngineError;
 
 #[inline]
+#[track_caller]
 pub(super) fn p_err(e: impl std::fmt::Display) -> EngineError {
-    EngineError::Persistence(e.to_string())
+    let loc = std::panic::Location::caller();
+    EngineError::Persistence(format!("{}:{} — {e}", loc.file(), loc.line()))
 }
 
 /// Insert a step record and emit a StepRetrying event when `attempt > 0`.

--- a/runkon-flow/src/executors/mod.rs
+++ b/runkon-flow/src/executors/mod.rs
@@ -182,23 +182,13 @@ pub(super) fn record_dispatch_success(
     crate::engine::record_step_success(
         state,
         step_key.to_string(),
-        crate::types::StepSuccess {
-            step_name: agent_label.to_string(),
-            result_text: output.result_text.clone(),
-            cost_usd: output.cost_usd,
-            num_turns: output.num_turns,
-            duration_ms: output.duration_ms,
-            input_tokens: output.input_tokens,
-            output_tokens: output.output_tokens,
-            cache_read_input_tokens: output.cache_read_input_tokens,
-            cache_creation_input_tokens: output.cache_creation_input_tokens,
-            markers: output.markers.clone(),
+        crate::types::StepSuccess::from_action_output(
+            output,
+            agent_label.to_string(),
             context,
-            child_run_id: output.child_run_id.clone(),
             iteration,
-            structured_output: output.structured_output.clone(),
             output_file,
-        },
+        ),
     );
     Ok(())
 }

--- a/runkon-flow/src/executors/mod.rs
+++ b/runkon-flow/src/executors/mod.rs
@@ -154,7 +154,6 @@ pub(super) fn build_action_params(
 /// Persist a completed step and record its success result in one call.
 /// Centralises the `persist_completed_step` + `record_step_success` pair used
 /// by `call.rs` after a successful agent dispatch.
-#[allow(clippy::too_many_arguments)]
 pub(super) fn record_dispatch_success(
     state: &mut crate::engine::ExecutionState,
     step_id: &str,
@@ -182,22 +181,24 @@ pub(super) fn record_dispatch_success(
     )?;
     crate::engine::record_step_success(
         state,
-        step_key.to_string(),
-        agent_label,
-        output.result_text.clone(),
-        output.cost_usd,
-        output.num_turns,
-        output.duration_ms,
-        output.input_tokens,
-        output.output_tokens,
-        output.cache_read_input_tokens,
-        output.cache_creation_input_tokens,
-        output.markers.clone(),
-        context,
-        output.child_run_id.clone(),
-        iteration,
-        output.structured_output.clone(),
-        output_file,
+        &crate::types::StepSuccess {
+            step_key: step_key.to_string(),
+            step_name: agent_label.to_string(),
+            result_text: output.result_text.clone(),
+            cost_usd: output.cost_usd,
+            num_turns: output.num_turns,
+            duration_ms: output.duration_ms,
+            input_tokens: output.input_tokens,
+            output_tokens: output.output_tokens,
+            cache_read_input_tokens: output.cache_read_input_tokens,
+            cache_creation_input_tokens: output.cache_creation_input_tokens,
+            markers: output.markers.clone(),
+            context,
+            child_run_id: output.child_run_id.clone(),
+            iteration,
+            structured_output: output.structured_output.clone(),
+            output_file,
+        },
     );
     Ok(())
 }

--- a/runkon-flow/src/executors/parallel.rs
+++ b/runkon-flow/src/executors/parallel.rs
@@ -235,12 +235,17 @@ pub fn execute_parallel(
                     Err(EngineError::Workflow(msg))
                 })
             };
-            let _ = tx.send((
+            if let Err(e) = tx.send((
                 dispatch_input.step_id,
                 dispatch_input.agent_name,
                 dispatch_input.agent_step_key,
                 result,
-            ));
+            )) {
+                tracing::warn!(
+                    "parallel: result channel broken (receiver dropped): {}",
+                    e
+                );
+            }
         });
     }
     // Drop the sender so the receiver knows when all threads have completed.

--- a/runkon-flow/src/executors/parallel.rs
+++ b/runkon-flow/src/executors/parallel.rs
@@ -267,8 +267,9 @@ pub fn execute_parallel(
     let mut successes = 0u32;
     let mut failures = 0u32;
 
-    for pr in &results {
-        match &pr.result {
+    let results_count = results.len();
+    for pr in results {
+        match pr.result {
             Ok(output) => {
                 let markers_json = crate::helpers::serialize_or_empty_array(
                     &output.markers,
@@ -299,23 +300,13 @@ pub fn execute_parallel(
                 record_step_success(
                     state,
                     pr.agent_step_key.clone(),
-                    StepSuccess {
-                        step_name: pr.agent_name.clone(),
-                        result_text: output.result_text.clone(),
-                        cost_usd: output.cost_usd,
-                        num_turns: output.num_turns,
-                        duration_ms: output.duration_ms,
-                        input_tokens: output.input_tokens,
-                        output_tokens: output.output_tokens,
-                        cache_read_input_tokens: output.cache_read_input_tokens,
-                        cache_creation_input_tokens: output.cache_creation_input_tokens,
-                        markers: output.markers.clone(),
+                    StepSuccess::from_action_output(
+                        &output,
+                        pr.agent_name.clone(),
                         context,
-                        child_run_id: output.child_run_id.clone(),
-                        structured_output: output.structured_output.clone(),
-                        output_file: None,
                         iteration,
-                    },
+                        None,
+                    ),
                 );
             }
             Err(e) => {
@@ -331,7 +322,7 @@ pub fn execute_parallel(
 
     // Apply min_success policy (skipped-on-resume agents count as successes)
     let effective_successes = successes + skipped_count;
-    let total_agents = results.len() as u32 + skipped_count;
+    let total_agents = results_count as u32 + skipped_count;
     let min_required = node.min_success.unwrap_or(total_agents);
     tracing::info!(
         "parallel: {successes} succeeded, {failures} failed, {skipped_count} skipped out of {total_agents} agents",

--- a/runkon-flow/src/executors/parallel.rs
+++ b/runkon-flow/src/executors/parallel.rs
@@ -7,7 +7,7 @@ use crate::engine_error::{EngineError, Result};
 use crate::status::WorkflowStepStatus;
 use crate::traits::action_executor::{ActionOutput, ActionParams, ExecutionContext};
 use crate::traits::persistence::{NewStep, StepUpdate};
-use crate::types::{ContextEntry, StepResult};
+use crate::types::{StepResult, StepSuccess};
 
 use super::p_err;
 
@@ -287,14 +287,23 @@ pub fn execute_parallel(
                 merged_markers.extend(output.markers.iter().cloned());
 
                 // Push parallel agent context
-                state.contexts.push(ContextEntry {
-                    step: pr.agent_name.clone(),
-                    iteration,
-                    context: context.clone(),
+                state.contexts.push(StepSuccess {
+                    step_name: pr.agent_name.clone(),
+                    result_text: output.result_text.clone(),
+                    cost_usd: output.cost_usd,
+                    num_turns: output.num_turns,
+                    duration_ms: output.duration_ms,
+                    input_tokens: output.input_tokens,
+                    output_tokens: output.output_tokens,
+                    cache_read_input_tokens: output.cache_read_input_tokens,
+                    cache_creation_input_tokens: output.cache_creation_input_tokens,
                     markers: output.markers.clone(),
+                    context: context.clone(),
+                    child_run_id: output.child_run_id.clone(),
                     structured_output: output.structured_output.clone(),
                     output_file: None,
-                });
+                    iteration,
+                }.into());
 
                 state.accumulate_metrics(
                     output.cost_usd,

--- a/runkon-flow/src/executors/parallel.rs
+++ b/runkon-flow/src/executors/parallel.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::cancellation_reason::CancellationReason;
 use crate::dsl::ParallelNode;
-use crate::engine::{resolve_schema, ExecutionState};
+use crate::engine::{record_step_success, resolve_schema, ExecutionState};
 use crate::engine_error::{EngineError, Result};
 use crate::status::WorkflowStepStatus;
 use crate::traits::action_executor::{ActionOutput, ActionParams, ExecutionContext};
@@ -36,6 +36,7 @@ pub fn execute_parallel(
     struct ParallelCallResult {
         agent_name: String,
         step_id: String,
+        agent_step_key: String,
         result: std::result::Result<ActionOutput, EngineError>,
         attempt: u32,
     }
@@ -43,6 +44,7 @@ pub fn execute_parallel(
     struct DispatchInput {
         step_id: String,
         agent_name: String,
+        agent_step_key: String,
         ectx: ExecutionContext,
         params: ActionParams,
     }
@@ -101,7 +103,7 @@ pub fn execute_parallel(
     // to exit early when fail_fast fires.
     let scope_token = state.cancellation.child();
 
-    for (i, _agent_step_key, call_schema, effective_with) in call_inputs {
+    for (i, agent_step_key, call_schema, effective_with) in call_inputs {
         let pos = pos_base + i as i64;
         let agent_ref = &node.calls[i];
         let agent_label = agent_ref.label();
@@ -191,6 +193,7 @@ pub fn execute_parallel(
         dispatch_queue.push(DispatchInput {
             step_id,
             agent_name: agent_label.to_string(),
+            agent_step_key,
             ectx,
             params,
         });
@@ -200,6 +203,7 @@ pub fn execute_parallel(
     // so that a fail_fast cancellation from a result that arrives while threads are still
     // starting will prevent those threads from doing any work.
     let (completion_tx, completion_rx) = std::sync::mpsc::channel::<(
+        String,
         String,
         String,
         std::result::Result<ActionOutput, EngineError>,
@@ -231,7 +235,12 @@ pub fn execute_parallel(
                     Err(EngineError::Workflow(msg))
                 })
             };
-            let _ = tx.send((dispatch_input.step_id, dispatch_input.agent_name, result));
+            let _ = tx.send((
+                dispatch_input.step_id,
+                dispatch_input.agent_name,
+                dispatch_input.agent_step_key,
+                result,
+            ));
         });
     }
     // Drop the sender so the receiver knows when all threads have completed.
@@ -239,11 +248,12 @@ pub fn execute_parallel(
 
     // Collect results as threads complete, triggering fail_fast cancellation as needed.
     let mut results: Vec<ParallelCallResult> = Vec::new();
-    for (step_id, agent_name, result) in completion_rx {
+    for (step_id, agent_name, agent_step_key, result) in completion_rx {
         let failed = result.is_err();
         results.push(ParallelCallResult {
             agent_name,
             step_id,
+            agent_step_key,
             result,
             attempt: 0,
         });
@@ -286,38 +296,27 @@ pub fn execute_parallel(
                 successes += 1;
                 merged_markers.extend(output.markers.iter().cloned());
 
-                // Push parallel agent context
-                state.contexts.push(StepSuccess {
-                    step_name: pr.agent_name.clone(),
-                    result_text: output.result_text.clone(),
-                    cost_usd: output.cost_usd,
-                    num_turns: output.num_turns,
-                    duration_ms: output.duration_ms,
-                    input_tokens: output.input_tokens,
-                    output_tokens: output.output_tokens,
-                    cache_read_input_tokens: output.cache_read_input_tokens,
-                    cache_creation_input_tokens: output.cache_creation_input_tokens,
-                    markers: output.markers.clone(),
-                    context: context.clone(),
-                    child_run_id: output.child_run_id.clone(),
-                    structured_output: output.structured_output.clone(),
-                    output_file: None,
-                    iteration,
-                }.into());
-
-                state.accumulate_metrics(
-                    output.cost_usd,
-                    output.num_turns,
-                    output.duration_ms,
-                    output.input_tokens,
-                    output.output_tokens,
-                    output.cache_read_input_tokens,
-                    output.cache_creation_input_tokens,
+                record_step_success(
+                    state,
+                    pr.agent_step_key.clone(),
+                    StepSuccess {
+                        step_name: pr.agent_name.clone(),
+                        result_text: output.result_text.clone(),
+                        cost_usd: output.cost_usd,
+                        num_turns: output.num_turns,
+                        duration_ms: output.duration_ms,
+                        input_tokens: output.input_tokens,
+                        output_tokens: output.output_tokens,
+                        cache_read_input_tokens: output.cache_read_input_tokens,
+                        cache_creation_input_tokens: output.cache_creation_input_tokens,
+                        markers: output.markers.clone(),
+                        context,
+                        child_run_id: output.child_run_id.clone(),
+                        structured_output: output.structured_output.clone(),
+                        output_file: None,
+                        iteration,
+                    },
                 );
-
-                if let Err(e) = state.flush_metrics() {
-                    tracing::warn!("Failed to flush mid-run metrics after parallel agent: {e}");
-                }
             }
             Err(e) => {
                 tracing::warn!("parallel: '{}' failed: {e}", pr.agent_name);

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -182,6 +182,7 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
     const SENSITIVE_ENV_VARS: &[&str] = &[
         "LD_PRELOAD",
         "LD_LIBRARY_PATH",
+        "DYLD_LIBRARY_PATH",
         "PATH",
         "DYLD_INSERT_LIBRARIES",
         "PYTHONPATH",
@@ -199,10 +200,11 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
         }
         if SENSITIVE_ENV_VARS.contains(&k.as_str()) {
             tracing::warn!(
-                "script '{}': env block overrides security-sensitive variable {:?}",
+                "script '{}': env block overrides security-sensitive variable {:?} — skipping",
                 node.name,
                 k
             );
+            continue;
         }
         let resolved = crate::prompt_builder::substitute_variables(v, &vars);
         env_vars.insert(k.clone(), resolved);

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -101,8 +101,8 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
 
         record_step_success(
             state,
-            &crate::types::StepSuccess {
-                step_key: node.name.clone(),
+            node.name.clone(),
+            crate::types::StepSuccess {
                 step_name: node.name.clone(),
                 result_text: Some("dry-run: script not executed".to_string()),
                 iteration,
@@ -315,8 +315,8 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
 
             record_step_success(
                 state,
-                &crate::types::StepSuccess {
-                    step_key: node.name.clone(),
+                node.name.clone(),
+                crate::types::StepSuccess {
                     step_name: node.name.clone(),
                     result_text: Some(format!("Script '{}' completed", node.name)),
                     duration_ms: Some(duration_ms),

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -1,4 +1,5 @@
-use std::path::{Path, PathBuf};
+use std::io::Read;
+use std::path::Path;
 
 use crate::dsl::ScriptNode;
 use crate::engine::{
@@ -13,33 +14,7 @@ use crate::traits::run_context::RunContext;
 
 use super::p_err;
 
-/// Create a named temp file that persists after the handle is dropped.
-///
-/// Logs a warning on any failure mode so the caller can see why capture is missing.
-fn make_temp_file(step_name: &str, purpose: &str) -> Option<PathBuf> {
-    match tempfile::NamedTempFile::new() {
-        Ok(f) => {
-            let path = f.path().to_path_buf();
-            match f.keep() {
-                Ok(_) => Some(path),
-                Err(e) => {
-                    tracing::warn!(
-                        "script '{}': failed to persist temp {purpose} file: {e}",
-                        step_name
-                    );
-                    None
-                }
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                "script '{}': failed to create temp {purpose} file: {e}",
-                step_name
-            );
-            None
-        }
-    }
-}
+use wait_timeout::ChildExt;
 
 fn apply_script_on_fail(
     state: &mut ExecutionState,
@@ -212,9 +187,6 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
 
     // Execute the script
     let working_dir = &state.worktree_ctx.working_dir;
-    let output_file = make_temp_file(&node.name, "stdout");
-    // Redirect stderr to a temp file so it never leaks to the TUI terminal.
-    let stderr_file = make_temp_file(&node.name, "stderr");
 
     let mut cmd = std::process::Command::new("sh");
     cmd.arg("-c").arg(&script_cmd);
@@ -222,171 +194,14 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
     for (k, v) in &env_vars {
         cmd.env(k, v);
     }
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
 
-    // Optionally capture stdout to output file
-    if let Some(ref out_path) = output_file {
-        match std::fs::File::create(out_path) {
-            Ok(file) => {
-                cmd.stdout(file);
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "script '{}': failed to open stdout file for writing: {e}",
-                    node.name
-                );
-            }
-        }
-    }
-
-    // Redirect stderr to a temp file so it never leaks to the TUI terminal.
-    if let Some(ref err_path) = stderr_file {
-        match std::fs::File::create(err_path) {
-            Ok(file) => {
-                cmd.stderr(file);
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "script '{}': failed to open stderr capture file: {e}",
-                    node.name
-                );
-            }
-        }
-    }
-
-    let start = std::time::Instant::now();
-    let result = cmd.status();
-    let duration_ms = start.elapsed().as_millis() as i64;
-
-    match result {
-        Ok(status) if status.success() => {
-            tracing::info!(
-                "script '{}': completed successfully in {}ms",
-                node.name,
-                duration_ms
-            );
-
-            // Clean up stderr capture file on success.
-            if let Some(ref p) = stderr_file {
-                let _ = std::fs::remove_file(p);
-            }
-
-            // Read stdout and parse the CONDUCTOR_OUTPUT block so markers like
-            // `has_code_changes` are available to downstream `if` conditions.
-            let stdout = output_file.as_ref().and_then(|p| {
-                std::fs::read_to_string(p)
-                    .map_err(|e| {
-                        tracing::warn!("script '{}': failed to read stdout: {e}", node.name)
-                    })
-                    .ok()
-            });
-            let (markers, context) = stdout
-                .as_deref()
-                .and_then(crate::helpers::parse_conductor_output)
-                .map(|out| (out.markers, out.context))
-                .unwrap_or_else(|| {
-                    let ctx = stdout.as_deref().unwrap_or("").chars().take(2000).collect();
-                    (vec![], ctx)
-                });
-
-            let markers_json = crate::helpers::serialize_or_empty_array(
-                &markers,
-                &format!("script '{}'", node.name),
-            );
-            let output_file_path = output_file
-                .as_ref()
-                .map(|p| p.to_string_lossy().to_string());
-
-            state
-                .persistence
-                .update_step(
-                    &step_id,
-                    StepUpdate {
-                        status: WorkflowStepStatus::Completed,
-                        child_run_id: None,
-                        result_text: Some(format!("Script '{}' completed", node.name)),
-                        context_out: Some(context.clone()),
-                        markers_out: Some(markers_json),
-                        retry_count: Some(0),
-                        structured_output: None,
-                        step_error: None,
-                    },
-                )
-                .map_err(p_err)?;
-
-            record_step_success(
-                state,
-                node.name.clone(),
-                crate::types::StepSuccess {
-                    step_name: node.name.clone(),
-                    result_text: Some(format!("Script '{}' completed", node.name)),
-                    duration_ms: Some(duration_ms),
-                    markers,
-                    context,
-                    iteration,
-                    output_file: output_file_path,
-                    ..crate::types::StepSuccess::default()
-                },
-            );
-
-            Ok(())
-        }
-        Ok(status) => {
-            let exit_code = status.code().unwrap_or(-1);
-
-            // Read captured stderr (up to 2 000 chars) to include in the error.
-            let captured_stderr = stderr_file.as_ref().and_then(|p| {
-                std::fs::read_to_string(p)
-                    .map_err(|e| {
-                        tracing::warn!(
-                            "script '{}': failed to read captured stderr: {e}",
-                            node.name
-                        )
-                    })
-                    .ok()
-                    .map(|s| s.trim().chars().take(2000).collect::<String>())
-                    .filter(|s| !s.is_empty())
-            });
-
-            let err_msg = match &captured_stderr {
-                Some(stderr) => format!(
-                    "Script '{}' exited with code {}\n{}",
-                    node.name, exit_code, stderr
-                ),
-                None => format!("Script '{}' exited with code {}", node.name, exit_code),
-            };
-            tracing::warn!("{}", err_msg);
-
-            state
-                .persistence
-                .update_step(
-                    &step_id,
-                    StepUpdate {
-                        status: WorkflowStepStatus::Failed,
-                        child_run_id: None,
-                        result_text: Some(err_msg.clone()),
-                        context_out: None,
-                        markers_out: None,
-                        retry_count: Some(0),
-                        structured_output: None,
-                        step_error: Some(err_msg.clone()),
-                    },
-                )
-                .map_err(p_err)?;
-
-            // Clean up output file and stderr file on failure
-            if let Some(ref p) = output_file {
-                let _ = std::fs::remove_file(p);
-            }
-            if let Some(ref p) = stderr_file {
-                let _ = std::fs::remove_file(p);
-            }
-
-            apply_script_on_fail(state, &node.name, &node.on_fail, err_msg)
-        }
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
         Err(e) => {
             let err_msg = format!("Script '{}' failed to execute: {e}", node.name);
             tracing::warn!("{}", err_msg);
-
             state
                 .persistence
                 .update_step(
@@ -403,13 +218,201 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
                     },
                 )
                 .map_err(p_err)?;
-
-            if let Some(ref p) = stderr_file {
-                let _ = std::fs::remove_file(p);
-            }
-
-            apply_script_on_fail(state, &node.name, &node.on_fail, err_msg)
+            return apply_script_on_fail(state, &node.name, &node.on_fail, err_msg);
         }
+    };
+
+    let start = std::time::Instant::now();
+
+    let status = if let Some(timeout_secs) = node.timeout {
+        let timeout = std::time::Duration::from_secs(timeout_secs);
+        match child.wait_timeout(timeout) {
+            Ok(Some(s)) => s,
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _duration_ms = start.elapsed().as_millis() as i64;
+                let err_msg = format!(
+                    "Script '{}' timed out after {}s",
+                    node.name, timeout_secs
+                );
+                tracing::warn!("{}", err_msg);
+                state
+                    .persistence
+                    .update_step(
+                        &step_id,
+                        StepUpdate {
+                            status: WorkflowStepStatus::Failed,
+                            child_run_id: None,
+                            result_text: Some(err_msg.clone()),
+                            context_out: None,
+                            markers_out: None,
+                            retry_count: Some(0),
+                            structured_output: None,
+                            step_error: Some(err_msg.clone()),
+                        },
+                    )
+                    .map_err(p_err)?;
+                return apply_script_on_fail(state, &node.name, &node.on_fail, err_msg);
+            }
+            Err(e) => {
+                let err_msg = format!("Script '{}' wait failed: {e}", node.name);
+                tracing::warn!("{}", err_msg);
+                state
+                    .persistence
+                    .update_step(
+                        &step_id,
+                        StepUpdate {
+                            status: WorkflowStepStatus::Failed,
+                            child_run_id: None,
+                            result_text: Some(err_msg.clone()),
+                            context_out: None,
+                            markers_out: None,
+                            retry_count: Some(0),
+                            structured_output: None,
+                            step_error: Some(err_msg.clone()),
+                        },
+                    )
+                    .map_err(p_err)?;
+                return apply_script_on_fail(state, &node.name, &node.on_fail, err_msg);
+            }
+        }
+    } else {
+        match child.wait() {
+            Ok(s) => s,
+            Err(e) => {
+                let err_msg = format!("Script '{}' wait failed: {e}", node.name);
+                tracing::warn!("{}", err_msg);
+                state
+                    .persistence
+                    .update_step(
+                        &step_id,
+                        StepUpdate {
+                            status: WorkflowStepStatus::Failed,
+                            child_run_id: None,
+                            result_text: Some(err_msg.clone()),
+                            context_out: None,
+                            markers_out: None,
+                            retry_count: Some(0),
+                            structured_output: None,
+                            step_error: Some(err_msg.clone()),
+                        },
+                    )
+                    .map_err(p_err)?;
+                return apply_script_on_fail(state, &node.name, &node.on_fail, err_msg);
+            }
+        }
+    };
+    let duration_ms = start.elapsed().as_millis() as i64;
+
+    // Read stdout/stderr from pipes after the child has exited.
+    let stdout = child
+        .stdout
+        .take()
+        .and_then(|mut pipe| {
+            let mut buf = Vec::new();
+            pipe.read_to_end(&mut buf).ok()?;
+            String::from_utf8(buf).ok()
+        })
+        .unwrap_or_default();
+    let stderr = child
+        .stderr
+        .take()
+        .and_then(|mut pipe| {
+            let mut buf = Vec::new();
+            pipe.read_to_end(&mut buf).ok()?;
+            String::from_utf8(buf).ok()
+        })
+        .unwrap_or_default();
+
+    if status.success() {
+        tracing::info!(
+            "script '{}': completed successfully in {}ms",
+            node.name,
+            duration_ms
+        );
+
+        let (markers, context) = crate::helpers::parse_conductor_output(&stdout)
+            .map(|out| (out.markers, out.context))
+            .unwrap_or_else(|| {
+                let ctx = stdout.chars().take(2000).collect();
+                (vec![], ctx)
+            });
+
+        let markers_json = crate::helpers::serialize_or_empty_array(
+            &markers,
+            &format!("script '{}'", node.name),
+        );
+
+        state
+            .persistence
+            .update_step(
+                &step_id,
+                StepUpdate {
+                    status: WorkflowStepStatus::Completed,
+                    child_run_id: None,
+                    result_text: Some(format!("Script '{}' completed", node.name)),
+                    context_out: Some(context.clone()),
+                    markers_out: Some(markers_json),
+                    retry_count: Some(0),
+                    structured_output: None,
+                    step_error: None,
+                },
+            )
+            .map_err(p_err)?;
+
+        record_step_success(
+            state,
+            node.name.clone(),
+            crate::types::StepSuccess {
+                step_name: node.name.clone(),
+                result_text: Some(format!("Script '{}' completed", node.name)),
+                duration_ms: Some(duration_ms),
+                markers,
+                context,
+                iteration,
+                ..crate::types::StepSuccess::default()
+            },
+        );
+
+        Ok(())
+    } else {
+        let exit_code = status.code().unwrap_or(-1);
+
+        let captured_stderr = stderr
+            .trim()
+            .chars()
+            .take(2000)
+            .collect::<String>();
+
+        let err_msg = if captured_stderr.is_empty() {
+            format!("Script '{}' exited with code {}", node.name, exit_code)
+        } else {
+            format!(
+                "Script '{}' exited with code {}\n{}",
+                node.name, exit_code, captured_stderr
+            )
+        };
+        tracing::warn!("{}", err_msg);
+
+        state
+            .persistence
+            .update_step(
+                &step_id,
+                StepUpdate {
+                    status: WorkflowStepStatus::Failed,
+                    child_run_id: None,
+                    result_text: Some(err_msg.clone()),
+                    context_out: None,
+                    markers_out: None,
+                    retry_count: Some(0),
+                    structured_output: None,
+                    step_error: Some(err_msg.clone()),
+                },
+            )
+            .map_err(p_err)?;
+
+        apply_script_on_fail(state, &node.name, &node.on_fail, err_msg)
     }
 }
 

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -219,8 +219,21 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
     // Spawn reader threads BEFORE waiting for the child to avoid pipe deadlock.
     // If the child writes more than the OS pipe buffer size to either stream
     // while the parent is blocked in wait(), the child would hang forever.
+    fn spawn_reader_thread<R: Read + Send + 'static>(
+        mut pipe: R,
+        stream_name: &'static str,
+    ) -> std::thread::JoinHandle<Vec<u8>> {
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            if let Err(e) = pipe.read_to_end(&mut buf) {
+                tracing::warn!("script: failed to read {stream_name} pipe: {e}");
+            }
+            buf
+        })
+    }
+
     let stdout_handle = {
-        let mut pipe = match child.stdout.take() {
+        let pipe = match child.stdout.take() {
             Some(p) => p,
             None => {
                 return fail_script_step(
@@ -234,16 +247,10 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
                 );
             }
         };
-        std::thread::spawn(move || {
-            let mut buf = Vec::new();
-            if let Err(e) = pipe.read_to_end(&mut buf) {
-                tracing::warn!("script: failed to read stdout pipe: {e}");
-            }
-            buf
-        })
+        spawn_reader_thread(pipe, "stdout")
     };
     let stderr_handle = {
-        let mut pipe = match child.stderr.take() {
+        let pipe = match child.stderr.take() {
             Some(p) => p,
             None => {
                 return fail_script_step(
@@ -257,13 +264,7 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
                 );
             }
         };
-        std::thread::spawn(move || {
-            let mut buf = Vec::new();
-            if let Err(e) = pipe.read_to_end(&mut buf) {
-                tracing::warn!("script: failed to read stderr pipe: {e}");
-            }
-            buf
-        })
+        spawn_reader_thread(pipe, "stderr")
     };
 
     let start = std::time::Instant::now();
@@ -769,5 +770,56 @@ mod tests {
         assert_eq!(steps.len(), 1);
         let step = &steps[0];
         assert_eq!(step.status, WorkflowStepStatus::Completed);
+    }
+
+    /// A non-success exit code with stderr output must capture stderr in the step error.
+    #[test]
+    fn non_success_exit_with_stderr_capture() {
+        let (persistence, run_id) = make_persistence();
+        let mut state = make_state(Arc::clone(&persistence), run_id.clone());
+        let node = ScriptNode {
+            name: "fails-with-stderr".to_string(),
+            run: "echo 'error details' >&2 && exit 1".to_string(),
+            env: Default::default(),
+            timeout: None,
+            retries: 0,
+            on_fail: None,
+            bot_name: None,
+        };
+        let result = execute_script(&mut state, &node, 0);
+        assert!(result.is_err(), "expected failure for non-zero exit");
+
+        let steps = persistence.get_steps(&run_id).unwrap();
+        assert_eq!(steps.len(), 1);
+        let step = &steps[0];
+        assert_eq!(step.status, WorkflowStepStatus::Failed);
+        let err_text = step.result_text.as_deref().unwrap_or("");
+        assert!(
+            err_text.contains("error details"),
+            "stderr should be captured in error message: {err_text}"
+        );
+    }
+
+    /// Non-UTF-8 stderr on a failed script must not panic; the step is marked Failed.
+    #[test]
+    fn non_utf8_stderr_is_handled_gracefully() {
+        let (persistence, run_id) = make_persistence();
+        let mut state = make_state(Arc::clone(&persistence), run_id.clone());
+        let node = ScriptNode {
+            name: "bad-stderr".to_string(),
+            run: "python3 -c \"import sys; sys.stderr.buffer.write(bytes([0x80,0x81,0x82])); sys.exit(1)\"".to_string(),
+            env: Default::default(),
+            timeout: None,
+            retries: 0,
+            on_fail: None,
+            bot_name: None,
+        };
+        let result = execute_script(&mut state, &node, 0);
+        assert!(result.is_err(), "expected failure for non-zero exit");
+
+        let steps = persistence.get_steps(&run_id).unwrap();
+        assert_eq!(steps.len(), 1);
+        let step = &steps[0];
+        assert_eq!(step.status, WorkflowStepStatus::Failed);
     }
 }

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -31,6 +31,21 @@ fn apply_script_on_fail(
     }
 }
 
+/// Persist a script step failure and apply on_fail logic in one call.
+fn fail_script_step(
+    state: &mut ExecutionState,
+    step_id: &str,
+    node: &ScriptNode,
+    err_msg: String,
+) -> Result<()> {
+    tracing::warn!("{}", err_msg);
+    state
+        .persistence
+        .update_step(step_id, StepUpdate::failed(err_msg.clone(), 0))
+        .map_err(p_err)?;
+    apply_script_on_fail(state, &node.name, &node.on_fail, err_msg)
+}
+
 pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: u32) -> Result<()> {
     let pos = state.position;
     state.position += 1;
@@ -200,26 +215,37 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
     let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
-            let err_msg = format!("Script '{}' failed to execute: {e}", node.name);
-            tracing::warn!("{}", err_msg);
-            state
-                .persistence
-                .update_step(
-                    &step_id,
-                    StepUpdate {
-                        status: WorkflowStepStatus::Failed,
-                        child_run_id: None,
-                        result_text: Some(err_msg.clone()),
-                        context_out: None,
-                        markers_out: None,
-                        retry_count: Some(0),
-                        structured_output: None,
-                        step_error: Some(err_msg.clone()),
-                    },
-                )
-                .map_err(p_err)?;
-            return apply_script_on_fail(state, &node.name, &node.on_fail, err_msg);
+            return fail_script_step(
+                state,
+                &step_id,
+                node,
+                format!("Script '{}' failed to execute: {e}", node.name),
+            );
         }
+    };
+
+    // Spawn reader threads BEFORE waiting for the child to avoid pipe deadlock.
+    // If the child writes more than the OS pipe buffer size to either stream
+    // while the parent is blocked in wait(), the child would hang forever.
+    let stdout_handle = {
+        let mut pipe = child.stdout.take().expect("stdout was piped");
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            if let Err(e) = pipe.read_to_end(&mut buf) {
+                tracing::warn!("script: failed to read stdout pipe: {e}");
+            }
+            buf
+        })
+    };
+    let stderr_handle = {
+        let mut pipe = child.stderr.take().expect("stderr was piped");
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            if let Err(e) = pipe.read_to_end(&mut buf) {
+                tracing::warn!("script: failed to read stderr pipe: {e}");
+            }
+            buf
+        })
     };
 
     let start = std::time::Instant::now();
@@ -231,101 +257,62 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
             Ok(None) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                let _duration_ms = start.elapsed().as_millis() as i64;
-                let err_msg = format!(
-                    "Script '{}' timed out after {}s",
-                    node.name, timeout_secs
+                let _ = stdout_handle.join();
+                let _ = stderr_handle.join();
+                return fail_script_step(
+                    state,
+                    &step_id,
+                    node,
+                    format!("Script '{}' timed out after {}s", node.name, timeout_secs),
                 );
-                tracing::warn!("{}", err_msg);
-                state
-                    .persistence
-                    .update_step(
-                        &step_id,
-                        StepUpdate {
-                            status: WorkflowStepStatus::Failed,
-                            child_run_id: None,
-                            result_text: Some(err_msg.clone()),
-                            context_out: None,
-                            markers_out: None,
-                            retry_count: Some(0),
-                            structured_output: None,
-                            step_error: Some(err_msg.clone()),
-                        },
-                    )
-                    .map_err(p_err)?;
-                return apply_script_on_fail(state, &node.name, &node.on_fail, err_msg);
             }
             Err(e) => {
-                let err_msg = format!("Script '{}' wait failed: {e}", node.name);
-                tracing::warn!("{}", err_msg);
-                state
-                    .persistence
-                    .update_step(
-                        &step_id,
-                        StepUpdate {
-                            status: WorkflowStepStatus::Failed,
-                            child_run_id: None,
-                            result_text: Some(err_msg.clone()),
-                            context_out: None,
-                            markers_out: None,
-                            retry_count: Some(0),
-                            structured_output: None,
-                            step_error: Some(err_msg.clone()),
-                        },
-                    )
-                    .map_err(p_err)?;
-                return apply_script_on_fail(state, &node.name, &node.on_fail, err_msg);
+                let _ = stdout_handle.join();
+                let _ = stderr_handle.join();
+                return fail_script_step(
+                    state,
+                    &step_id,
+                    node,
+                    format!("Script '{}' wait failed: {e}", node.name),
+                );
             }
         }
     } else {
         match child.wait() {
             Ok(s) => s,
             Err(e) => {
-                let err_msg = format!("Script '{}' wait failed: {e}", node.name);
-                tracing::warn!("{}", err_msg);
-                state
-                    .persistence
-                    .update_step(
-                        &step_id,
-                        StepUpdate {
-                            status: WorkflowStepStatus::Failed,
-                            child_run_id: None,
-                            result_text: Some(err_msg.clone()),
-                            context_out: None,
-                            markers_out: None,
-                            retry_count: Some(0),
-                            structured_output: None,
-                            step_error: Some(err_msg.clone()),
-                        },
-                    )
-                    .map_err(p_err)?;
-                return apply_script_on_fail(state, &node.name, &node.on_fail, err_msg);
+                let _ = stdout_handle.join();
+                let _ = stderr_handle.join();
+                return fail_script_step(
+                    state,
+                    &step_id,
+                    node,
+                    format!("Script '{}' wait failed: {e}", node.name),
+                );
             }
         }
     };
     let duration_ms = start.elapsed().as_millis() as i64;
 
-    // Read stdout/stderr from pipes after the child has exited.
-    let stdout = child
-        .stdout
-        .take()
-        .and_then(|mut pipe| {
-            let mut buf = Vec::new();
-            pipe.read_to_end(&mut buf).ok()?;
-            String::from_utf8(buf).ok()
-        })
-        .unwrap_or_default();
-    let stderr = child
-        .stderr
-        .take()
-        .and_then(|mut pipe| {
-            let mut buf = Vec::new();
-            pipe.read_to_end(&mut buf).ok()?;
-            String::from_utf8(buf).ok()
-        })
-        .unwrap_or_default();
+    let stdout = match stdout_handle.join() {
+        Ok(buf) => match String::from_utf8(buf) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("script: stdout is not valid UTF-8: {e}");
+                String::new()
+            }
+        },
+        Err(_) => {
+            tracing::warn!("script: stdout reader thread panicked");
+            String::new()
+        }
+    };
 
     if status.success() {
+        // Discard stderr on success — join the thread so it doesn't leak,
+        // but don't convert to String to avoid unnecessary allocation.
+        let _ = stderr_handle.join();
+
         tracing::info!(
             "script '{}': completed successfully in {}ms",
             node.name,
@@ -379,6 +366,20 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
     } else {
         let exit_code = status.code().unwrap_or(-1);
 
+        let stderr = match stderr_handle.join() {
+            Ok(buf) => match String::from_utf8(buf) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("script: stderr is not valid UTF-8: {e}");
+                    String::new()
+                }
+            },
+            Err(_) => {
+                tracing::warn!("script: stderr reader thread panicked");
+                String::new()
+            }
+        };
+
         let captured_stderr = stderr
             .trim()
             .chars()
@@ -393,26 +394,8 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
                 node.name, exit_code, captured_stderr
             )
         };
-        tracing::warn!("{}", err_msg);
 
-        state
-            .persistence
-            .update_step(
-                &step_id,
-                StepUpdate {
-                    status: WorkflowStepStatus::Failed,
-                    child_run_id: None,
-                    result_text: Some(err_msg.clone()),
-                    context_out: None,
-                    markers_out: None,
-                    retry_count: Some(0),
-                    structured_output: None,
-                    step_error: Some(err_msg.clone()),
-                },
-            )
-            .map_err(p_err)?;
-
-        apply_script_on_fail(state, &node.name, &node.on_fail, err_msg)
+        fail_script_step(state, &step_id, node, err_msg)
     }
 }
 
@@ -695,6 +678,35 @@ mod tests {
         assert!(
             !ctx.contains("/malicious/lib"),
             "DYLD_LIBRARY_PATH should be blocked; context: {ctx:?}"
+        );
+    }
+
+    /// A script that exceeds its timeout is killed and the step is marked Failed.
+    #[test]
+    fn script_timeout_kills_long_running_process() {
+        let (persistence, run_id) = make_persistence();
+        let mut state = make_state(Arc::clone(&persistence), run_id.clone());
+        let node = ScriptNode {
+            name: "sleepy".to_string(),
+            run: "sleep 5".to_string(),
+            env: Default::default(),
+            timeout: Some(1), // 1 second timeout
+            retries: 0,
+            on_fail: None,
+            bot_name: None,
+        };
+        let result = execute_script(&mut state, &node, 0);
+        // on_fail is None, so failure should return Err.
+        assert!(result.is_err(), "expected timeout error");
+
+        let steps = persistence.get_steps(&run_id).unwrap();
+        assert_eq!(steps.len(), 1);
+        let step = &steps[0];
+        assert_eq!(step.status, WorkflowStepStatus::Failed);
+        let err_text = step.result_text.as_deref().unwrap_or("");
+        assert!(
+            err_text.contains("timed out"),
+            "error should mention timeout: {err_text}"
         );
     }
 }

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -101,22 +101,13 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
 
         record_step_success(
             state,
-            node.name.clone(),
-            &node.name,
-            Some("dry-run: script not executed".to_string()),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            vec![],
-            String::new(),
-            None,
-            iteration,
-            None,
-            None,
+            &crate::types::StepSuccess {
+                step_key: node.name.clone(),
+                step_name: node.name.clone(),
+                result_text: Some("dry-run: script not executed".to_string()),
+                iteration,
+                ..crate::types::StepSuccess::default()
+            },
         );
         return Ok(());
     }
@@ -322,22 +313,17 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
 
             record_step_success(
                 state,
-                node.name.clone(),
-                &node.name,
-                Some(format!("Script '{}' completed", node.name)),
-                None,
-                None,
-                Some(duration_ms),
-                None,
-                None,
-                None,
-                None,
-                markers,
-                context,
-                None,
-                iteration,
-                None,
-                output_file_path,
+                &crate::types::StepSuccess {
+                    step_key: node.name.clone(),
+                    step_name: node.name.clone(),
+                    result_text: Some(format!("Script '{}' completed", node.name)),
+                    duration_ms: Some(duration_ms),
+                    markers,
+                    context,
+                    iteration,
+                    output_file: output_file_path,
+                    ..crate::types::StepSuccess::default()
+                },
             );
 
             Ok(())

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -8,7 +8,6 @@ use crate::engine::{
 };
 use crate::engine_error::Result;
 use crate::prompt_builder::build_variable_map;
-use crate::status::WorkflowStepStatus;
 use crate::traits::persistence::{NewStep, StepUpdate};
 use crate::traits::run_context::RunContext;
 
@@ -72,23 +71,16 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
 
     if state.exec_config.dry_run {
         tracing::info!("script '{}': dry-run, skipping execution", node.name);
-        state
-            .persistence
-            .update_step(
-                &step_id,
-                StepUpdate {
-                    status: WorkflowStepStatus::Completed,
-                    child_run_id: None,
-                    result_text: Some("dry-run: script not executed".to_string()),
-                    context_out: None,
-                    markers_out: None,
-                    retry_count: Some(0),
-                    structured_output: None,
-                    step_error: None,
-                },
-            )
-            .map_err(p_err)?;
-
+        super::persist_completed_step(
+            state,
+            &step_id,
+            None,
+            Some("dry-run: script not executed".to_string()),
+            None,
+            None,
+            0,
+            None,
+        )?;
         record_step_success(
             state,
             node.name.clone(),
@@ -228,7 +220,20 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
     // If the child writes more than the OS pipe buffer size to either stream
     // while the parent is blocked in wait(), the child would hang forever.
     let stdout_handle = {
-        let mut pipe = child.stdout.take().expect("stdout was piped");
+        let mut pipe = match child.stdout.take() {
+            Some(p) => p,
+            None => {
+                return fail_script_step(
+                    state,
+                    &step_id,
+                    node,
+                    format!(
+                        "script '{}': stdout pipe unavailable after spawn",
+                        node.name
+                    ),
+                );
+            }
+        };
         std::thread::spawn(move || {
             let mut buf = Vec::new();
             if let Err(e) = pipe.read_to_end(&mut buf) {
@@ -238,7 +243,20 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
         })
     };
     let stderr_handle = {
-        let mut pipe = child.stderr.take().expect("stderr was piped");
+        let mut pipe = match child.stderr.take() {
+            Some(p) => p,
+            None => {
+                return fail_script_step(
+                    state,
+                    &step_id,
+                    node,
+                    format!(
+                        "script '{}': stderr pipe unavailable after spawn",
+                        node.name
+                    ),
+                );
+            }
+        };
         std::thread::spawn(move || {
             let mut buf = Vec::new();
             if let Err(e) = pipe.read_to_end(&mut buf) {
@@ -331,22 +349,16 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
             &format!("script '{}'", node.name),
         );
 
-        state
-            .persistence
-            .update_step(
-                &step_id,
-                StepUpdate {
-                    status: WorkflowStepStatus::Completed,
-                    child_run_id: None,
-                    result_text: Some(format!("Script '{}' completed", node.name)),
-                    context_out: Some(context.clone()),
-                    markers_out: Some(markers_json),
-                    retry_count: Some(0),
-                    structured_output: None,
-                    step_error: None,
-                },
-            )
-            .map_err(p_err)?;
+        super::persist_completed_step(
+            state,
+            &step_id,
+            None,
+            Some(format!("Script '{}' completed", node.name)),
+            Some(context.clone()),
+            Some(markers_json),
+            0,
+            None,
+        )?;
 
         record_step_success(
             state,
@@ -404,6 +416,7 @@ mod tests {
     use super::*;
     use crate::dsl::ScriptNode;
     use crate::engine::{ExecutionState, WorktreeContext};
+    use crate::status::WorkflowStepStatus;
     use crate::persistence_memory::InMemoryWorkflowPersistence;
     use crate::traits::action_executor::ActionRegistry;
     use crate::traits::item_provider::ItemProviderRegistry;
@@ -708,5 +721,53 @@ mod tests {
             err_text.contains("timed out"),
             "error should mention timeout: {err_text}"
         );
+    }
+
+    /// A script that writes more than the OS pipe buffer to stdout must not deadlock.
+    /// This is a regression test for the pipe-deadlock fix (reader threads spawned
+    /// before wait()).
+    #[test]
+    fn pipe_deadlock_regression_large_stdout() {
+        let (persistence, run_id) = make_persistence();
+        let mut state = make_state(Arc::clone(&persistence), run_id.clone());
+        // Output 128KB of 'x' to stdout — well above the typical 64KB pipe buffer.
+        let node = ScriptNode {
+            name: "bigout".to_string(),
+            run: "python3 -c \"import sys; sys.stdout.write('x' * 131072)\"".to_string(),
+            env: Default::default(),
+            timeout: None,
+            retries: 0,
+            on_fail: None,
+            bot_name: None,
+        };
+        execute_script(&mut state, &node, 0).unwrap();
+
+        let steps = persistence.get_steps(&run_id).unwrap();
+        assert_eq!(steps.len(), 1);
+        let step = &steps[0];
+        assert_eq!(step.status, WorkflowStepStatus::Completed);
+    }
+
+    /// Non-UTF-8 stdout is handled gracefully: the step still completes and the
+    /// invalid bytes are dropped with a logged warning.
+    #[test]
+    fn non_utf8_stdout_is_handled_gracefully() {
+        let (persistence, run_id) = make_persistence();
+        let mut state = make_state(Arc::clone(&persistence), run_id.clone());
+        let node = ScriptNode {
+            name: "binary".to_string(),
+            run: "python3 -c \"import sys; sys.stdout.buffer.write(bytes([0x80,0x81,0x82]))\"".to_string(),
+            env: Default::default(),
+            timeout: None,
+            retries: 0,
+            on_fail: None,
+            bot_name: None,
+        };
+        execute_script(&mut state, &node, 0).unwrap();
+
+        let steps = persistence.get_steps(&run_id).unwrap();
+        assert_eq!(steps.len(), 1);
+        let step = &steps[0];
+        assert_eq!(step.status, WorkflowStepStatus::Completed);
     }
 }

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -655,4 +655,43 @@ mod tests {
             "template in env value should be substituted; context: {ctx:?}"
         );
     }
+
+    /// Security-sensitive env vars in node.env are skipped, not injected.
+    #[test]
+    fn sensitive_env_vars_are_blocked() {
+        let (persistence, run_id) = make_persistence();
+        let mut state = make_state(Arc::clone(&persistence), run_id.clone());
+
+        let mut env = HashMap::new();
+        env.insert("LD_PRELOAD".to_string(), "/malicious/lib.so".to_string());
+        env.insert("DYLD_LIBRARY_PATH".to_string(), "/malicious/lib".to_string());
+        env.insert("SAFE_VAR".to_string(), "allowed_value".to_string());
+        let node = ScriptNode {
+            name: "sensitive-test".to_string(),
+            run: "echo SAFE_VAR=[$SAFE_VAR] LD_PRELOAD=[$LD_PRELOAD] DYLD_LIBRARY_PATH=[$DYLD_LIBRARY_PATH]".to_string(),
+            env,
+            timeout: None,
+            retries: 0,
+            on_fail: None,
+            bot_name: None,
+        };
+        execute_script(&mut state, &node, 0).unwrap();
+
+        let steps = persistence.get_steps(&run_id).unwrap();
+        let step = &steps[0];
+        assert_eq!(step.status, WorkflowStepStatus::Completed);
+        let ctx = step.context_out.as_deref().unwrap_or("");
+        assert!(
+            ctx.contains("SAFE_VAR=[allowed_value]"),
+            "SAFE_VAR should be injected; context: {ctx:?}"
+        );
+        assert!(
+            !ctx.contains("/malicious/lib.so"),
+            "LD_PRELOAD should be blocked; context: {ctx:?}"
+        );
+        assert!(
+            !ctx.contains("/malicious/lib"),
+            "DYLD_LIBRARY_PATH should be blocked; context: {ctx:?}"
+        );
+    }
 }

--- a/runkon-flow/src/types.rs
+++ b/runkon-flow/src/types.rs
@@ -194,10 +194,11 @@ pub struct WorkflowResult {
 
 /// Input describing a successfully completed step, passed to `record_step_success`.
 ///
-/// Groups the ~16 positional arguments that previously made call sites unwieldy.
+/// Groups the step output data that previously made call sites unwieldy.
+/// Does not include `step_key` or `iteration` — those are execution bookkeeping
+/// concerns kept separate from the step output payload.
 #[derive(Debug, Clone, Default)]
 pub struct StepSuccess {
-    pub step_key: String,
     pub step_name: String,
     pub result_text: Option<String>,
     pub cost_usd: Option<f64>,
@@ -362,5 +363,28 @@ mod tests {
         assert_eq!(r.child_run_id, Some("child-1".to_string()));
         assert_eq!(r.structured_output, Some(r#"{"ok":true}"#.to_string()));
         assert_eq!(r.output_file, Some("/tmp/out".to_string()));
+    }
+
+    #[test]
+    fn completed_without_metrics_ignores_metric_fields() {
+        let success = StepSuccess {
+            step_name: "restore".to_string(),
+            result_text: Some("ok".to_string()),
+            cost_usd: Some(0.10),
+            num_turns: Some(5),
+            duration_ms: Some(3000),
+            markers: vec!["done".to_string()],
+            context: "restored".to_string(),
+            ..StepSuccess::default()
+        };
+        let r = StepResult::completed_without_metrics(&success);
+        assert_eq!(r.step_name, "restore");
+        assert_eq!(r.status, WorkflowStepStatus::Completed);
+        assert_eq!(r.result_text, Some("ok".to_string()));
+        assert!(r.cost_usd.is_none(), "cost_usd should be None");
+        assert!(r.num_turns.is_none(), "num_turns should be None");
+        assert!(r.duration_ms.is_none(), "duration_ms should be None");
+        assert_eq!(r.markers, vec!["done"]);
+        assert_eq!(r.context, "restored");
     }
 }

--- a/runkon-flow/src/types.rs
+++ b/runkon-flow/src/types.rs
@@ -195,8 +195,9 @@ pub struct WorkflowResult {
 /// Input describing a successfully completed step, passed to `record_step_success`.
 ///
 /// Groups the step output data that previously made call sites unwieldy.
-/// Does not include `step_key` or `iteration` — those are execution bookkeeping
-/// concerns kept separate from the step output payload.
+/// Does not include `step_key` — that is an execution bookkeeping concern kept
+/// as a separate parameter. `iteration` is included because it is needed to
+/// populate `ContextEntry`.
 #[derive(Debug, Clone, Default)]
 pub struct StepSuccess {
     pub step_name: String,
@@ -295,6 +296,19 @@ pub struct ContextEntry {
     pub structured_output: Option<String>,
     #[serde(default)]
     pub output_file: Option<String>,
+}
+
+impl From<StepSuccess> for ContextEntry {
+    fn from(success: StepSuccess) -> Self {
+        Self {
+            step: success.step_name,
+            iteration: success.iteration,
+            context: success.context,
+            markers: success.markers,
+            structured_output: success.structured_output,
+            output_file: success.output_file,
+        }
+    }
 }
 
 /// A single row in the `workflow_run_step_fan_out_items` table.

--- a/runkon-flow/src/types.rs
+++ b/runkon-flow/src/types.rs
@@ -377,7 +377,7 @@ pub struct FanOutItemRow {
 
 #[cfg(test)]
 mod tests {
-    use super::{StepResult, StepSuccess};
+    use super::{StepResult, StepSuccess, WorkflowRunStep};
     use crate::status::WorkflowStepStatus;
 
     #[test]
@@ -480,6 +480,40 @@ mod tests {
         assert_eq!(entry.markers, vec!["m1", "m2"]);
         assert_eq!(entry.structured_output, Some(r#"{"k":"v"}"#.to_string()));
         assert_eq!(entry.output_file, Some("/tmp/out".to_string()));
+    }
+
+    #[test]
+    fn from_workflow_run_step_maps_fields() {
+        let step = WorkflowRunStep {
+            result_text: Some("all good".to_string()),
+            child_run_id: Some("child-1".to_string()),
+            structured_output: Some(r#"{"ok":true}"#.to_string()),
+            output_file: Some("/tmp/out".to_string()),
+            ..WorkflowRunStep::default()
+        };
+        let success = StepSuccess::from_workflow_run_step(
+            "child-step".to_string(),
+            &step,
+            vec!["m1".to_string(), "m2".to_string()],
+            "ctx-body".to_string(),
+            7,
+        );
+        assert_eq!(success.step_name, "child-step");
+        assert_eq!(success.result_text, Some("all good".to_string()));
+        assert_eq!(success.markers, vec!["m1", "m2"]);
+        assert_eq!(success.context, "ctx-body");
+        assert_eq!(success.child_run_id, Some("child-1".to_string()));
+        assert_eq!(success.structured_output, Some(r#"{"ok":true}"#.to_string()));
+        assert_eq!(success.output_file, Some("/tmp/out".to_string()));
+        assert_eq!(success.iteration, 7);
+        // Metric fields should default to None
+        assert!(success.cost_usd.is_none());
+        assert!(success.num_turns.is_none());
+        assert!(success.duration_ms.is_none());
+        assert!(success.input_tokens.is_none());
+        assert!(success.output_tokens.is_none());
+        assert!(success.cache_read_input_tokens.is_none());
+        assert!(success.cache_creation_input_tokens.is_none());
     }
 
     #[test]

--- a/runkon-flow/src/types.rs
+++ b/runkon-flow/src/types.rs
@@ -255,28 +255,21 @@ impl StepResult {
     ///
     /// Convenience wrapper for the common case where cost/turns/duration are
     /// not available (e.g. restored from a prior run or bubble-up from a child
-    /// workflow).
-    pub fn completed_without_metrics(
-        step_name: &str,
-        result_text: Option<String>,
-        markers: Vec<String>,
-        context: String,
-        child_run_id: Option<String>,
-        structured_output: Option<String>,
-        output_file: Option<String>,
-    ) -> Self {
-        Self::completed(
-            step_name,
-            &StepSuccess {
-                result_text,
-                markers,
-                context,
-                child_run_id,
-                structured_output,
-                output_file,
-                ..StepSuccess::default()
-            },
-        )
+    /// workflow). Metric fields on `success` are ignored.
+    pub fn completed_without_metrics(step_name: &str, success: &StepSuccess) -> Self {
+        Self {
+            step_name: step_name.to_string(),
+            status: WorkflowStepStatus::Completed,
+            result_text: success.result_text.clone(),
+            cost_usd: None,
+            num_turns: None,
+            duration_ms: None,
+            markers: success.markers.clone(),
+            context: success.context.clone(),
+            child_run_id: success.child_run_id.clone(),
+            structured_output: success.structured_output.clone(),
+            output_file: success.output_file.clone(),
+        }
     }
 
     /// Create a completed StepResult from a [`StepSuccess`] description.

--- a/runkon-flow/src/types.rs
+++ b/runkon-flow/src/types.rs
@@ -244,6 +244,27 @@ impl StepSuccess {
             output_file,
         }
     }
+
+    /// Build a [`StepSuccess`] from a database [`WorkflowRunStep`] record.
+    pub fn from_workflow_run_step(
+        step_name: String,
+        step: &WorkflowRunStep,
+        markers: Vec<String>,
+        context: String,
+        iteration: u32,
+    ) -> Self {
+        Self {
+            step_name,
+            result_text: step.result_text.clone(),
+            markers,
+            context,
+            child_run_id: step.child_run_id.clone(),
+            structured_output: step.structured_output.clone(),
+            output_file: step.output_file.clone(),
+            iteration,
+            ..Self::default()
+        }
+    }
 }
 
 /// Result of a single step execution (kept in memory during execution).
@@ -459,5 +480,45 @@ mod tests {
         assert_eq!(entry.markers, vec!["m1", "m2"]);
         assert_eq!(entry.structured_output, Some(r#"{"k":"v"}"#.to_string()));
         assert_eq!(entry.output_file, Some("/tmp/out".to_string()));
+    }
+
+    #[test]
+    fn from_action_output_maps_all_fields() {
+        let output = crate::traits::action_executor::ActionOutput {
+            markers: vec!["m1".to_string()],
+            context: Some("ctx".to_string()),
+            result_text: Some("rt".to_string()),
+            cost_usd: Some(0.05),
+            num_turns: Some(3),
+            duration_ms: Some(1200),
+            input_tokens: Some(100),
+            output_tokens: Some(200),
+            cache_read_input_tokens: Some(50),
+            cache_creation_input_tokens: Some(25),
+            child_run_id: Some("child-1".to_string()),
+            structured_output: Some(r#"{"ok":true}"#.to_string()),
+        };
+        let success = StepSuccess::from_action_output(
+            &output,
+            "review".to_string(),
+            "ctx".to_string(),
+            5,
+            Some("/tmp/out".to_string()),
+        );
+        assert_eq!(success.step_name, "review");
+        assert_eq!(success.result_text, Some("rt".to_string()));
+        assert_eq!(success.cost_usd, Some(0.05));
+        assert_eq!(success.num_turns, Some(3));
+        assert_eq!(success.duration_ms, Some(1200));
+        assert_eq!(success.input_tokens, Some(100));
+        assert_eq!(success.output_tokens, Some(200));
+        assert_eq!(success.cache_read_input_tokens, Some(50));
+        assert_eq!(success.cache_creation_input_tokens, Some(25));
+        assert_eq!(success.markers, vec!["m1"]);
+        assert_eq!(success.context, "ctx");
+        assert_eq!(success.child_run_id, Some("child-1".to_string()));
+        assert_eq!(success.iteration, 5);
+        assert_eq!(success.structured_output, Some(r#"{"ok":true}"#.to_string()));
+        assert_eq!(success.output_file, Some("/tmp/out".to_string()));
     }
 }

--- a/runkon-flow/src/types.rs
+++ b/runkon-flow/src/types.rs
@@ -401,4 +401,34 @@ mod tests {
         assert_eq!(r.markers, vec!["done"]);
         assert_eq!(r.context, "restored");
     }
+
+    #[test]
+    fn step_success_into_context_entry_maps_all_fields() {
+        let success = StepSuccess {
+            step_name: "my-step".to_string(),
+            iteration: 7,
+            context: "ctx-body".to_string(),
+            markers: vec!["m1".to_string(), "m2".to_string()],
+            structured_output: Some(r#"{"k":"v"}"#.to_string()),
+            output_file: Some("/tmp/out".to_string()),
+            // Fields not mapped into ContextEntry should be distinct so we
+            // would catch an accidental mapping.
+            result_text: Some("rt".to_string()),
+            cost_usd: Some(1.23),
+            num_turns: Some(42),
+            duration_ms: Some(999),
+            input_tokens: Some(100),
+            output_tokens: Some(200),
+            cache_read_input_tokens: Some(50),
+            cache_creation_input_tokens: Some(25),
+            child_run_id: Some("child-1".to_string()),
+        };
+        let entry: super::ContextEntry = success.into();
+        assert_eq!(entry.step, "my-step", "step should come from step_name");
+        assert_eq!(entry.iteration, 7);
+        assert_eq!(entry.context, "ctx-body");
+        assert_eq!(entry.markers, vec!["m1", "m2"]);
+        assert_eq!(entry.structured_output, Some(r#"{"k":"v"}"#.to_string()));
+        assert_eq!(entry.output_file, Some("/tmp/out".to_string()));
+    }
 }

--- a/runkon-flow/src/types.rs
+++ b/runkon-flow/src/types.rs
@@ -217,6 +217,35 @@ pub struct StepSuccess {
     pub output_file: Option<String>,
 }
 
+impl StepSuccess {
+    /// Build a [`StepSuccess`] from an [`ActionOutput`] plus execution bookkeeping.
+    pub fn from_action_output(
+        output: &crate::traits::action_executor::ActionOutput,
+        step_name: String,
+        context: String,
+        iteration: u32,
+        output_file: Option<String>,
+    ) -> Self {
+        Self {
+            step_name,
+            result_text: output.result_text.clone(),
+            cost_usd: output.cost_usd,
+            num_turns: output.num_turns,
+            duration_ms: output.duration_ms,
+            input_tokens: output.input_tokens,
+            output_tokens: output.output_tokens,
+            cache_read_input_tokens: output.cache_read_input_tokens,
+            cache_creation_input_tokens: output.cache_creation_input_tokens,
+            markers: output.markers.clone(),
+            context,
+            child_run_id: output.child_run_id.clone(),
+            iteration,
+            structured_output: output.structured_output.clone(),
+            output_file,
+        }
+    }
+}
+
 /// Result of a single step execution (kept in memory during execution).
 #[derive(Debug, Clone, Default)]
 pub struct StepResult {

--- a/runkon-flow/src/types.rs
+++ b/runkon-flow/src/types.rs
@@ -256,26 +256,18 @@ impl StepResult {
     /// Convenience wrapper for the common case where cost/turns/duration are
     /// not available (e.g. restored from a prior run or bubble-up from a child
     /// workflow). Metric fields on `success` are ignored.
-    pub fn completed_without_metrics(step_name: &str, success: &StepSuccess) -> Self {
-        Self {
-            step_name: step_name.to_string(),
-            status: WorkflowStepStatus::Completed,
-            result_text: success.result_text.clone(),
-            cost_usd: None,
-            num_turns: None,
-            duration_ms: None,
-            markers: success.markers.clone(),
-            context: success.context.clone(),
-            child_run_id: success.child_run_id.clone(),
-            structured_output: success.structured_output.clone(),
-            output_file: success.output_file.clone(),
-        }
+    pub fn completed_without_metrics(success: &StepSuccess) -> Self {
+        let mut s = Self::completed(success);
+        s.cost_usd = None;
+        s.num_turns = None;
+        s.duration_ms = None;
+        s
     }
 
     /// Create a completed StepResult from a [`StepSuccess`] description.
-    pub fn completed(step_name: &str, success: &StepSuccess) -> Self {
+    pub fn completed(success: &StepSuccess) -> Self {
         Self {
-            step_name: step_name.to_string(),
+            step_name: success.step_name.clone(),
             status: WorkflowStepStatus::Completed,
             result_text: success.result_text.clone(),
             cost_usd: success.cost_usd,
@@ -346,6 +338,7 @@ mod tests {
     #[test]
     fn step_result_completed_sets_all_fields() {
         let success = StepSuccess {
+            step_name: "review".to_string(),
             result_text: Some("looks good".to_string()),
             cost_usd: Some(0.05),
             num_turns: Some(3),
@@ -357,7 +350,7 @@ mod tests {
             output_file: Some("/tmp/out".to_string()),
             ..StepSuccess::default()
         };
-        let r = StepResult::completed("review", &success);
+        let r = StepResult::completed(&success);
         assert_eq!(r.step_name, "review");
         assert_eq!(r.status, WorkflowStepStatus::Completed);
         assert_eq!(r.result_text, Some("looks good".to_string()));

--- a/runkon-flow/src/types.rs
+++ b/runkon-flow/src/types.rs
@@ -192,6 +192,29 @@ pub struct WorkflowResult {
     pub total_cache_creation_input_tokens: i64,
 }
 
+/// Input describing a successfully completed step, passed to `record_step_success`.
+///
+/// Groups the ~16 positional arguments that previously made call sites unwieldy.
+#[derive(Debug, Clone, Default)]
+pub struct StepSuccess {
+    pub step_key: String,
+    pub step_name: String,
+    pub result_text: Option<String>,
+    pub cost_usd: Option<f64>,
+    pub num_turns: Option<i64>,
+    pub duration_ms: Option<i64>,
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub cache_read_input_tokens: Option<i64>,
+    pub cache_creation_input_tokens: Option<i64>,
+    pub markers: Vec<String>,
+    pub context: String,
+    pub child_run_id: Option<String>,
+    pub iteration: u32,
+    pub structured_output: Option<String>,
+    pub output_file: Option<String>,
+}
+
 /// Result of a single step execution (kept in memory during execution).
 #[derive(Debug, Clone, Default)]
 pub struct StepResult {
@@ -244,44 +267,32 @@ impl StepResult {
     ) -> Self {
         Self::completed(
             step_name,
-            result_text,
-            None,
-            None,
-            None,
-            markers,
-            context,
-            child_run_id,
-            structured_output,
-            output_file,
+            &StepSuccess {
+                result_text,
+                markers,
+                context,
+                child_run_id,
+                structured_output,
+                output_file,
+                ..StepSuccess::default()
+            },
         )
     }
 
-    /// Create a completed StepResult with all output fields.
-    #[allow(clippy::too_many_arguments)]
-    pub fn completed(
-        step_name: &str,
-        result_text: Option<String>,
-        cost_usd: Option<f64>,
-        num_turns: Option<i64>,
-        duration_ms: Option<i64>,
-        markers: Vec<String>,
-        context: String,
-        child_run_id: Option<String>,
-        structured_output: Option<String>,
-        output_file: Option<String>,
-    ) -> Self {
+    /// Create a completed StepResult from a [`StepSuccess`] description.
+    pub fn completed(step_name: &str, success: &StepSuccess) -> Self {
         Self {
             step_name: step_name.to_string(),
             status: WorkflowStepStatus::Completed,
-            result_text,
-            cost_usd,
-            num_turns,
-            duration_ms,
-            markers,
-            context,
-            child_run_id,
-            structured_output,
-            output_file,
+            result_text: success.result_text.clone(),
+            cost_usd: success.cost_usd,
+            num_turns: success.num_turns,
+            duration_ms: success.duration_ms,
+            markers: success.markers.clone(),
+            context: success.context.clone(),
+            child_run_id: success.child_run_id.clone(),
+            structured_output: success.structured_output.clone(),
+            output_file: success.output_file.clone(),
         }
     }
 }
@@ -316,7 +327,7 @@ pub struct FanOutItemRow {
 
 #[cfg(test)]
 mod tests {
-    use super::StepResult;
+    use super::{StepResult, StepSuccess};
     use crate::status::WorkflowStepStatus;
 
     #[test]
@@ -341,18 +352,19 @@ mod tests {
 
     #[test]
     fn step_result_completed_sets_all_fields() {
-        let r = StepResult::completed(
-            "review",
-            Some("looks good".to_string()),
-            Some(0.05),
-            Some(3),
-            Some(1200),
-            vec!["approved".to_string()],
-            "ctx".to_string(),
-            Some("child-1".to_string()),
-            Some(r#"{"ok":true}"#.to_string()),
-            Some("/tmp/out".to_string()),
-        );
+        let success = StepSuccess {
+            result_text: Some("looks good".to_string()),
+            cost_usd: Some(0.05),
+            num_turns: Some(3),
+            duration_ms: Some(1200),
+            markers: vec!["approved".to_string()],
+            context: "ctx".to_string(),
+            child_run_id: Some("child-1".to_string()),
+            structured_output: Some(r#"{"ok":true}"#.to_string()),
+            output_file: Some("/tmp/out".to_string()),
+            ..StepSuccess::default()
+        };
+        let r = StepResult::completed("review", &success);
         assert_eq!(r.step_name, "review");
         assert_eq!(r.status, WorkflowStepStatus::Completed);
         assert_eq!(r.result_text, Some("looks good".to_string()));

--- a/runkon-flow/tests/common/mod.rs
+++ b/runkon-flow/tests/common/mod.rs
@@ -329,14 +329,14 @@ impl MockChildRunner {
 impl ChildWorkflowRunner for MockChildRunner {
     fn execute_child(
         &self,
-        child_def: &WorkflowDef,
+        workflow_name: &str,
         _parent_state: &ExecutionState,
         params: ChildWorkflowInput,
     ) -> runkon_flow::engine_error::Result<WorkflowResult> {
         let item_id = params.inputs.get("item.id").cloned().unwrap_or_default();
         self.call_log.lock().unwrap().push(item_id.clone());
         let succeeded = self.outcomes.get(&item_id).copied().unwrap_or(true);
-        Ok(mock_workflow_result(&item_id, &child_def.name, succeeded))
+        Ok(mock_workflow_result(&item_id, workflow_name, succeeded))
     }
 
     fn resume_child(
@@ -609,7 +609,7 @@ impl CancellingMockRunner {
 impl ChildWorkflowRunner for CancellingMockRunner {
     fn execute_child(
         &self,
-        child_def: &WorkflowDef,
+        workflow_name: &str,
         _parent_state: &ExecutionState,
         params: ChildWorkflowInput,
     ) -> runkon_flow::engine_error::Result<WorkflowResult> {
@@ -620,7 +620,7 @@ impl ChildWorkflowRunner for CancellingMockRunner {
             self.token.cancel(CancellationReason::UserRequested(None));
         }
         let succeeded = self.outcomes.get(&item_id).copied().unwrap_or(true);
-        Ok(mock_workflow_result(&item_id, &child_def.name, succeeded))
+        Ok(mock_workflow_result(&item_id, workflow_name, succeeded))
     }
 
     fn resume_child(


### PR DESCRIPTION
record_step_success previously took 17 positional arguments, making call sites verbose and error-prone. Introduce a StepSuccess struct that groups all step-success metadata and update record_step_success to accept &StepSuccess.

Also update StepResult::completed to take &StepSuccess so the struct is used consistently throughout the success-path pipeline.

Files changed:
- types.rs: add StepSuccess struct; refactor StepResult::completed
- engine.rs: refactor record_step_success signature
- executors/mod.rs: update record_dispatch_success
- executors/call_workflow.rs: build StepSuccess at call site
- executors/foreach.rs: simplify record_foreach_step_success wrapper
- executors/script.rs: build StepSuccess at both call sites