### PR TITLE
refactor(persistence): hoist token columns onto workflow_run_steps (Path X.1)

### DIFF
--- a/conductor-core/src/agent/manager/lifecycle.rs
+++ b/conductor-core/src/agent/manager/lifecycle.rs
@@ -294,6 +294,31 @@ impl<'a> AgentManager<'a> {
                 ":id": run_id,
             },
         )?;
+        // Mirror metrics onto the linked workflow step row, if any (Path X.1).
+        // Unlike the agent_runs UPDATE above, this is unconditional w.r.t. the
+        // step's status — workflow steps transition independently and the
+        // engine relies on these values being readable after the run terminates.
+        self.conn.execute(
+            "UPDATE workflow_run_steps \
+             SET cost_usd = COALESCE(:cost_usd, cost_usd), \
+                 num_turns = COALESCE(:num_turns, num_turns), \
+                 duration_ms = COALESCE(:duration_ms, duration_ms), \
+                 input_tokens = COALESCE(:input_tokens, input_tokens), \
+                 output_tokens = COALESCE(:output_tokens, output_tokens), \
+                 cache_read_input_tokens = COALESCE(:cache_read_input_tokens, cache_read_input_tokens), \
+                 cache_creation_input_tokens = COALESCE(:cache_creation_input_tokens, cache_creation_input_tokens) \
+             WHERE child_run_id = :id",
+            named_params! {
+                ":cost_usd": log_result.cost_usd,
+                ":num_turns": log_result.num_turns,
+                ":duration_ms": log_result.duration_ms,
+                ":input_tokens": log_result.input_tokens,
+                ":output_tokens": log_result.output_tokens,
+                ":cache_read_input_tokens": log_result.cache_read_input_tokens,
+                ":cache_creation_input_tokens": log_result.cache_creation_input_tokens,
+                ":id": run_id,
+            },
+        )?;
         Ok(())
     }
 
