### PR TITLE
refactor: cluster:dedup-leftover — error mapping, test helpers, truncate, spawn flows

### DIFF
--- a/conductor-core/src/agent/manager/feedback.rs
+++ b/conductor-core/src/agent/manager/feedback.rs
@@ -5,10 +5,10 @@ use crate::db::{query_collect, sql_placeholders};
 use crate::error::{ConductorError, Result};
 
 use super::super::db::{optional_row, row_to_feedback_request, FEEDBACK_SELECT};
-use super::super::status::truncate_utf8;
 use super::super::status::{FeedbackStatus, FeedbackType, FEEDBACK_MAX_LEN};
 use super::super::types::{FeedbackOption, FeedbackRequest, FeedbackRequestParams};
 use super::AgentManager;
+use crate::text_util::truncate_str;
 
 /// Normalize a raw user response based on feedback type and available options.
 ///
@@ -78,7 +78,7 @@ impl<'a> AgentManager<'a> {
         prompt: &str,
         params: Option<&FeedbackRequestParams>,
     ) -> Result<FeedbackRequest> {
-        let prompt = truncate_utf8(prompt, FEEDBACK_MAX_LEN);
+        let prompt = truncate_str(prompt, FEEDBACK_MAX_LEN);
         let id = crate::new_id();
         let now = Utc::now().to_rfc3339();
 
@@ -146,7 +146,7 @@ impl<'a> AgentManager<'a> {
 
     /// Submit a response to a pending feedback request and resume the run.
     pub fn submit_feedback(&self, feedback_id: &str, response: &str) -> Result<FeedbackRequest> {
-        let response = truncate_utf8(response, FEEDBACK_MAX_LEN);
+        let response = truncate_str(response, FEEDBACK_MAX_LEN);
         let now = Utc::now().to_rfc3339();
 
         // Update feedback request

--- a/conductor-core/src/agent/status.rs
+++ b/conductor-core/src/agent/status.rs
@@ -68,19 +68,6 @@ pub fn parse_feedback_marker_structured(text: &str) -> Option<ParsedFeedbackMark
     })
 }
 
