### PR TITLE
fix(security): cluster-security trio — path traversal, web CORS/bind, hook docs

### DIFF
--- a/conductor-core/src/notification_hooks.rs
+++ b/conductor-core/src/notification_hooks.rs
@@ -1,3 +1,24 @@
+//! Notification hook execution.
+//!
+//! # Security model
+//!
+//! Shell hooks run user-configured commands via `sh -c <hook.run>`. The
+//! command string itself is read directly from the conductor config file
+//! and is **not** validated, sandboxed, or restricted to an allow-list.
+//! Event data is passed via environment variables (safe), but the hook
+//! body has full shell privileges.
+//!
+//! This means: anyone who can write to `~/.conductor/config.toml` (or any
+//! repo's `.conductor/config.toml` that conductor reads) can achieve
+//! arbitrary code execution under the conductor user the next time a
+//! matching event fires. Treat the conductor config files as trusted
+//! input — do not let untrusted PRs/branches modify them, and do not
+//! source config from a shared writable location.
+//!
+//! HTTP hooks have a different (smaller) blast radius: only the
+//! configured URL is reachable; headers beginning with `$` resolve from
+//! the host process environment.
+
 use std::process::Stdio;
 use std::time::Duration;
 

--- a/conductor-tui/src/state/tree.rs
+++ b/conductor-tui/src/state/tree.rs
@@ -270,7 +270,7 @@ pub fn build_branch_picker_tree(
     let (rest_indices, rest_positions) =
         dfs_tree_order(rest.len(), get_branch, get_parent, "", false);
 
-    for (idx, pos) in rest_indices.into_iter().zip(rest_positions.into_iter()) {
+    for (idx, pos) in rest_indices.into_iter().zip(rest_positions) {
         result.push(rest[idx].clone());
         positions.push(pos);
     }

--- a/conductor-tui/src/theme.rs
+++ b/conductor-tui/src/theme.rs
@@ -325,7 +325,7 @@ pub fn scan_custom_themes() -> (Vec<(String, String)>, Vec<String>) {
         }
     }
 
-    results.sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));
+    results.sort_by_key(|a| a.1.to_lowercase());
     (results, warnings)
 }
 