@@ -349,6 +374,10 @@ impl<'a> AgentManager<'a> {
     /// using `+=` would multiply-count tokens.  The final [`update_run_completed`]
     /// call overwrites these columns with the authoritative values from the
     /// `result` event.
+    ///
+    /// The same values are mirrored onto any `workflow_run_steps` row whose
+    /// `child_run_id` points at this run (Path X.1) so runkon-flow's persistence
+    /// layer can read step metrics without JOINing `agent_runs`.
     pub fn update_run_tokens_partial(
         &self,
         run_id: &str,
@@ -363,6 +392,20 @@ impl<'a> AgentManager<'a> {
                  cache_read_input_tokens = :cache_read_input_tokens, \
                  cache_creation_input_tokens = :cache_creation_input_tokens \
              WHERE id = :id",
+            named_params! {
+                ":input_tokens": input_tokens,
+                ":output_tokens": output_tokens,
+                ":cache_read_input_tokens": cache_read_input_tokens,
+                ":cache_creation_input_tokens": cache_creation_input_tokens,
+                ":id": run_id,
+            },
+        )?;
+        self.conn.execute(
+            "UPDATE workflow_run_steps \
+             SET input_tokens = :input_tokens, output_tokens = :output_tokens, \
+                 cache_read_input_tokens = :cache_read_input_tokens, \
+                 cache_creation_input_tokens = :cache_creation_input_tokens \
+             WHERE child_run_id = :id",
             named_params! {
                 ":input_tokens": input_tokens,
                 ":output_tokens": output_tokens,

--- a/conductor-core/src/agent/manager/lifecycle.rs
+++ b/conductor-core/src/agent/manager/lifecycle.rs
@@ -298,26 +298,15 @@ impl<'a> AgentManager<'a> {
         // Unlike the agent_runs UPDATE above, this is unconditional w.r.t. the
         // step's status — workflow steps transition independently and the
         // engine relies on these values being readable after the run terminates.
-        self.conn.execute(
-            "UPDATE workflow_run_steps \
-             SET cost_usd = COALESCE(:cost_usd, cost_usd), \
-                 num_turns = COALESCE(:num_turns, num_turns), \
-                 duration_ms = COALESCE(:duration_ms, duration_ms), \
-                 input_tokens = COALESCE(:input_tokens, input_tokens), \
-                 output_tokens = COALESCE(:output_tokens, output_tokens), \
-                 cache_read_input_tokens = COALESCE(:cache_read_input_tokens, cache_read_input_tokens), \
-                 cache_creation_input_tokens = COALESCE(:cache_creation_input_tokens, cache_creation_input_tokens) \
-             WHERE child_run_id = :id",
-            named_params! {
-                ":cost_usd": log_result.cost_usd,
-                ":num_turns": log_result.num_turns,
-                ":duration_ms": log_result.duration_ms,
-                ":input_tokens": log_result.input_tokens,
-                ":output_tokens": log_result.output_tokens,
-                ":cache_read_input_tokens": log_result.cache_read_input_tokens,
-                ":cache_creation_input_tokens": log_result.cache_creation_input_tokens,
-                ":id": run_id,
-            },
+        crate::workflow::WorkflowManager::new(self.conn).mirror_step_metrics_from_run(
+            run_id,
+            log_result.cost_usd,
+            log_result.num_turns,
+            log_result.duration_ms,
+            log_result.input_tokens,
+            log_result.output_tokens,
+            log_result.cache_read_input_tokens,
+            log_result.cache_creation_input_tokens,
         )?;
         Ok(())
     }
@@ -400,19 +389,15 @@ impl<'a> AgentManager<'a> {
                 ":id": run_id,
             },
         )?;
-        self.conn.execute(
-            "UPDATE workflow_run_steps \
-             SET input_tokens = :input_tokens, output_tokens = :output_tokens, \
-                 cache_read_input_tokens = :cache_read_input_tokens, \
-                 cache_creation_input_tokens = :cache_creation_input_tokens \
-             WHERE child_run_id = :id",
-            named_params! {
-                ":input_tokens": input_tokens,
-                ":output_tokens": output_tokens,
-                ":cache_read_input_tokens": cache_read_input_tokens,
-                ":cache_creation_input_tokens": cache_creation_input_tokens,
-                ":id": run_id,
-            },
+        crate::workflow::WorkflowManager::new(self.conn).mirror_step_metrics_from_run(
+            run_id,
+            None,
+            None,
+            None,
+            Some(input_tokens),
+            Some(output_tokens),
+            Some(cache_read_input_tokens),
+            Some(cache_creation_input_tokens),
         )?;
         Ok(())
     }

--- a/conductor-core/src/agent/manager/lifecycle.rs
+++ b/conductor-core/src/agent/manager/lifecycle.rs
@@ -300,13 +300,15 @@ impl<'a> AgentManager<'a> {
         // engine relies on these values being readable after the run terminates.
         crate::workflow::WorkflowManager::new(self.conn).mirror_step_metrics_from_run(
             run_id,
-            log_result.cost_usd,
-            log_result.num_turns,
-            log_result.duration_ms,
-            log_result.input_tokens,
-            log_result.output_tokens,
-            log_result.cache_read_input_tokens,
-            log_result.cache_creation_input_tokens,
+            crate::workflow::StepMetrics {
+                cost_usd: log_result.cost_usd,
+                num_turns: log_result.num_turns,
+                duration_ms: log_result.duration_ms,
+                input_tokens: log_result.input_tokens,
+                output_tokens: log_result.output_tokens,
+                cache_read_input_tokens: log_result.cache_read_input_tokens,
+                cache_creation_input_tokens: log_result.cache_creation_input_tokens,
+            },
         )?;
         Ok(())
     }
@@ -391,13 +393,13 @@ impl<'a> AgentManager<'a> {
         )?;
         crate::workflow::WorkflowManager::new(self.conn).mirror_step_metrics_from_run(
             run_id,
-            None,
-            None,
-            None,
-            Some(input_tokens),
-            Some(output_tokens),
-            Some(cache_read_input_tokens),
-            Some(cache_creation_input_tokens),
+            crate::workflow::StepMetrics {
+                input_tokens: Some(input_tokens),
+                output_tokens: Some(output_tokens),
+                cache_read_input_tokens: Some(cache_read_input_tokens),
+                cache_creation_input_tokens: Some(cache_creation_input_tokens),
+                ..Default::default()
+            },
         )?;
         Ok(())
     }

--- a/conductor-core/src/db/migrations.rs
+++ b/conductor-core/src/db/migrations.rs
@@ -5,7 +5,7 @@ use crate::error::{ConductorError, Result};
 
 /// The highest migration version this binary knows about.
 /// **When adding a new migration, update this constant to match the new version.**
-pub const LATEST_SCHEMA_VERSION: u32 = 80;
+pub const LATEST_SCHEMA_VERSION: u32 = 81;
 
 /// Legacy plan step shape used only for migrating JSON data from agent_runs.plan.
 #[derive(Deserialize)]
@@ -1187,6 +1187,57 @@ pub fn run(conn: &Connection) -> Result<()> {
             })?;
         }
         bump_version(conn, 80)?;
+    }
+
+    // Migration 081: hoist token / cost / duration columns onto workflow_run_steps.
+    // Path X.1 — lets runkon-flow's persistence layer read step metrics without
+    // JOINing the conductor-specific agent_runs table. Column-existence guard
+    // handles DBs that already have these columns from feature branches.
+    //
+    // Backfill is split out of the .sql file so partial-schema test setups
+    // (missing agent_runs or its token columns) survive the ALTER TABLE step.
+    // Both the workflow_run_steps existence check and the agent_runs source-
+    // column check are required because some unit tests build minimal fixtures
+    // that omit one or both tables.
+    if version < 81 {
+        let has_workflow_run_steps_table: bool = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='table' AND name='workflow_run_steps'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n > 0)
+            .unwrap_or(false);
+        let has_step_input_tokens: bool = has_workflow_run_steps_table
+            && conn
+                .prepare("SELECT input_tokens FROM workflow_run_steps LIMIT 0")
+                .is_ok();
+        if has_workflow_run_steps_table && !has_step_input_tokens {
+            conn.execute_batch(include_str!(
+                "migrations/081_workflow_step_token_columns.sql"
+            ))?;
+        }
+        // Backfill from agent_runs only when both tables and the source columns
+        // exist. In production migrations always reach here with both present;
+        // only synthetic test schemas omit them.
+        let agent_runs_has_input_tokens: bool = conn
+            .prepare("SELECT input_tokens FROM agent_runs LIMIT 0")
+            .is_ok();
+        if agent_runs_has_input_tokens {
+            conn.execute_batch(
+                "UPDATE workflow_run_steps \
+                 SET (input_tokens, output_tokens, cache_read_input_tokens, \
+                      cache_creation_input_tokens, cost_usd, num_turns, duration_ms) = ( \
+                     SELECT ar.input_tokens, ar.output_tokens, ar.cache_read_input_tokens, \
+                            ar.cache_creation_input_tokens, ar.cost_usd, ar.num_turns, ar.duration_ms \
+                     FROM agent_runs ar \
+                     WHERE ar.id = workflow_run_steps.child_run_id) \
+                 WHERE child_run_id IS NOT NULL \
+                   AND input_tokens IS NULL",
+            )?;
+        }
+        bump_version(conn, 81)?;
     }
 
     Ok(())