-/// Truncate a string to at most `max_bytes` bytes, ensuring the cut falls on a
-/// valid UTF-8 character boundary (avoids panics on multi-byte characters).
-pub(crate) fn truncate_utf8(s: &str, max_bytes: usize) -> &str {
-    if s.len() <= max_bytes {
-        return s;
-    }
-    let mut end = max_bytes;
-    while !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
-}
-
 /// Status of a human-in-the-loop feedback request.
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -162,93 +149,6 @@ crate::impl_sql_enum!(FeedbackType);
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn ascii_within_limit() {
-        assert_eq!(truncate_utf8("hello", 10), "hello");
-    }
-
-    #[test]
-    fn ascii_exact_limit() {
-        assert_eq!(truncate_utf8("hello", 5), "hello");
-    }
-
-    #[test]
-    fn ascii_over_limit() {
-        assert_eq!(truncate_utf8("hello world", 5), "hello");
-    }
-
-    #[test]
-    fn empty_string() {
-        assert_eq!(truncate_utf8("", 5), "");
-        assert_eq!(truncate_utf8("", 0), "");
-    }
-
-    #[test]
-    fn max_bytes_zero() {
-        assert_eq!(truncate_utf8("hello", 0), "");
-        assert_eq!(truncate_utf8("é", 0), "");
-    }
-
-    #[test]
-    fn two_byte_char_boundary() {
-        // 'é' is 2 bytes (0xC3 0xA9), "aé" is 3 bytes
-        let s = "aé";
-        assert_eq!(s.len(), 3);
-        // Limit 3: fits entirely
-        assert_eq!(truncate_utf8(s, 3), "aé");
-        // Limit 2: would split 'é', must back up to 1
-        assert_eq!(truncate_utf8(s, 2), "a");
-        // Limit 1: just 'a'
-        assert_eq!(truncate_utf8(s, 1), "a");
-    }
-
-    #[test]
-    fn three_byte_char_boundary() {
-        // '€' is 3 bytes (0xE2 0x82 0xAC), "a€" is 4 bytes
-        let s = "a€";
-        assert_eq!(s.len(), 4);
-        assert_eq!(truncate_utf8(s, 4), "a€");
-        // Limit 3: splits '€', back up to 1
-        assert_eq!(truncate_utf8(s, 3), "a");
-        assert_eq!(truncate_utf8(s, 2), "a");
-        assert_eq!(truncate_utf8(s, 1), "a");
-    }
-
-    #[test]
-    fn four_byte_char_boundary() {
-        // '🦀' is 4 bytes, "a🦀" is 5 bytes
-        let s = "a🦀";
-        assert_eq!(s.len(), 5);
-        assert_eq!(truncate_utf8(s, 5), "a🦀");
-        // Limits 2-4: all split '🦀', back up to 1
-        assert_eq!(truncate_utf8(s, 4), "a");
-        assert_eq!(truncate_utf8(s, 3), "a");
-        assert_eq!(truncate_utf8(s, 2), "a");
-    }
-
-    #[test]
-    fn all_multibyte_string() {
-        // "ééé" = 6 bytes (each 'é' is 2 bytes)
-        let s = "ééé";
-        assert_eq!(s.len(), 6);
-        assert_eq!(truncate_utf8(s, 6), "ééé");
-        assert_eq!(truncate_utf8(s, 5), "éé");
-        assert_eq!(truncate_utf8(s, 4), "éé");
-        assert_eq!(truncate_utf8(s, 3), "é");
-        assert_eq!(truncate_utf8(s, 2), "é");
-        assert_eq!(truncate_utf8(s, 1), "");
-    }
-
-    #[test]
-    fn large_string_sanity() {
-        let s = "a".repeat(1000) + "🦀";
-        assert_eq!(s.len(), 1004);
-        assert_eq!(truncate_utf8(&s, 1004), s.as_str());
-        assert_eq!(truncate_utf8(&s, 1003), &s[..1000]);
-        assert_eq!(truncate_utf8(&s, 1000), &s[..1000]);
-        assert_eq!(truncate_utf8(&s, 500), &s[..500]);
-    }
 
     #[test]
     fn parse_structured_plain_text() {

--- a/conductor-core/src/workflow/runkon_bridge.rs
+++ b/conductor-core/src/workflow/runkon_bridge.rs
@@ -66,6 +66,16 @@ fn bridge_lock_err(e: impl std::fmt::Display) -> EngineError {
     EngineError::Workflow(format!("db mutex poisoned: {e}"))
 }
 
+/// Wrap a `ConductorError` from a child-workflow execute/resume call into
+/// an `EngineError`, preserving cancellation passthrough so a child cancel
+/// propagates as a cancellation rather than a generic workflow failure.
+fn wrap_child_workflow_err(e: ConductorError, ctx: String) -> EngineError {
+    match e {
+        ConductorError::WorkflowCancelled => EngineError::from(e),
+        other => EngineError::Workflow(format!("{ctx}: {other}")),
+    }
+}
+
 ///
 /// The runkon-flow `ExecutionContext` does not carry `db_path`, so we store it
 /// in the adapter and inject it when constructing the core `ExecutionContext`.
@@ -399,12 +409,8 @@ impl runkon_flow::engine::ChildWorkflowRunner for ConductorChildWorkflowRunner {
         })?;
 
         let exec_config = crate::workflow::WorkflowExecConfig {
-            poll_interval: parent_state.exec_config.poll_interval,
-            step_timeout: parent_state.exec_config.step_timeout,
-            fail_fast: parent_state.exec_config.fail_fast,
-            dry_run: parent_state.exec_config.dry_run,
-            shutdown: parent_state.exec_config.shutdown.clone(),
             event_sinks: parent_state.event_sinks.iter().cloned().collect(),
+            ..parent_state.exec_config.clone()
         };
 
         // Route child workflows through execute_workflow_standalone so they use
