### PR TITLE
fix(workflow): `as = "..."` on script steps now injects GH_TOKEN as the named bot

### DIFF
--- a/conductor-core/src/workflow/coordinator.rs
+++ b/conductor-core/src/workflow/coordinator.rs
@@ -1619,12 +1619,22 @@ mod tests {
         from_step: Option<&'a str>,
         db_path: std::path::PathBuf,
     ) -> WorkflowResumeInput<'a> {
+        make_resume_input_with_restart(config, run_id, from_step, db_path, false)
+    }
+
+    fn make_resume_input_with_restart<'a>(
+        config: &'a crate::config::Config,
+        run_id: &'a str,
+        from_step: Option<&'a str>,
+        db_path: std::path::PathBuf,
+        restart: bool,
+    ) -> WorkflowResumeInput<'a> {
         WorkflowResumeInput {
             config,
             workflow_run_id: run_id,
             model: None,
             from_step,
-            restart: false,
+            restart,
             conductor_bin_dir: None,
             event_sinks: vec![],
             db_path: Some(db_path),
@@ -2004,17 +2014,13 @@ mod tests {
         };
 
         let config = crate::config::Config::default();
-        let input = WorkflowResumeInput {
-            config: &config,
-            workflow_run_id: &run_id,
-            model: None,
-            from_step: None,
-            restart: true,
-            conductor_bin_dir: None,
-            event_sinks: vec![],
-            db_path: Some(db_file.path().to_path_buf()),
-            shutdown: None,
-        };
+        let input = make_resume_input_with_restart(
+            &config,
+            &run_id,
+            None,
+            db_file.path().to_path_buf(),
+            true,
+        );
         let result = resume_workflow(&input).expect("restart of empty workflow must succeed");
         assert!(
             result.all_succeeded,

--- a/conductor-core/src/workflow/coordinator.rs
+++ b/conductor-core/src/workflow/coordinator.rs
@@ -595,6 +595,7 @@ pub fn execute_workflow_standalone(params: &WorkflowExecStandalone) -> Result<Wo
     let script_env_provider = super::runkon_bridge::build_rk_script_env_provider(
         params.conductor_bin_dir.clone(),
         params.extra_plugin_dirs.clone(),
+        Arc::new(config.clone()),
     );
 
     let schema_resolver = make_schema_resolver(workflow.name.clone());
@@ -1036,8 +1037,11 @@ pub fn resume_workflow(input: &WorkflowResumeInput<'_>) -> Result<WorkflowResult
         wf_run.repo_id.clone(),
     ));
 
-    let script_env_provider =
-        super::runkon_bridge::build_rk_script_env_provider(input.conductor_bin_dir.clone(), vec![]);
+    let script_env_provider = super::runkon_bridge::build_rk_script_env_provider(
+        input.conductor_bin_dir.clone(),
+        vec![],
+        Arc::new(config.clone()),
+    );
 
     let schema_resolver = make_schema_resolver(wf_run.workflow_name.clone());
 

--- a/conductor-core/src/workflow/coordinator.rs
+++ b/conductor-core/src/workflow/coordinator.rs
@@ -1729,4 +1729,296 @@ mod tests {
             "run_id_notify slot must be populated before any engine work"
         );
     }