--- a/conductor-core/src/db/migrations/081_workflow_step_token_columns.sql
+++ b/conductor-core/src/db/migrations/081_workflow_step_token_columns.sql
@@ -1,0 +1,20 @@
+-- Migration 081: hoist token / cost / duration columns onto workflow_run_steps.
+--
+-- Path X.1 of the persistence-layer cleanup (Phase 4 prep). These columns
+-- previously lived only on agent_runs and were JOINed at read time via
+-- workflow_run_steps.child_run_id. Moving them onto workflow_run_steps lets
+-- runkon-flow's persistence layer read step rows without reaching into the
+-- conductor-specific agent_runs table.
+--
+-- Backfill of existing data is performed in Rust (see migrations.rs) so that
+-- partial-schema test setups without agent_runs.input_tokens still pass the
+-- ALTER TABLE step. agent_runs keeps its copy of the same columns for now;
+-- deduplication is tracked as Path X.2.
+
+ALTER TABLE workflow_run_steps ADD COLUMN input_tokens INTEGER;
+ALTER TABLE workflow_run_steps ADD COLUMN output_tokens INTEGER;
+ALTER TABLE workflow_run_steps ADD COLUMN cache_read_input_tokens INTEGER;
+ALTER TABLE workflow_run_steps ADD COLUMN cache_creation_input_tokens INTEGER;
+ALTER TABLE workflow_run_steps ADD COLUMN cost_usd REAL;
+ALTER TABLE workflow_run_steps ADD COLUMN num_turns INTEGER;
+ALTER TABLE workflow_run_steps ADD COLUMN duration_ms INTEGER;