--- a/conductor-tui/src/ui/workflows.rs
+++ b/conductor-tui/src/ui/workflows.rs
@@ -2142,8 +2142,8 @@ fn foreach_progress_spans(
     let running = items.iter().filter(|i| i.status == "running").count();
     let pending = items.iter().filter(|i| i.status == "pending").count();
 
-    let bar = if total > 0 {
-        let filled = (completed * 15 / total).min(15);
+    let bar = if let Some(filled) = (completed * 15).checked_div(total) {
+        let filled = filled.min(15);
         let empty = 15 - filled;
         format!("[{}{}]", "█".repeat(filled), "░".repeat(empty))
     } else {

--- a/conductor-web/src/main.rs
+++ b/conductor-web/src/main.rs
@@ -726,6 +726,16 @@ async fn main() -> Result<()> {
         .parse()
         .map_err(|e| anyhow::anyhow!("invalid CONDUCTOR_PORT: {e}"))?;
 
+    if !host.is_loopback() {
+        tracing::warn!(
+            host = %host,
+            "CONDUCTOR_HOST is bound to a non-loopback address; the conductor-web API has no \
+             authentication and will be reachable by anyone who can reach this host. Use \
+             127.0.0.1 (the default) unless an external auth layer (reverse proxy, VPN, etc.) \
+             is in front of this server."
+        );
+    }
+
     let mut origins: Vec<HeaderValue> = vec![
         format!("http://localhost:{port}").parse().unwrap(),
         format!("http://127.0.0.1:{port}").parse().unwrap(),

--- a/conductor-web/src/routes/mod.rs
+++ b/conductor-web/src/routes/mod.rs
@@ -14,20 +14,28 @@ pub mod workflows;
 pub mod worktrees;
 
 use crate::state::AppState;
-use axum::http::HeaderValue;
+use axum::http::{header, HeaderValue, Method};
 use axum::routing::{delete, get, patch, post, put};
 use axum::Router;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::CorsLayer;
 
 /// Build the API router with CORS restricted to the given origins.
 ///
 /// This keeps CORS configuration inside conductor-web so that embedders
 /// (e.g. conductor-desktop) don't need to depend on axum/tower-http directly.
+/// Methods and headers are restricted to the specific values the API uses,
+/// matching the production server config in `conductor-web/src/main.rs`.
 pub fn api_router_with_cors(allowed_origins: Vec<HeaderValue>) -> Router<AppState> {
     let cors = CorsLayer::new()
         .allow_origin(allowed_origins)
-        .allow_methods(Any)
-        .allow_headers(Any);
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::PATCH,
+        ])
+        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION]);
     api_router().layer(cors)
 }
 

--- a/docs/notification-hooks.md
+++ b/docs/notification-hooks.md
@@ -367,3 +367,18 @@ Example for `workflow_run.completed`:
 ```
 
 See `docs/examples/hooks/` for working shell and HTTP hook examples.
+
+---
+
+## Security model
+
+Shell hooks run user-configured commands via `sh -c <hook.run>`. The command string is read directly from `config.toml` and is **not** validated, sandboxed, or restricted to an allow-list. Event data is passed safely through environment variables, but the hook body itself executes with full shell privileges as the conductor user.
+
+**Threat:** anyone who can write to `~/.conductor/config.toml` — or to a repo-local `.conductor/config.toml` that conductor reads — can achieve arbitrary code execution under the conductor user on the next matching event.
+
+**Implications:**
+
+- Treat conductor config files as trusted input. Do not source them from a shared writable location, and do not check repo-local `.conductor/config.toml` from a branch you would not run code from.
+- Untrusted PRs that modify `.conductor/config.toml` should be reviewed for hook additions/changes the same way you would review a `Makefile` change — they are equivalent in privilege.
+- HTTP hooks have a smaller blast radius (only the configured URL is reachable; secrets in `$VAR` headers come from the host process environment), but the URL itself is still arbitrary — apply the same trust model to the config file.
+- Conductor does not currently provide a hook allow-list, sandbox, or signed-config mechanism. Defense relies on filesystem permissions on the config file.

--- a/runkon-flow/src/dsl/parser.rs
+++ b/runkon-flow/src/dsl/parser.rs
@@ -15,6 +15,23 @@ use super::types::{
 // Parser helpers
 // ---------------------------------------------------------------------------
 
+/// Reject an agent path that contains parent-directory components (`..`).
+///
+/// Enforced at parse time so any future code path that constructs an
+/// `AgentRef::Path` via the parser cannot bypass `script_utils::resolve_script_path`'s
+/// containment check.
+fn validate_agent_path(s: &str) -> std::result::Result<(), String> {
+    if Path::new(s)
+        .components()
+        .any(|c| c == std::path::Component::ParentDir)
+    {
+        return Err(format!(
+            "agent path contains parent-directory traversal (..): {s}"
+        ));
+    }
+    Ok(())
+}
+
 /// A value from a key-value pair in the DSL, remembering whether it was quoted.
 #[derive(Debug, Clone)]
 enum KvValue {
@@ -49,11 +66,14 @@ impl KvValue {
         }
     }
 
-    fn into_agent_ref(self) -> AgentRef {
+    fn into_agent_ref(self) -> std::result::Result<AgentRef, String> {
         match self {
-            Self::Bare(s) => AgentRef::Name(s),
-            Self::Quoted(s) if s.contains('/') => AgentRef::Path(s),
-            Self::Quoted(s) => AgentRef::Name(s),
+            Self::Bare(s) => Ok(AgentRef::Name(s)),
+            Self::Quoted(s) if s.contains('/') => {
+                validate_agent_path(&s)?;
+                Ok(AgentRef::Path(s))
+            }
+            Self::Quoted(s) => Ok(AgentRef::Name(s)),
             Self::Array(_) => unreachable!("BUG: into_agent_ref() called on KvValue::Array"),
             Self::Map(_) => unreachable!("BUG: into_agent_ref() called on KvValue::Map"),
         }
@@ -169,7 +189,10 @@ impl Parser {
             Token::Required => Ok(AgentRef::Name("required".to_string())),
             Token::Default => Ok(AgentRef::Name("default".to_string())),
             Token::Description => Ok(AgentRef::Name("description".to_string())),
-            Token::StringLit(s) => Ok(AgentRef::Path(s)),
+            Token::StringLit(s) => {
+                validate_agent_path(&s)?;
+                Ok(AgentRef::Path(s))
+            }
             other => Err(format!(
                 "Expected agent name (identifier) or path (quoted string), got {other:?}"
             )),
@@ -359,13 +382,11 @@ impl Parser {
             .transpose()
             .map_err(|e| format!("{err_prefix}invalid retries: {e}"))?
             .unwrap_or(0);
-        let on_fail = kvs.remove("on_fail").map(|v| {
-            if v.as_str() == "continue" {
-                OnFail::Continue
-            } else {
-                OnFail::Agent(v.into_agent_ref())
-            }
-        });
+        let on_fail = match kvs.remove("on_fail") {
+            None => None,
+            Some(v) if v.as_str() == "continue" => Some(OnFail::Continue),
+            Some(v) => Some(OnFail::Agent(v.into_agent_ref()?)),
+        };
         let bot_name = kvs.remove("as").map(|v| v.into_string());
         Ok((retries, on_fail, bot_name))
     }
@@ -1398,5 +1419,55 @@ workflow wf {
         let src = "workflow wf {}";
         let def = parse_workflow_str(src, "my/path/wf.wf").unwrap();
         assert_eq!(def.source_path, "my/path/wf.wf");
+    }
+
+    #[test]
+    fn parse_rejects_dotdot_in_quoted_agent_path() {
+        let src = r#"
+workflow wf {
+    call "../../etc/passwd"
+}
+"#;
+        let err = parse_workflow_str(src, "t.wf").expect_err("must reject ..");
+        assert!(
+            err.contains("parent-directory traversal"),
+            "expected traversal error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_dotdot_in_on_fail_agent_path() {
+        let src = r#"
+workflow wf {
+    call planner {
+        on_fail = "../oops/handler.md"
+    }
+}
+"#;
+        let err = parse_workflow_str(src, "t.wf").expect_err("must reject ..");
+        assert!(
+            err.contains("parent-directory traversal"),
+            "expected traversal error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_accepts_safe_agent_path_with_slash() {
+        // Quoted strings containing `/` but no `..` should still produce
+        // AgentRef::Path successfully — the validation must only reject
+        // traversal, not legitimate relative paths.
+        let src = r#"
+workflow wf {
+    call ".claude/agents/plan.md"
+}
+"#;
+        let def = parse_workflow_str(src, "t.wf").expect("safe path must parse");
+        match &def.body[0] {
+            WorkflowNode::Call(c) => assert_eq!(
+                c.agent,
+                AgentRef::Path(".claude/agents/plan.md".to_string())
+            ),
+            other => panic!("expected Call, got {other:?}"),
+        }
     }
 }

--- a/runkon-flow/src/dsl/script_utils.rs
+++ b/runkon-flow/src/dsl/script_utils.rs
@@ -10,17 +10,14 @@ fn path_is_within_dir(dir: &Path, file: &Path) -> bool {
 }
 
 /// Returns the ordered list of `(search_root, candidate_path)` pairs for a
-/// script name.
+/// script name. The caller must pass a relative `run`; absolute paths are
+/// rejected up-front by [`resolve_script_path`].
 pub(crate) fn script_search_paths(
     run: &str,
     working_dir: &str,
     repo_path: &str,
     skills_dir: Option<&std::path::Path>,
 ) -> Vec<(std::path::PathBuf, std::path::PathBuf)> {
-    let p = std::path::Path::new(run);
-    if p.is_absolute() {
-        return vec![(p.to_path_buf(), p.to_path_buf())];
-    }
     let wd = std::path::Path::new(working_dir);
     let rp = std::path::Path::new(repo_path);
     let mut pairs = vec![
@@ -36,20 +33,25 @@ pub(crate) fn script_search_paths(
 }
 
 /// Resolve a script name to an existing path using the standard search order.
+///
+/// Absolute paths are rejected unconditionally: a workflow `run:` value that
+/// resolves outside the standard search roots (working dir, repo, `.conductor/scripts`,
+/// skills dir) cannot be executed, even if it exists on disk. This blocks a
+/// hostile `.wf` file from invoking arbitrary system binaries via
+/// `run: /etc/shadow` or similar.
 pub fn resolve_script_path(
     run: &str,
     working_dir: &str,
     repo_path: &str,
     skills_dir: Option<&std::path::Path>,
 ) -> Option<std::path::PathBuf> {
+    if std::path::Path::new(run).is_absolute() {
+        return None;
+    }
     let pairs = script_search_paths(run, working_dir, repo_path, skills_dir);
-    let is_absolute = std::path::Path::new(run).is_absolute();
 
     for (root, candidate) in &pairs {
         if candidate.exists() {
-            if is_absolute {
-                return Some(candidate.clone());
-            }
             if run.contains("..") {
                 continue;
             }
@@ -79,9 +81,10 @@ pub fn make_script_resolver(
 ) -> impl Fn(&str) -> Result<std::path::PathBuf, String> {
     move |run| {
         resolve_script_path(run, &working_dir, &repo_path, skills_dir.as_deref()).ok_or_else(|| {
-            let p = std::path::Path::new(run);
-            if p.is_absolute() {
-                run.to_string()
+            if std::path::Path::new(run).is_absolute() {
+                format!(
+                    "absolute paths are not allowed in `run:` (got '{run}'); use a path relative to the working dir, repo, .conductor/scripts, or skills dir"
+                )
             } else {
                 let pairs =
                     script_search_paths(run, &working_dir, &repo_path, skills_dir.as_deref());
@@ -93,5 +96,38 @@ pub fn make_script_resolver(
                 searched.join(", ")
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_script_path_rejects_absolute_path_even_if_it_exists() {
+        // /bin/sh exists on every Unix system the test runs on; it must still be
+        // rejected because it lies outside the standard script search roots.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let wd = tmp.path().to_str().unwrap();
+        assert_eq!(resolve_script_path("/bin/sh", wd, wd, None), None);
+    }
+
+    #[test]
+    fn resolve_script_path_rejects_traversal_back_into_search_root() {
+        // A relative path that lexically escapes the search root via `..`
+        // must be rejected (existing behavior; covered here to lock it in).
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let wd = tmp.path().to_str().unwrap();
+        assert_eq!(resolve_script_path("../foo.sh", wd, wd, None), None);
+    }
+
+    #[test]
+    fn make_script_resolver_returns_explicit_error_for_absolute_path() {
+        let resolver = make_script_resolver("/tmp".into(), "/tmp".into(), None);
+        let err = resolver("/etc/shadow").expect_err("absolute path must error");
+        assert!(
+            err.contains("absolute paths are not allowed"),
+            "error should explain why absolute paths fail; got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes 6 ultrareview-flagged security issues in the **cluster:security** triage from the 0.10.0 backlog (filed against the 0.10.0 work but the vulnerable code lives on `main` too).

3 commits, one per sub-cluster:

- **`98de9afc`** — path-traversal (#2588, #2620, #2630): reject absolute paths in `resolve_script_path`; validate `..` at `AgentRef::Path` parse time.
- **`8a68169b`** — web (#2594, #2634): tighten CORS methods/headers in `api_router_with_cors`; warn on non-loopback `CONDUCTOR_HOST`.
- **`ebafd704`** — docs (#2651): document the notification-hook threat model.

The 4 remaining issues in the trio (#2563, #2577, #2585, #2609) are already fixed in current code; they will be closed separately as stale.

## Test plan

- [x] `cargo test -p runkon-flow --lib` (155 pass, 6 new tests cover absolute-path rejection, parser `..` rejection at both construction sites, and a positive case for legitimate slash-bearing paths)
- [x] `cargo test -p conductor-web --lib` (127 pass)
- [x] `cargo test -p conductor-core --lib` (2434 pass)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p runkon-flow -p conductor-web -p conductor-core --all-targets -- -D warnings`
- [ ] Manual: confirm a workflow with `run: /etc/shadow` is rejected at parse-time validation (covered by `make_script_resolver_returns_explicit_error_for_absolute_path` test)
- [ ] Manual: confirm `CONDUCTOR_HOST=0.0.0.0 cargo run -p conductor-web` logs the warning at startup