+
+    // -------------------------------------------------------------------------
+    // execute_workflow_standalone — happy path
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn execute_workflow_standalone_happy_path_succeeds_and_persists_run() {
+        // An empty workflow (no steps, no targets) completes immediately.
+        // Verifies: validation passes, DB run record is created and reaches
+        // "completed" state, and the engine returns all_succeeded=true.
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+        crate::db::open_database(db_file.path()).unwrap();
+
+        let params = make_standalone_params(db_file.path().to_path_buf(), None, None);
+        let result = execute_workflow_standalone(&params)
+            .expect("empty workflow should complete without error");
+        assert!(
+            result.all_succeeded,
+            "empty workflow must complete with all_succeeded=true"
+        );
+
+        let conn = crate::db::open_database(db_file.path()).unwrap();
+        let status: String = conn
+            .query_row("SELECT status FROM workflow_runs LIMIT 1", [], |r| r.get(0))
+            .expect("workflow run must be persisted in the database");
+        assert_eq!(
+            status, "completed",
+            "workflow run status must be 'completed' after a successful empty-workflow run"
+        );
+    }
+
+    #[test]
+    fn execute_workflow_standalone_inputs_are_persisted() {
+        // Verify that caller-supplied inputs are written to the DB before the
+        // engine executes, so restarts and resumes can read them back.
+        // Note: apply_workflow_input_defaults is the caller's responsibility;
+        // here we pass a pre-merged map directly via params.inputs.
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+        crate::db::open_database(db_file.path()).unwrap();
+
+        let mut params = make_standalone_params(db_file.path().to_path_buf(), None, None);
+        params
+            .inputs
+            .insert("env".to_string(), "staging".to_string());
+
+        execute_workflow_standalone(&params).expect("empty workflow should succeed");
+
+        let conn = crate::db::open_database(db_file.path()).unwrap();
+        let inputs_json: String = conn
+            .query_row("SELECT inputs FROM workflow_runs LIMIT 1", [], |r| r.get(0))
+            .expect("workflow run must be persisted");
+        let inputs: HashMap<String, String> = serde_json::from_str(&inputs_json).unwrap();
+        assert_eq!(
+            inputs.get("env").map(String::as_str),
+            Some("staging"),
+            "caller-supplied input values must be persisted to the DB before engine executes"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // resume_workflow_standalone — error and success paths
+    // -------------------------------------------------------------------------
+
+    fn make_resume_standalone(
+        run_id: &str,
+        from_step: Option<String>,
+        restart: bool,
+        db_path: std::path::PathBuf,
+    ) -> crate::workflow::types::WorkflowResumeStandalone {
+        crate::workflow::types::WorkflowResumeStandalone {
+            config: crate::config::Config::default(),
+            workflow_run_id: run_id.to_string(),
+            model: None,
+            from_step,
+            restart,
+            db_path: Some(db_path),
+            conductor_bin_dir: None,
+            shutdown: None,
+        }
+    }
+
+    fn insert_failed_run_with_repo(
+        conn: &rusqlite::Connection,
+        snapshot_json: Option<&str>,
+    ) -> String {
+        crate::test_helpers::insert_test_repo(conn, "r1", "test-repo", "/tmp");
+        let parent = crate::agent::AgentManager::new(conn)
+            .create_run(None, "workflow", None)
+            .unwrap();
+        let wf_mgr = WorkflowManager::new(conn);
+        let run = wf_mgr
+            .create_workflow_run_with_targets(
+                "test-wf",
+                None,
+                None,
+                Some("r1"),
+                &parent.id,
+                false,
+                "manual",
+                snapshot_json,
+                None,
+                None,
+            )
+            .unwrap();
+        conn.execute(
+            "UPDATE workflow_runs SET status = 'failed' WHERE id = ?1",
+            rusqlite::params![run.id],
+        )
+        .unwrap();
+        run.id
+    }
+
+    #[test]
+    fn resume_workflow_standalone_missing_run_returns_err() {
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+        crate::db::open_database(db_file.path()).unwrap();
+
+        let params =
+            make_resume_standalone("no-such-run-id", None, false, db_file.path().to_path_buf());
+        let err = resume_workflow_standalone(&params).unwrap_err();
+        assert!(
+            err.to_string().contains("not found"),
+            "expected 'not found' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resume_workflow_standalone_missing_snapshot_returns_err() {
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+        let run_id = {
+            let conn = crate::db::open_database(db_file.path()).unwrap();
+            insert_failed_run_with_repo(&conn, None) // no definition_snapshot
+        };
+
+        let params = make_resume_standalone(&run_id, None, false, db_file.path().to_path_buf());
+        let err = resume_workflow_standalone(&params).unwrap_err();
+        assert!(
+            err.to_string().contains("no definition snapshot"),
+            "expected 'no definition snapshot' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn resume_workflow_standalone_success_with_empty_workflow() {
+        // A failed run whose snapshot encodes an empty workflow (no steps) resumes
+        // immediately to completion. Validates the full setup → FlowEngine.resume()
+        // path without any external subprocess or agent.
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+        let snapshot = serde_json::to_string(&make_wf(vec![])).unwrap();
+        let run_id = {
+            let conn = crate::db::open_database(db_file.path()).unwrap();
+            insert_failed_run_with_repo(&conn, Some(&snapshot))
+        };
+
+        let params = make_resume_standalone(&run_id, None, false, db_file.path().to_path_buf());
+        let result =
+            resume_workflow_standalone(&params).expect("resume of empty workflow must succeed");
+        assert!(
+            result.all_succeeded,
+            "resumed empty workflow must complete with all_succeeded=true"
+        );
+    }
+
+    #[test]
+    fn resume_workflow_standalone_with_restart_true_succeeds() {
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+        let snapshot = serde_json::to_string(&make_wf(vec![])).unwrap();
+        let run_id = {
+            let conn = crate::db::open_database(db_file.path()).unwrap();
+            insert_failed_run_with_repo(&conn, Some(&snapshot))
+        };
+
+        let params = make_resume_standalone(&run_id, None, true, db_file.path().to_path_buf());
+        let result =
+            resume_workflow_standalone(&params).expect("restart of empty workflow must succeed");
+        assert!(
+            result.all_succeeded,
+            "restarted empty workflow must complete with all_succeeded=true"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // resume_workflow — happy path with worktree and repo-id targets
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn resume_workflow_happy_path_with_repo_id() {
+        // Verifies the full resume_workflow flow: DB resets, FlowEngine.resume()
+        // call, and final completed status. Uses a repo-based run (worktree_id=None)
+        // so no worktree filesystem access is required.
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+        let snapshot = serde_json::to_string(&make_wf(vec![])).unwrap();
+        let run_id = {
+            let conn = crate::db::open_database(db_file.path()).unwrap();
+            insert_failed_run_with_repo(&conn, Some(&snapshot))
+        };
+
+        let config = crate::config::Config::default();
+        let input = make_resume_input(&config, &run_id, None, db_file.path().to_path_buf());
+        let result = resume_workflow(&input).expect("resume of empty workflow must succeed");
+        assert!(
+            result.all_succeeded,
+            "resumed empty workflow must complete with all_succeeded=true"
+        );
+
+        let conn = crate::db::open_database(db_file.path()).unwrap();
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM workflow_runs WHERE id = ?1",
+                rusqlite::params![run_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            status, "completed",
+            "workflow run must reach 'completed' status after successful resume"
+        );
+    }
+
+    #[test]
+    fn resume_workflow_happy_path_with_worktree() {
+        // Verifies resume when the run has a worktree_id. The worktree path
+        // `/tmp` exists so no fallback to repo root is needed, and the empty
+        // workflow completes without any step execution.
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+        let snapshot = serde_json::to_string(&make_wf(vec![])).unwrap();
+        let run_id = {
+            let conn = crate::db::open_database(db_file.path()).unwrap();
+            // insert_test_repo / insert_test_worktree use "/tmp" paths that exist.
+            crate::test_helpers::insert_test_repo(&conn, "r1", "test-repo", "/tmp");
+            crate::test_helpers::insert_test_worktree(&conn, "w1", "r1", "feat-test", "/tmp");
+            let parent = crate::agent::AgentManager::new(&conn)
+                .create_run(Some("w1"), "workflow", None)
+                .unwrap();
+            let wf_mgr = WorkflowManager::new(&conn);
+            let run = wf_mgr
+                .create_workflow_run(
+                    "test-wf",
+                    Some("w1"),
+                    &parent.id,
+                    false,
+                    "manual",
+                    Some(&snapshot),
+                )
+                .unwrap();
+            conn.execute(
+                "UPDATE workflow_runs SET status = 'failed' WHERE id = ?1",
+                rusqlite::params![run.id],
+            )
+            .unwrap();
+            run.id
+        };
+
+        let config = crate::config::Config::default();
+        let input = make_resume_input(&config, &run_id, None, db_file.path().to_path_buf());
+        let result = resume_workflow(&input).expect("resume with worktree must succeed");
+        assert!(
+            result.all_succeeded,
+            "resumed empty workflow must complete with all_succeeded=true"
+        );
+    }
+
+    #[test]
+    fn resume_workflow_with_restart_resets_all_steps() {
+        // With restart=true, resume_workflow clears all steps, then runs the
+        // engine from scratch. For an empty workflow this is a no-op, but the
+        // function must still return Ok.
+        let db_file = tempfile::NamedTempFile::new().unwrap();
+        let snapshot = serde_json::to_string(&make_wf(vec![])).unwrap();
+        let run_id = {
+            let conn = crate::db::open_database(db_file.path()).unwrap();
+            insert_failed_run_with_repo(&conn, Some(&snapshot))
+        };
+
+        let config = crate::config::Config::default();
+        let input = WorkflowResumeInput {
+            config: &config,
+            workflow_run_id: &run_id,
+            model: None,
+            from_step: None,
+            restart: true,
+            conductor_bin_dir: None,
+            event_sinks: vec![],
+            db_path: Some(db_file.path().to_path_buf()),
+            shutdown: None,
+        };
+        let result = resume_workflow(&input).expect("restart of empty workflow must succeed");
+        assert!(
+            result.all_succeeded,
+            "restarted empty workflow must complete with all_succeeded=true"
+        );
+    }
 }

--- a/conductor-core/src/workflow/runkon_bridge.rs
+++ b/conductor-core/src/workflow/runkon_bridge.rs
@@ -541,16 +541,24 @@ pub(super) fn build_rk_item_provider_registry(
 
 /// Build a `ScriptEnvProvider` for use with runkon-flow.
 ///
-/// Uses `ConductorScriptEnvProvider` so that script steps inherit the
-/// conductor binary directory and any extra plugin directories on `PATH`.
+/// Uses `ConductorScriptEnvProvider` so that script steps inherit:
+/// - the conductor binary directory and any extra plugin directories on `PATH`
+/// - a `GH_TOKEN` resolved from a per-step `as = "..."` (or workflow-level
+///   default bot) when the named bot is configured under `[github.apps.<name>]`
+///
+/// `config` is wrapped in an `Arc` so the provider can stay alive past the
+/// caller's stack frame and resolve a fresh installation token per script
+/// step (tokens have a 1-hour lifetime, so re-resolving each call is fine).
 pub(super) fn build_rk_script_env_provider(
     conductor_bin_dir: Option<std::path::PathBuf>,
     extra_plugin_dirs: Vec<String>,
+    config: Arc<crate::config::Config>,
 ) -> Arc<dyn runkon_flow::traits::script_env_provider::ScriptEnvProvider> {
     Arc::new(
         crate::workflow::script_env_provider::ConductorScriptEnvProvider::new(
             conductor_bin_dir,
             extra_plugin_dirs,
+            config,
         ),
     )
 }

--- a/conductor-core/src/workflow/script_env_provider.rs
+++ b/conductor-core/src/workflow/script_env_provider.rs
@@ -1,32 +1,47 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use runkon_flow::traits::run_context::RunContext;
 use runkon_flow::traits::script_env_provider::ScriptEnvProvider;
 
+use crate::config::Config;
+use crate::github_app::{resolve_named_app_token, TokenResolution};
+
 /// Conductor-specific script env provider.
 ///
-/// Composes a `PATH` that prepends `conductor_bin_dir` and any extra plugin
-/// directories in front of the inherited `PATH`, then delegates env building
-/// to the caller's script executor.
+/// Composes:
+///
+/// 1. A `PATH` that prepends `conductor_bin_dir` and any extra plugin
+///    directories in front of the inherited `PATH`, so script steps can
+///    invoke the `conductor` binary without it needing to be on the user's
+///    `$PATH`.
+/// 2. A `GH_TOKEN` env var resolved from the workflow step's `as = "..."`
+///    directive (or the workflow-level default bot), so `gh` calls in the
+///    script run as that GitHub App identity rather than the conductor
+///    user. Falls back to the user's `gh` credentials when no bot is
+///    requested or token resolution fails.
 pub(crate) struct ConductorScriptEnvProvider {
     conductor_bin_dir: Option<std::path::PathBuf>,
     extra_plugin_dirs: Vec<String>,
+    config: Arc<Config>,
 }
 
 impl ConductorScriptEnvProvider {
     pub(crate) fn new(
         conductor_bin_dir: Option<std::path::PathBuf>,
         extra_plugin_dirs: Vec<String>,
+        config: Arc<Config>,
     ) -> Self {
         Self {
             conductor_bin_dir,
             extra_plugin_dirs,
+            config,
         }
     }
 }
 
 impl ScriptEnvProvider for ConductorScriptEnvProvider {
-    fn env(&self, _ctx: &dyn RunContext) -> HashMap<String, String> {
+    fn env(&self, _ctx: &dyn RunContext, bot_name: Option<&str>) -> HashMap<String, String> {
         let mut env = HashMap::new();
         if let Some(ref bin_dir) = self.conductor_bin_dir {
             let existing = std::env::var("PATH").unwrap_or_default();
@@ -37,6 +52,37 @@ impl ScriptEnvProvider for ConductorScriptEnvProvider {
             }
             env.insert("PATH".to_string(), parts.join(":"));
         }
+
+        // Resolve a GitHub App installation token for the requested bot
+        // identity. NotConfigured / Fallback both leave GH_TOKEN unset so
+        // the script falls back to the user's `gh auth` credentials.
+        if let Some(name) = bot_name {
+            match resolve_named_app_token(&self.config, Some(name), "script") {
+                TokenResolution::AppToken(token) => {
+                    env.insert("GH_TOKEN".to_string(), token);
+                }
+                TokenResolution::Fallback { reason } => {
+                    tracing::warn!(
+                        bot = name,
+                        reason = %reason,
+                        "GitHub App token resolution failed for `as = \"{}\"`; \
+                         script will use the gh CLI user identity",
+                        name
+                    );
+                }
+                TokenResolution::NotConfigured => {
+                    tracing::warn!(
+                        bot = name,
+                        "Workflow requested `as = \"{}\"` but no matching \
+                         [github.apps.{}] is configured; script will use the \
+                         gh CLI user identity",
+                        name,
+                        name
+                    );
+                }
+            }
+        }
+
         env
     }
 }
@@ -59,17 +105,21 @@ mod tests {
     }
 
     #[test]
-    fn test_env_empty_when_no_bin_dir() {
-        let provider = ConductorScriptEnvProvider::new(None, vec![]);
-        let env = provider.env(&NoopCtx);
-        assert!(env.is_empty(), "expected empty env when no bin_dir is set");
+    fn test_env_empty_when_no_bin_dir_and_no_bot() {
+        let provider = ConductorScriptEnvProvider::new(None, vec![], Arc::new(Config::default()));
+        let env = provider.env(&NoopCtx, None);
+        assert!(
+            env.is_empty(),
+            "expected empty env when no bin_dir and no bot, got: {env:?}"
+        );
     }
 
     #[test]
     fn test_env_path_starts_with_bin_dir() {
         let bin_dir = std::path::PathBuf::from("/usr/local/bin/conductor-dir");
-        let provider = ConductorScriptEnvProvider::new(Some(bin_dir), vec![]);
-        let env = provider.env(&NoopCtx);
+        let provider =
+            ConductorScriptEnvProvider::new(Some(bin_dir), vec![], Arc::new(Config::default()));
+        let env = provider.env(&NoopCtx, None);
         let path = env.get("PATH").expect("PATH should be set");
         assert!(
             path.starts_with("/usr/local/bin/conductor-dir"),
@@ -83,12 +133,33 @@ mod tests {
         let provider = ConductorScriptEnvProvider::new(
             Some(bin_dir),
             vec!["/opt/plugins".to_string(), "/home/user/plugins".to_string()],
+            Arc::new(Config::default()),
         );
-        let env = provider.env(&NoopCtx);
+        let env = provider.env(&NoopCtx, None);
         let path = env.get("PATH").expect("PATH should be set");
         let parts: Vec<&str> = path.splitn(4, ':').collect();
         assert_eq!(parts[0], "/bin/conductor");
         assert_eq!(parts[1], "/opt/plugins");
         assert_eq!(parts[2], "/home/user/plugins");
+    }
+
+    #[test]
+    fn bot_name_with_no_app_configured_omits_gh_token() {
+        // No [github.apps.<name>] configured → NotConfigured branch.
+        // Caller must NOT see a GH_TOKEN in the env (otherwise scripts
+        // would inherit a stale or empty token).
+        let provider = ConductorScriptEnvProvider::new(None, vec![], Arc::new(Config::default()));
+        let env = provider.env(&NoopCtx, Some("reviewer"));
+        assert!(
+            !env.contains_key("GH_TOKEN"),
+            "GH_TOKEN must not be set when the named bot is not configured"
+        );
+    }
+
+    #[test]
+    fn no_bot_name_omits_gh_token() {
+        let provider = ConductorScriptEnvProvider::new(None, vec![], Arc::new(Config::default()));
+        let env = provider.env(&NoopCtx, None);
+        assert!(!env.contains_key("GH_TOKEN"));
     }
 }

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -108,7 +108,9 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
     // Build environment variables
     let mut env_vars: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
-    // Inject PATH and other env from the script env provider
+    // Inject PATH, GH_TOKEN (when `as = "..."` resolves to a host-known bot),
+    // and other env from the script env provider. Falls back to the
+    // workflow-level default bot when the step doesn't specify one.
     {
         struct ScriptRunCtx<'a> {
             working_dir: &'a str,
@@ -138,7 +140,11 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
             working_dir: &state.worktree_ctx.working_dir,
             repo_path: &state.worktree_ctx.repo_path,
         };
-        let provider_env = state.script_env_provider.env(&run_ctx);
+        let effective_bot = node
+            .bot_name
+            .as_deref()
+            .or(state.default_bot_name.as_deref());
+        let provider_env = state.script_env_provider.env(&run_ctx, effective_bot);
         env_vars.extend(provider_env);
     }
 

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -176,6 +176,9 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
         "PYTHONPATH",
         "RUBYLIB",
         "NODE_PATH",
+        // Protect the bot-identity token resolved by `as = "..."` from being
+        // silently overwritten by a workflow-authored env block.
+        "GH_TOKEN",
     ];
     for (k, v) in &node.env {
         if k.contains('=') || k.contains('\0') {

--- a/runkon-flow/src/flow_engine.rs
+++ b/runkon-flow/src/flow_engine.rs
@@ -816,7 +816,11 @@ mod tests {
     fn custom_script_env_provider_is_stored_in_bundle() {
         struct FixedEnvProvider;
         impl ScriptEnvProvider for FixedEnvProvider {
-            fn env(&self, _ctx: &dyn RunContext) -> HashMap<String, String> {
+            fn env(
+                &self,
+                _ctx: &dyn RunContext,
+                _bot_name: Option<&str>,
+            ) -> HashMap<String, String> {
                 let mut m = HashMap::new();
                 m.insert("CUSTOM_VAR".to_string(), "42".to_string());
                 m
@@ -841,7 +845,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let env = engine.script_env_provider.env(&NoopCtx);
+        let env = engine.script_env_provider.env(&NoopCtx, None);
         assert_eq!(env.get("CUSTOM_VAR").map(String::as_str), Some("42"));
     }
 

--- a/runkon-flow/src/traits/script_env_provider.rs
+++ b/runkon-flow/src/traits/script_env_provider.rs
@@ -2,15 +2,22 @@ use std::collections::HashMap;
 
 use crate::traits::run_context::RunContext;
 
+/// Builds the per-script-step environment.
+///
+/// `bot_name`, when `Some`, identifies a host-configured bot identity
+/// (e.g. a GitHub App installation) the host should resolve into auth
+/// material — typically a `GH_TOKEN` env var so the script's `gh` calls
+/// run as that bot rather than the conductor user. Provider impls that
+/// don't support bot identities should ignore the parameter.
 pub trait ScriptEnvProvider: Send + Sync {
-    fn env(&self, ctx: &dyn RunContext) -> HashMap<String, String>;
+    fn env(&self, ctx: &dyn RunContext, bot_name: Option<&str>) -> HashMap<String, String>;
 }
 
 /// No-op default — returns empty env when no provider is configured.
 pub struct NoOpScriptEnvProvider;
 
 impl ScriptEnvProvider for NoOpScriptEnvProvider {
-    fn env(&self, _ctx: &dyn RunContext) -> HashMap<String, String> {
+    fn env(&self, _ctx: &dyn RunContext, _bot_name: Option<&str>) -> HashMap<String, String> {
         HashMap::new()
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2716. After Phase 3.1 (#2568) moved script execution from conductor-core's executor (which correctly resolved `bot_name` and injected `GH_TOKEN`) to runkon-flow's, the new executor stopped reading `ScriptNode.bot_name` — so `as = "reviewer"` parsed but silently dropped, and `gh pr review` ran with the conductor user's credentials. PR #2715 reproduced this: the review came from `devinrosen` instead of the `[github.apps.reviewer]` bot.

This PR restores the original behavior:

- **Trait change** (`runkon-flow/src/traits/script_env_provider.rs`): `ScriptEnvProvider::env` now takes `bot_name: Option<&str>`. `NoOpScriptEnvProvider` and the test fixture ignore it.
- **Executor** (`runkon-flow/src/executors/script.rs`): computes `effective_bot = node.bot_name.or(state.default_bot_name)` (matching the original conductor-core fallback) and passes it to the provider.
- **Provider impl** (`conductor-core/src/workflow/script_env_provider.rs`): now holds `Arc<Config>`; when `bot_name` is `Some`, calls `resolve_named_app_token` and inserts `GH_TOKEN`. `NotConfigured` and `Fallback` log a warning so the silent drop becomes loud.
- **Wiring** (`runkon_bridge.rs`, `coordinator.rs`): both `execute_workflow_standalone` and `resume_workflow` thread `Arc::new(config.clone())` into the provider builder.

The bug only exists on `release/0.10.0` — `main` still uses the pre-Phase-3 conductor-core executor which never regressed. Targeting `release/0.10.0`; will flow to `main` on the eventual merge.

## Test plan

- [x] `cargo test -p runkon-flow --lib` (227 pass)
- [x] `cargo test -p runkon-flow --features test-utils --tests` (227 + 6+8+5+10+9 integration pass)
- [x] `cargo test -p conductor-core --lib` (1901 pass — 2 new tests for the GH_TOKEN injection paths)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p runkon-flow -p conductor-core --all-targets -- -D warnings`
- [ ] **Manual verify**: run iterate-pr.wf on a fresh PR with `[github.apps.reviewer]` configured, confirm the submitted review is authored by the bot identity, not `devinrosen`. The unit tests cover the env-build paths but can't exercise the full token-exchange flow.