--- a/conductor-core/src/workflow/constants.rs
+++ b/conductor-core/src/workflow/constants.rs
@@ -16,7 +16,9 @@ pub(super) const STEP_COLUMNS: &str =
      iteration, parallel_group_id, context_out, markers_out, retry_count, \
      gate_type, gate_prompt, gate_timeout, gate_approved_by, gate_approved_at, gate_feedback, \
      structured_output, output_file, gate_options, gate_selections, \
-     fan_out_total, fan_out_completed, fan_out_failed, fan_out_skipped, step_error";
+     fan_out_total, fan_out_completed, fan_out_failed, fan_out_skipped, step_error, \
+     input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens, \
+     cost_usd, num_turns, duration_ms";
 
 /// Table-prefixed variant of `STEP_COLUMNS` for JOIN queries where `s` aliases `workflow_run_steps`.
 /// Use this when selecting step columns alongside columns from other tables to avoid ambiguity.
@@ -46,7 +48,9 @@ mod tests {
              s.iteration, s.parallel_group_id, s.context_out, s.markers_out, s.retry_count, \
              s.gate_type, s.gate_prompt, s.gate_timeout, s.gate_approved_by, s.gate_approved_at, \
              s.gate_feedback, s.structured_output, s.output_file, s.gate_options, s.gate_selections, \
-             s.fan_out_total, s.fan_out_completed, s.fan_out_failed, s.fan_out_skipped, s.step_error"
+             s.fan_out_total, s.fan_out_completed, s.fan_out_failed, s.fan_out_skipped, s.step_error, \
+             s.input_tokens, s.output_tokens, s.cache_read_input_tokens, s.cache_creation_input_tokens, \
+             s.cost_usd, s.num_turns, s.duration_ms"
         );
 
         let cols: Vec<&str> = STEP_COLUMNS_WITH_PREFIX.split(", ").collect();
@@ -61,6 +65,6 @@ mod tests {
 
         // Spot-check first and last known columns.
         assert_eq!(cols.first().copied(), Some("s.id"));
-        assert_eq!(cols.last().copied(), Some("s.step_error"));
+        assert_eq!(cols.last().copied(), Some("s.duration_ms"));
     }
 }

--- a/conductor-core/src/workflow/manager/mod.rs
+++ b/conductor-core/src/workflow/manager/mod.rs
@@ -10,6 +10,7 @@ mod steps;
 mod tests;
 
 pub use definitions::InvalidWorkflowEntry;
+pub use steps::StepMetrics;
 
 #[allow(unused_imports)]
 pub(super) use helpers::{row_to_workflow_run, row_to_workflow_step};