@@ -436,12 +442,8 @@ impl runkon_flow::engine::ChildWorkflowRunner for ConductorChildWorkflowRunner {
         };
 
         let core_result = super::coordinator::execute_workflow_standalone(&standalone_params)
-            .map_err(|e| match e {
-                ConductorError::WorkflowCancelled => EngineError::from(e),
-                other => EngineError::Workflow(format!(
-                    "child workflow '{}' failed: {other}",
-                    workflow_name
-                )),
+            .map_err(|e| {
+                wrap_child_workflow_err(e, format!("child workflow '{workflow_name}' failed"))
             })?;
 
         Ok(core_result)
@@ -464,11 +466,11 @@ impl runkon_flow::engine::ChildWorkflowRunner for ConductorChildWorkflowRunner {
             shutdown: None,
         };
 
-        let core_result = super::coordinator::resume_workflow(&input).map_err(|e| match e {
-            ConductorError::WorkflowCancelled => EngineError::from(e),
-            other => EngineError::Workflow(format!(
-                "failed to resume child workflow run '{workflow_run_id}': {other}"
-            )),
+        let core_result = super::coordinator::resume_workflow(&input).map_err(|e| {
+            wrap_child_workflow_err(
+                e,
+                format!("failed to resume child workflow run '{workflow_run_id}'"),
+            )
         })?;
 
         Ok(core_result)

--- a/conductor-tui/src/app/agent_execution.rs
+++ b/conductor-tui/src/app/agent_execution.rs
@@ -69,6 +69,9 @@ pub(super) fn drive_headless_run(
         plugin_dirs: &[],
     };
 
+    // `try_spawn_headless_run` combines build_headless_agent_args + spawn_headless.
+    // If spawn fails after the prompt file was written, it removes the file
+    // internally before returning Err, so no separate cleanup is needed here.
     let (handle, prompt_file) =
         match conductor_core::agent_runtime::try_spawn_headless_run(&spawn_params) {
             Ok(pair) => pair,

--- a/conductor-tui/src/app/agent_execution.rs
+++ b/conductor-tui/src/app/agent_execution.rs
@@ -21,6 +21,88 @@ fn resolve_log_path(run: &AgentRun) -> Option<PathBuf> {
     }
 }
 
+/// Owned configuration for spawning a headless agent run, sized to the union
+/// of inputs the three TUI launch flows (`start_agent_headless`,
+/// `start_repo_agent_headless`, `handle_restart_agent`) need to pass into
+/// [`drive_headless_run`].
+pub(super) struct HeadlessRunConfig {
+    pub working_dir: String,
+    pub prompt: String,
+    pub resume_session_id: Option<String>,
+    pub model: Option<String>,
+    pub bot_name: Option<String>,
+    pub permission_mode: Option<conductor_core::config::AgentPermissionMode>,
+}
+
+/// Shared post-creation logic for the three TUI headless launch flows.
+///
+/// The caller is responsible for opening the DB, creating the `AgentRun`
+/// (each flow calls a different `AgentManager` method), and constructing
+/// the surrounding modal/UI state. From there, this helper:
+///
+/// 1. Builds args + spawns the subprocess via `try_spawn_headless_run`,
+///    marking the run failed on spawn errors.
+/// 2. Records the subprocess PID on the run.
+/// 3. Sends the launch-result action via `on_launched`.
+/// 4. Drains stdout, emitting `Action::AgentEvent` per parsed event.
+/// 5. Sends `Action::AgentComplete` and removes the prompt file on exit.
+///
+/// `on_launched` decides which `Action` variant carries the launch result —
+/// flows differ (`AgentLaunchComplete`, `RepoAgentLaunched`,
+/// `AgentRestartComplete`) but all wrap a `Result<String, String>`.
+pub(super) fn drive_headless_run(
+    run: AgentRun,
+    config: HeadlessRunConfig,
+    mgr: &AgentManager<'_>,
+    tx: &crate::event::BackgroundSender,
+    on_launched: impl FnOnce(std::result::Result<String, String>) -> Action,
+    success_msg: &str,
+) {
+    let spawn_params = conductor_core::agent_runtime::SpawnHeadlessParams {
+        run_id: &run.id,
+        working_dir: &config.working_dir,
+        prompt: &config.prompt,
+        resume_session_id: config.resume_session_id.as_deref(),
+        model: config.model.as_deref(),
+        bot_name: config.bot_name.as_deref(),
+        permission_mode: config.permission_mode.as_ref(),
+        plugin_dirs: &[],
+    };
+
+    let (handle, prompt_file) =
+        match conductor_core::agent_runtime::try_spawn_headless_run(&spawn_params) {
+            Ok(pair) => pair,
+            Err(e) => {
+                let _ = mgr.update_run_failed(&run.id, &e);
+                let _ = tx.send(on_launched(Err(e)));
+                return;
+            }
+        };
+
+    if let Err(e) = mgr.update_run_subprocess_pid(&run.id, handle.pid()) {
+        tracing::warn!("failed to store subprocess PID for run {}: {e}", run.id);
+    }
+
+    let _ = tx.send(on_launched(Ok(success_msg.to_string())));
+
+    let run_id = run.id.clone();
+    let Some(log_path) = resolve_log_path(&run) else {
+        return;
+    };
+    let tx2 = tx.clone();
+    let (stdout, finish) = handle.into_drain_parts();
+    conductor_core::agent_runtime::drain_stream_json(stdout, &run_id, &log_path, mgr, |event| {
+        let _ = tx2.send(Action::AgentEvent {
+            run_id: run_id.clone(),
+            event: event.clone(),
+        });
+    });
+
+    let _ = std::fs::remove_file(&prompt_file);
+    finish();
+    let _ = tx.send(Action::AgentComplete { run_id });
+}
+
 impl App {
     pub(super) fn handle_toggle_agent_issues(&mut self) {
         let Some(repo) = self
@@ -522,69 +604,21 @@ impl App {
                 }
             };
 
-            let build_params = conductor_core::agent_runtime::SpawnHeadlessParams {
-                run_id: &run.id,
-                working_dir: &worktree_path,
-                prompt: &prompt,
-                resume_session_id: resume_session_id.as_deref(),
-                model: model.as_deref(),
-                bot_name: None,
-                permission_mode: None,
-                plugin_dirs: &[],
-            };
-            let (args, prompt_file) =
-                match conductor_core::agent_runtime::build_headless_agent_args(&build_params) {
-                    Ok(pair) => pair,
-                    Err(e) => {
-                        let _ = mgr.update_run_failed(&run.id, &e);
-                        let _ = tx.send(Action::AgentLaunchComplete { result: Err(e) });
-                        return;
-                    }
-                };
-
-            let handle = match conductor_core::agent_runtime::spawn_headless(
-                &args,
-                std::path::Path::new(&worktree_path),
-            ) {
-                Ok(h) => h,
-                Err(e) => {
-                    let _ = mgr.update_run_failed(&run.id, &e);
-                    let _ = std::fs::remove_file(&prompt_file);
-                    let _ = tx.send(Action::AgentLaunchComplete { result: Err(e) });
-                    return;
-                }
-            };
-
-            if let Err(e) = mgr.update_run_subprocess_pid(&run.id, handle.pid()) {
-                tracing::warn!("failed to store subprocess PID for run {}: {e}", run.id);
-            }
-
-            let _ = tx.send(Action::AgentLaunchComplete {
-                result: Ok("Agent launched (headless)".to_string()),
-            });
-
-            let run_id = run.id.clone();
-            let Some(log_path) = resolve_log_path(&run) else {
-                return;
-            };
-            let tx2 = tx.clone();
-            let (stdout, finish) = handle.into_drain_parts();
-            conductor_core::agent_runtime::drain_stream_json(
-                stdout,
-                &run_id,
-                &log_path,
-                &mgr,
-                |event| {
-                    let _ = tx2.send(Action::AgentEvent {
-                        run_id: run_id.clone(),
-                        event: event.clone(),
-                    });
+            drive_headless_run(
+                run,
+                HeadlessRunConfig {
+                    working_dir: worktree_path,
+                    prompt,
+                    resume_session_id,
+                    model,
+                    bot_name: None,
+                    permission_mode: None,
                 },
+                &mgr,
+                &tx,
+                |result| Action::AgentLaunchComplete { result },
+                "Agent launched (headless)",
             );
-
-            let _ = std::fs::remove_file(&prompt_file);
-            finish();
-            let _ = tx.send(Action::AgentComplete { run_id });
         });
     }
 
@@ -671,70 +705,21 @@ impl App {
                 }
             };
 
-            let plan_mode = conductor_core::config::AgentPermissionMode::RepoSafe;
-            let build_params = conductor_core::agent_runtime::SpawnHeadlessParams {
-                run_id: &run.id,
-                working_dir: &repo_path,
-                prompt: &prompt,
-                resume_session_id: resume_session_id.as_deref(),
-                model: None,
-                bot_name: None,
-                permission_mode: Some(&plan_mode),
-                plugin_dirs: &[],
-            };
-            let (args, prompt_file) =
-                match conductor_core::agent_runtime::build_headless_agent_args(&build_params) {
-                    Ok(pair) => pair,
-                    Err(e) => {
-                        let _ = mgr.update_run_failed(&run.id, &e);
-                        let _ = tx.send(Action::RepoAgentLaunched { result: Err(e) });
-                        return;
-                    }
-                };
-
-            let handle = match conductor_core::agent_runtime::spawn_headless(
-                &args,
-                std::path::Path::new(&repo_path),
-            ) {
-                Ok(h) => h,
-                Err(e) => {
-                    let _ = mgr.update_run_failed(&run.id, &e);
-                    let _ = std::fs::remove_file(&prompt_file);
-                    let _ = tx.send(Action::RepoAgentLaunched { result: Err(e) });
-                    return;
-                }
-            };
-
-            if let Err(e) = mgr.update_run_subprocess_pid(&run.id, handle.pid()) {
-                tracing::warn!("failed to store subprocess PID for run {}: {e}", run.id);
-            }
-
-            let _ = tx.send(Action::RepoAgentLaunched {
-                result: Ok("Repo agent launched (headless)".to_string()),
-            });
-
-            let run_id = run.id.clone();
-            let Some(log_path) = resolve_log_path(&run) else {
-                return;
-            };
-            let tx2 = tx.clone();
-            let (stdout, finish) = handle.into_drain_parts();
-            conductor_core::agent_runtime::drain_stream_json(
-                stdout,
-                &run_id,
-                &log_path,
-                &mgr,
-                |event| {
-                    let _ = tx2.send(Action::AgentEvent {
-                        run_id: run_id.clone(),
-                        event: event.clone(),
-                    });
+            drive_headless_run(
+                run,
+                HeadlessRunConfig {
+                    working_dir: repo_path,
+                    prompt,
+                    resume_session_id,
+                    model: None,
+                    bot_name: None,
+                    permission_mode: Some(conductor_core::config::AgentPermissionMode::RepoSafe),
                 },
+                &mgr,
+                &tx,
+                |result| Action::RepoAgentLaunched { result },
+                "Repo agent launched (headless)",
             );
-
-            let _ = std::fs::remove_file(&prompt_file);
-            finish();
-            let _ = tx.send(Action::AgentComplete { run_id });
         });
     }
 
@@ -801,56 +786,24 @@ impl App {
                 }
             };
 
-            let spawn_params = conductor_core::agent_runtime::SpawnHeadlessParams {
-                run_id: &new_run.id,
-                working_dir: &worktree_path,
-                prompt: &new_run.prompt,
-                resume_session_id: None,
-                model: new_run.model.as_deref(),
-                bot_name: new_run.bot_name.as_deref(),
-                permission_mode: None,
-                plugin_dirs: &[],
-            };
-            let (handle, prompt_file) =
-                match conductor_core::agent_runtime::try_spawn_headless_run(&spawn_params) {
-                    Ok(pair) => pair,
-                    Err(e) => {
-                        let _ = mgr.update_run_failed(&new_run.id, &e);
-                        let _ = tx.send(Action::AgentRestartComplete { result: Err(e) });
-                        return;
-                    }
-                };
-
-            if let Err(e) = mgr.update_run_subprocess_pid(&new_run.id, handle.pid()) {
-                tracing::warn!("failed to store subprocess PID for run {}: {e}", new_run.id);
-            }
-
-            let _ = tx.send(Action::AgentRestartComplete {
-                result: Ok("Agent restarted (headless)".to_string()),
-            });
-
-            let new_run_id = new_run.id.clone();
-            let Some(log_path) = resolve_log_path(&new_run) else {
-                return;
-            };
-            let tx2 = tx.clone();
-            let (stdout, finish) = handle.into_drain_parts();
-            conductor_core::agent_runtime::drain_stream_json(
-                stdout,
-                &new_run_id,
-                &log_path,
-                &mgr,
-                |event| {
-                    let _ = tx2.send(Action::AgentEvent {
-                        run_id: new_run_id.clone(),
-                        event: event.clone(),
-                    });
+            let prompt = new_run.prompt.clone();
+            let model = new_run.model.clone();
+            let bot_name = new_run.bot_name.clone();
+            drive_headless_run(
+                new_run,
+                HeadlessRunConfig {
+                    working_dir: worktree_path,
+                    prompt,
+                    resume_session_id: None,
+                    model,
+                    bot_name,
+                    permission_mode: None,
                 },
+                &mgr,
+                &tx,
+                |result| Action::AgentRestartComplete { result },
+                "Agent restarted (headless)",
             );
-
-            let _ = std::fs::remove_file(&prompt_file);
-            finish();
-            let _ = tx.send(Action::AgentComplete { run_id: new_run_id });
         });
     }
 

--- a/runkon-flow/src/helpers.rs
+++ b/runkon-flow/src/helpers.rs
@@ -518,19 +518,7 @@ mod tests {
         AgentRef, AlwaysNode, CallNode, CallWorkflowNode, Condition, DoNode, ForEachNode, GateNode,
         GateType, IfNode, OnMaxIter, ParallelNode, ScriptNode, UnlessNode, WhileNode, WorkflowNode,
     };
-
-    fn call_node(name: &str) -> WorkflowNode {
-        WorkflowNode::Call(CallNode {
-            agent: AgentRef::Name(name.to_string()),
-            retries: 0,
-            on_fail: None,
-            output: None,
-            with: vec![],
-            bot_name: None,
-            plugin_dirs: vec![],
-            timeout: None,
-        })
-    }
+    use crate::test_helpers::call_node;
 
     fn script_node(name: &str) -> WorkflowNode {
         WorkflowNode::Script(ScriptNode {

--- a/runkon-flow/tests/common/mod.rs
+++ b/runkon-flow/tests/common/mod.rs
@@ -5,8 +5,8 @@ use std::sync::{Arc, Mutex};
 
 use runkon_flow::cancellation::CancellationToken;
 use runkon_flow::dsl::{
-    AgentRef, ApprovalMode, CallNode, ForEachNode, GateNode, GateType, OnChildFail, OnCycle,
-    OnTimeout, WorkflowDef, WorkflowNode, WorkflowTrigger,
+    ApprovalMode, ForEachNode, GateNode, GateType, OnChildFail, OnCycle, OnTimeout, WorkflowDef,
+    WorkflowNode, WorkflowTrigger,
 };
 use runkon_flow::engine::{
     ChildWorkflowInput, ChildWorkflowRunner, ExecutionState, ResumeContext, WorktreeContext,
@@ -91,7 +91,7 @@ impl ActionExecutor for FailingExecutor {
 // ---------------------------------------------------------------------------
 
 #[allow(unused_imports)]
-pub use runkon_flow::test_helpers::{ForwardSink, VecSink};
+pub use runkon_flow::test_helpers::{call_node, make_def, ForwardSink, VecSink};
 
 // ---------------------------------------------------------------------------
 // State construction helpers
@@ -191,21 +191,8 @@ pub fn make_state_with_resume_ctx(
 // ---------------------------------------------------------------------------
 // WorkflowDef construction helpers
 // ---------------------------------------------------------------------------
-
-pub fn make_def(name: &str, body: Vec<WorkflowNode>) -> WorkflowDef {
-    WorkflowDef {
-        name: name.to_string(),
-        title: None,
-        description: String::new(),
-        trigger: WorkflowTrigger::Manual,
-        targets: vec![],
-        group: None,
-        inputs: vec![],
-        body,
-        always: vec![],
-        source_path: "test.wf".to_string(),
-    }
-}
+// `make_def` and `call_node` are re-exported from `runkon_flow::test_helpers`
+// at the top of this file.
 
 pub fn make_def_with_always(
     name: &str,
@@ -224,19 +211,6 @@ pub fn make_def_with_always(
         always,
         source_path: "test.wf".to_string(),
     }
-}
-
-pub fn call_node(agent: &str) -> WorkflowNode {
-    WorkflowNode::Call(CallNode {
-        agent: AgentRef::Name(agent.to_string()),
-        retries: 0,
-        on_fail: None,
-        output: None,
-        with: vec![],
-        bot_name: None,
-        plugin_dirs: vec![],
-        timeout: None,
-    })
 }
 
 pub fn gate_node(name: &str) -> WorkflowNode {


### PR DESCRIPTION
## Summary

Closes 6 of the 13 ultrareview-flagged duplications in the **cluster:dedup-leftover** triage from the 0.10.0 backlog. The other 7 either already addressed by current code (closed separately as stale) or punted to a follow-up that needs more design (#2646 prompt_builder unification, #2708 drain_stream_json shared parser).

4 commits, one per cohesive change:

- **`8a8b88f8`** — `runkon_bridge.rs`: extract `wrap_child_workflow_err` helper for the cancellation-preserving error wrap (closes #2687, #2695); replace field-by-field `WorkflowExecConfig` literal with `..parent.exec_config.clone()` + override (closes #2692).
- **`574a3b33`** — drop `agent::status::truncate_utf8` (byte-for-byte dup of `text_util::truncate_str`); update 2 callers in `agent::manager::feedback`. Removes 90+ lines of duplicate tests. (closes #2705)
- **`4186a7be`** — consolidate `call_node` and `make_def` test helpers (3× and 2× duplicate definitions) into the existing `runkon_flow::test_helpers` module; tests/common and src/helpers tests now import from one place. (closes #2604)
- **`9dc84ad7`** — extract `drive_headless_run` helper from the 3 TUI spawn flows in `agent_execution.rs`. Each handler shrinks from ~80 lines to ~15. Net -47 lines after the helper. (closes #2701)

The 5 stale issues (#2589, #2680, #2686, #2690, #2694) and 1 duplicate (#2695, dup of #2687) will be closed separately.

## Test plan

- [x] `cargo test -p runkon-flow --lib` (227 pass)
- [x] `cargo test -p runkon-flow --features test-utils --tests` (227 + 6+8+5+10+9 integration tests pass)
- [x] `cargo test -p conductor-core --lib` (1899 pass)
- [x] `cargo test -p conductor-tui --lib` (195 pass)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p runkon-flow -p conductor-core -p conductor-tui --all-targets -- -D warnings`
- [ ] Manual: launch agent / repo agent / restart agent via TUI to confirm `drive_headless_run` behaves identically (the only path with non-trivial behavior surface)

## Targeting release/0.10.0

Most of these dedup targets (`runkon_bridge.rs`, `coordinator.rs` adjacents) only exist on `release/0.10.0` — the runkon-flow extraction phases that introduced the duplication haven't merged to `main` yet. Issues that touch files on both branches (#2604, #2705) are bundled here for cluster cohesion.