--- a/conductor-core/src/workflow/manager/queries.rs
+++ b/conductor-core/src/workflow/manager/queries.rs
@@ -52,14 +52,10 @@ fn granularity_to_strftime_format(granularity: TimeGranularity) -> &'static str 
 }
 
 impl<'a> WorkflowManager<'a> {
-    /// Cost and token columns from the agent_runs join, used in gate step queries.
-    const AGENT_RUN_TOKEN_COLS: &'static str =
-        "ar.input_tokens, ar.output_tokens, ar.cache_read_input_tokens, ar.cache_creation_input_tokens, ar.cost_usd, ar.num_turns, ar.duration_ms";
-
-    /// Common SELECT clause for step queries with agent run token and cost data.
-    const STEP_SELECT_WITH_TOKENS: &'static str = "SELECT {cols}, ar.input_tokens, ar.output_tokens, ar.cache_read_input_tokens, ar.cache_creation_input_tokens, ar.cost_usd, ar.num_turns, ar.duration_ms \
-                 FROM workflow_run_steps s \
-                 LEFT JOIN agent_runs ar ON s.child_run_id = ar.id";
+    /// Common SELECT clause for step queries. Token / cost / duration columns
+    /// live on `workflow_run_steps` directly since migration 081 — no JOIN to
+    /// `agent_runs` required.
+    const STEP_SELECT_WITH_TOKENS: &'static str = "SELECT {cols} FROM workflow_run_steps s";
 
     /// Common subquery to get N most recent completed runs for a workflow.
     const N_RECENT_COMPLETED_RUNS_SUBQUERY: &'static str = "SELECT id FROM workflow_runs \
@@ -852,15 +848,13 @@ impl<'a> WorkflowManager<'a> {
         let placeholders = sql_placeholders(WorkflowRunStatus::ACTIVE.len());
         let active_strings = WorkflowRunStatus::active_strings();
         let sql = format!(
-            "SELECT {cols}, {token_cols}, r.workflow_name, r.target_label \
+            "SELECT {cols}, r.workflow_name, r.target_label \
              FROM workflow_run_steps s \
-             LEFT JOIN agent_runs ar ON ar.id = s.child_run_id \
              JOIN workflow_runs r ON r.id = s.workflow_run_id \
              WHERE s.gate_type IS NOT NULL AND s.status = 'waiting' \
              AND r.status IN ({placeholders}) \
              ORDER BY s.started_at",
             cols = &*STEP_COLUMNS_WITH_PREFIX,
-            token_cols = Self::AGENT_RUN_TOKEN_COLS,
         );
         crate::db::query_collect(
             self.conn,
@@ -878,9 +872,8 @@ impl<'a> WorkflowManager<'a> {
         let active_strings = WorkflowRunStatus::active_strings();
         let status_placeholders = sql_placeholders(active_strings.len());
         let sql = format!(
-            "SELECT {cols}, {token_cols}, r.workflow_name, r.target_label, wt.branch, t.source_id AS ticket_ref, r.definition_snapshot \
+            "SELECT {cols}, r.workflow_name, r.target_label, wt.branch, t.source_id AS ticket_ref, r.definition_snapshot \
              FROM workflow_run_steps s \
-             LEFT JOIN agent_runs ar ON ar.id = s.child_run_id \
              JOIN workflow_runs r ON r.id = s.workflow_run_id \
              LEFT JOIN worktrees wt ON wt.id = r.worktree_id \
              LEFT JOIN tickets t ON t.id = r.ticket_id \
@@ -889,7 +882,6 @@ impl<'a> WorkflowManager<'a> {
              AND (r.repo_id = ? OR wt.repo_id = ?) \
              ORDER BY s.started_at",
             cols = &*STEP_COLUMNS_WITH_PREFIX,
-            token_cols = Self::AGENT_RUN_TOKEN_COLS,
         );
         let mut all_params: Vec<rusqlite::types::Value> = active_strings
             .into_iter()
@@ -2043,11 +2035,13 @@ mod tests {
         assert!(empty.is_empty(), "empty input → empty result");
     }
 
-    /// Verify that token values stored in `agent_runs` are correctly propagated into
-    /// `WorkflowRunStep` when fetched via `find_waiting_gate` (which uses
-    /// `STEP_SELECT_WITH_TOKENS` + `row_to_workflow_step`).
+    /// Verify that token values stored on `workflow_run_steps` (Path X.1) surface
+    /// on `WorkflowRunStep` when fetched via `find_waiting_gate` (which uses
+    /// `STEP_SELECT_WITH_TOKENS` + `row_to_workflow_step`). Tokens used to come
+    /// from a JOIN to `agent_runs`; after migration 081 they live directly on
+    /// the step row.
     #[test]
-    fn find_waiting_gate_propagates_agent_run_tokens() {
+    fn find_waiting_gate_propagates_step_tokens() {
         let conn = setup_db();
 
         conn.execute(
@@ -2059,21 +2053,12 @@ mod tests {
         .unwrap();
 
         conn.execute(
-            "INSERT INTO agent_runs \
-             (id, prompt, status, started_at, input_tokens, output_tokens, \
-              cache_read_input_tokens, cache_creation_input_tokens) \
-             VALUES ('ar-gate-1', 'do something', 'completed', datetime('now'), \
-                     1000, 200, 50, 75)",
-            [],
-        )
-        .unwrap();
-
-        conn.execute(
             "INSERT INTO workflow_run_steps \
              (id, workflow_run_id, step_name, role, status, position, \
-              gate_type, child_run_id) \
+              gate_type, child_run_id, \
+              input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens) \
              VALUES ('step-gate-1', 'run-gate-1', 'review', 'gate', 'waiting', 0, \
-                     'human_approval', 'ar-gate-1')",
+                     'human_approval', NULL, 1000, 200, 50, 75)",
             [],
         )
         .unwrap();

--- a/conductor-core/src/workflow/manager/steps.rs
+++ b/conductor-core/src/workflow/manager/steps.rs
@@ -272,6 +272,47 @@ impl<'a> WorkflowManager<'a> {
         )
     }
 
+    /// Mirror agent-run metrics onto the linked workflow step row (Path X.1).
+    ///
+    /// Keyed by `child_run_id` so callers need not know the step's own id.
+    /// Uses COALESCE so a `None` value leaves the existing column untouched.
+    /// Called by `AgentManager` after writing the same values to `agent_runs`,
+    /// keeping `workflow_run_steps` readable without a JOIN.
+    #[allow(clippy::too_many_arguments)]
+    pub fn mirror_step_metrics_from_run(
+        &self,
+        run_id: &str,
+        cost_usd: Option<f64>,
+        num_turns: Option<i64>,
+        duration_ms: Option<i64>,
+        input_tokens: Option<i64>,
+        output_tokens: Option<i64>,
+        cache_read_input_tokens: Option<i64>,
+        cache_creation_input_tokens: Option<i64>,
+    ) -> Result<()> {
+        self.execute_step_sql(
+            "UPDATE workflow_run_steps \
+             SET cost_usd = COALESCE(:cost_usd, cost_usd), \
+                 num_turns = COALESCE(:num_turns, num_turns), \
+                 duration_ms = COALESCE(:duration_ms, duration_ms), \
+                 input_tokens = COALESCE(:input_tokens, input_tokens), \
+                 output_tokens = COALESCE(:output_tokens, output_tokens), \
+                 cache_read_input_tokens = COALESCE(:cache_read_input_tokens, cache_read_input_tokens), \
+                 cache_creation_input_tokens = COALESCE(:cache_creation_input_tokens, cache_creation_input_tokens) \
+             WHERE child_run_id = :run_id",
+            named_params![
+                ":cost_usd": cost_usd,
+                ":num_turns": num_turns,
+                ":duration_ms": duration_ms,
+                ":input_tokens": input_tokens,
+                ":output_tokens": output_tokens,
+                ":cache_read_input_tokens": cache_read_input_tokens,
+                ":cache_creation_input_tokens": cache_creation_input_tokens,
+                ":run_id": run_id,
+            ],
+        )
+    }
+
     /// Approve a gate: set gate_approved_at, gate_approved_by, optional feedback, and optional selections.
     pub fn approve_gate(
         &self,

--- a/conductor-core/src/workflow/manager/steps.rs
+++ b/conductor-core/src/workflow/manager/steps.rs
@@ -9,6 +9,21 @@ use crate::workflow::GateType;
 use super::WorkflowManager;
 use crate::workflow::WorkflowStepStatus;
 
+/// Agent-run metrics to mirror onto a linked `workflow_run_steps` row (Path X.1).
+///
+/// Grouped to avoid a positional `Option<T>` explosion at call sites.
+/// Fields left as `None` are ignored (COALESCE leaves existing DB values intact).
+#[derive(Debug, Clone, Default)]
+pub struct StepMetrics {
+    pub cost_usd: Option<f64>,
+    pub num_turns: Option<i64>,
+    pub duration_ms: Option<i64>,
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub cache_read_input_tokens: Option<i64>,
+    pub cache_creation_input_tokens: Option<i64>,
+}
+
 impl<'a> WorkflowManager<'a> {
     /// Execute a single SQL UPDATE and map the rusqlite error to [`ConductorError`].
     ///
@@ -275,21 +290,10 @@ impl<'a> WorkflowManager<'a> {
     /// Mirror agent-run metrics onto the linked workflow step row (Path X.1).
     ///
     /// Keyed by `child_run_id` so callers need not know the step's own id.
-    /// Uses COALESCE so a `None` value leaves the existing column untouched.
+    /// Uses COALESCE so a `None` field in [`StepMetrics`] leaves the existing column untouched.
     /// Called by `AgentManager` after writing the same values to `agent_runs`,
     /// keeping `workflow_run_steps` readable without a JOIN.
-    #[allow(clippy::too_many_arguments)]
-    pub fn mirror_step_metrics_from_run(
-        &self,
-        run_id: &str,
-        cost_usd: Option<f64>,
-        num_turns: Option<i64>,
-        duration_ms: Option<i64>,
-        input_tokens: Option<i64>,
-        output_tokens: Option<i64>,
-        cache_read_input_tokens: Option<i64>,
-        cache_creation_input_tokens: Option<i64>,
-    ) -> Result<()> {
+    pub fn mirror_step_metrics_from_run(&self, run_id: &str, metrics: StepMetrics) -> Result<()> {
         self.execute_step_sql(
             "UPDATE workflow_run_steps \
              SET cost_usd = COALESCE(:cost_usd, cost_usd), \
@@ -301,13 +305,13 @@ impl<'a> WorkflowManager<'a> {
                  cache_creation_input_tokens = COALESCE(:cache_creation_input_tokens, cache_creation_input_tokens) \
              WHERE child_run_id = :run_id",
             named_params![
-                ":cost_usd": cost_usd,
-                ":num_turns": num_turns,
-                ":duration_ms": duration_ms,
-                ":input_tokens": input_tokens,
-                ":output_tokens": output_tokens,
-                ":cache_read_input_tokens": cache_read_input_tokens,
-                ":cache_creation_input_tokens": cache_creation_input_tokens,
+                ":cost_usd": metrics.cost_usd,
+                ":num_turns": metrics.num_turns,
+                ":duration_ms": metrics.duration_ms,
+                ":input_tokens": metrics.input_tokens,
+                ":output_tokens": metrics.output_tokens,
+                ":cache_read_input_tokens": metrics.cache_read_input_tokens,
+                ":cache_creation_input_tokens": metrics.cache_creation_input_tokens,
                 ":run_id": run_id,
             ],
         )
@@ -664,5 +668,95 @@ mod tests {
         // COALESCE in SQL keeps the existing child_run_id when None is passed.
         assert_eq!(step.child_run_id.as_deref(), Some("child-run-3"));
         assert_eq!(step.step_error.as_deref(), Some("something went wrong"));
+    }
+
+    #[test]
+    fn mirror_step_metrics_writes_all_fields() {
+        let conn = test_helpers::setup_db();
+        let (_run_id, step_id) = setup(&conn);
+        let mgr = WorkflowManager::new(&conn);
+
+        mgr.mark_step_running(&step_id, WorkflowStepStatus::Running, Some("run-mirror-1"))
+            .unwrap();
+
+        mgr.mirror_step_metrics_from_run(
+            "run-mirror-1",
+            StepMetrics {
+                cost_usd: Some(1.23),
+                num_turns: Some(5),
+                duration_ms: Some(1000),
+                input_tokens: Some(100),
+                output_tokens: Some(200),
+                cache_read_input_tokens: Some(50),
+                cache_creation_input_tokens: Some(25),
+            },
+        )
+        .unwrap();
+
+        let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+        assert_eq!(step.cost_usd, Some(1.23));
+        assert_eq!(step.num_turns, Some(5));
+        assert_eq!(step.duration_ms, Some(1000));
+        assert_eq!(step.input_tokens, Some(100));
+        assert_eq!(step.output_tokens, Some(200));
+        assert_eq!(step.cache_read_input_tokens, Some(50));
+        assert_eq!(step.cache_creation_input_tokens, Some(25));
+    }
+
+    #[test]
+    fn mirror_step_metrics_coalesce_preserves_existing_when_none() {
+        let conn = test_helpers::setup_db();
+        let (_run_id, step_id) = setup(&conn);
+        let mgr = WorkflowManager::new(&conn);
+
+        mgr.mark_step_running(&step_id, WorkflowStepStatus::Running, Some("run-mirror-2"))
+            .unwrap();
+
+        // Write full metrics first.
+        mgr.mirror_step_metrics_from_run(
+            "run-mirror-2",
+            StepMetrics {
+                cost_usd: Some(9.99),
+                num_turns: Some(3),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // Second call — only token fields, cost_usd/num_turns must be preserved.
+        mgr.mirror_step_metrics_from_run(
+            "run-mirror-2",
+            StepMetrics {
+                input_tokens: Some(42),
+                output_tokens: Some(84),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+        assert_eq!(step.cost_usd, Some(9.99), "cost_usd must be preserved");
+        assert_eq!(step.num_turns, Some(3), "num_turns must be preserved");
+        assert_eq!(step.input_tokens, Some(42));
+        assert_eq!(step.output_tokens, Some(84));
+    }
+
+    #[test]
+    fn mirror_step_metrics_no_op_for_unknown_run_id() {
+        let conn = test_helpers::setup_db();
+        let (_run_id, step_id) = setup(&conn);
+        let mgr = WorkflowManager::new(&conn);
+
+        // No step has child_run_id = "does-not-exist", so the UPDATE affects 0 rows.
+        // The method must succeed (not error) in this case.
+        mgr.mirror_step_metrics_from_run(
+            "does-not-exist",
+            StepMetrics { cost_usd: Some(1.0), ..Default::default() },
+        )
+        .unwrap();
+
+        // Original step untouched.
+        let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+        assert!(step.cost_usd.is_none());
     }
 }

--- a/conductor-core/src/workflow/manager/steps.rs
+++ b/conductor-core/src/workflow/manager/steps.rs
@@ -751,7 +751,10 @@ mod tests {
         // The method must succeed (not error) in this case.
         mgr.mirror_step_metrics_from_run(
             "does-not-exist",
-            StepMetrics { cost_usd: Some(1.0), ..Default::default() },
+            StepMetrics {
+                cost_usd: Some(1.0),
+                ..Default::default()
+            },
         )
         .unwrap();
 

--- a/conductor-core/src/workflow/mod.rs
+++ b/conductor-core/src/workflow/mod.rs
@@ -54,7 +54,7 @@ pub use coordinator::{
 };
 pub use estimation::{Confidence, Estimate, LiveEstimate, StepEstimates};
 pub use manager::recovery::{ReapedStaleRun, StaleWorkflowRun};
-pub use manager::{InvalidWorkflowEntry, WorkflowManager};
+pub use manager::{InvalidWorkflowEntry, StepMetrics, WorkflowManager};
 pub use output::{parse_conductor_output, ConductorOutput};
 pub use runkon_flow::traits::persistence::{
     FanOutItemStatus, FanOutItemUpdate, GateApprovalState, NewRun, NewStep, StepUpdate,


### PR DESCRIPTION
Migration 081 adds input_tokens, output_tokens, cache_read/creation tokens, cost_usd, num_turns, and duration_ms columns to workflow_run_steps. These values used to live only on agent_runs and were JOINed at read time via child_run_id. Lifting them onto the step row lets runkon-flow's persistence layer read step metrics without reaching into the conductor-specific agent_runs table — a prerequisite for severing SqliteWorkflowPersistence's WorkflowManager dependency (Phase 4 step 4.2).

The schema change is additive. Existing rows are backfilled from agent_runs in a Rust-side guard so partial-schema migration unit tests survive the ALTER TABLE step. AgentManager::update_run_tokens_partial and update_run_completed_if_running_full mirror their writes onto the linked workflow step row, keeping both sources in sync until Path X.2 deprecates the agent_runs duplicates.

STEP_SELECT_WITH_TOKENS drops its LEFT JOIN agent_runs (now redundant) and the AGENT_RUN_TOKEN_COLS constant goes with it. Two waiting-gate queries that embedded the same token JOIN are also simplified.