### PR TITLE
refactor(runtimes): strip Claude-specific PermissionMode from runkon-runtimes (#2712)

### DIFF
--- a/conductor-cli/src/handlers/agent.rs
+++ b/conductor-cli/src/handlers/agent.rs
@@ -7,7 +7,7 @@ use rusqlite::Connection;
 use conductor_core::agent::{
     build_startup_context, parse_events_from_line, AgentManager, AgentRunExt, PlanStep,
 };
-use conductor_core::config::{load_config, AgentPermissionModeExt, Config};
+use conductor_core::config::{load_config, Config};
 use conductor_core::github;
 use conductor_core::github_app;
 use conductor_core::repo::RepoManager;

--- a/conductor-cli/src/helpers.rs
+++ b/conductor-cli/src/helpers.rs
@@ -1,7 +1,6 @@
 use std::process::Command;
 
 use conductor_core::agent::PlanStep;
-use conductor_core::config::AgentPermissionModeExt;
 use conductor_core::error::ConductorError;
 use conductor_core::tickets::TicketInput;
 

--- a/conductor-core/src/config.rs
+++ b/conductor-core/src/config.rs
@@ -7,26 +7,30 @@ use crate::error::{ConductorError, Result};
 
 // Re-export moved types from runkon-runtimes
 pub use runkon_runtimes::config::RuntimeConfig;
-pub use runkon_runtimes::permission::PermissionMode as AgentPermissionMode;
 
-/// Extension trait for [`AgentPermissionMode`] that provides conductor-specific
-/// and Claude-Code-CLI-specific flag mappings.
+/// Controls which permission flag is passed to Claude Code when launching agent runs.
 ///
-/// Kept in conductor-core (not runkon-runtimes) so the portable crate stays
-/// vendor-neutral.
-pub trait AgentPermissionModeExt {
-    /// Returns the conductor CLI flag for this mode (used in `conductor agent run` passthrough args).
-    fn cli_flag(&self) -> &str;
-    /// Returns the actual permission flag to pass to the `claude` subprocess.
-    fn claude_permission_flag(&self) -> &str;
-    /// Returns the optional value argument that follows the claude permission flag.
-    fn claude_permission_flag_value(&self) -> Option<&str>;
-    /// Returns the `--allowedTools` pattern for this mode, if any.
-    fn allowed_tools(&self) -> Option<&'static str>;
+/// Defined natively in conductor-core (not re-exported from runkon-runtimes)
+/// so the portable runtime crate stays vendor-neutral. Convert to the opaque
+/// [`runkon_runtimes::permission::PermissionMode`] via
+/// [`Self::to_runtime_permission_mode`] when constructing a `RuntimeRequest`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentPermissionMode {
+    /// `--enable-auto-mode` (may prompt for permissions in headless agents).
+    AutoMode,
+    /// `--dangerously-skip-permissions` (default for headless agent runs).
+    #[default]
+    SkipPermissions,
+    /// `--permission-mode plan` (read-only mode for repo-scoped agents).
+    Plan,
+    /// `--dangerously-skip-permissions` + `--allowedTools` read-safe pattern.
+    RepoSafe,
 }
 
-impl AgentPermissionModeExt for AgentPermissionMode {
-    fn cli_flag(&self) -> &str {
+impl AgentPermissionMode {
+    /// Conductor CLI flag for this mode (used in `conductor agent run` passthrough args).
+    pub fn cli_flag(&self) -> &'static str {
         match self {
             Self::AutoMode => "--enable-auto-mode",
             Self::SkipPermissions => "--dangerously-skip-permissions",
@@ -35,7 +39,8 @@ impl AgentPermissionModeExt for AgentPermissionMode {
         }
     }
 
-    fn claude_permission_flag(&self) -> &str {
+    /// Permission flag passed directly to the `claude` subprocess.
+    pub fn claude_permission_flag(&self) -> &'static str {
         match self {
             Self::AutoMode => "--enable-auto-mode",
             Self::SkipPermissions => "--dangerously-skip-permissions",
@@ -44,19 +49,42 @@ impl AgentPermissionModeExt for AgentPermissionMode {
         }
     }
 
-    fn claude_permission_flag_value(&self) -> Option<&str> {
+    /// Optional value argument that follows the claude permission flag.
+    pub fn claude_permission_flag_value(&self) -> Option<&'static str> {
         match self {
             Self::Plan => Some("plan"),
             _ => None,
         }
     }
 
-    fn allowed_tools(&self) -> Option<&'static str> {
+    /// Optional value argument for the conductor CLI flag (`--permission-mode <value>`).
+    pub fn cli_flag_value(&self) -> Option<&'static str> {
+        match self {
+            Self::Plan => Some("plan"),
+            Self::RepoSafe => Some("repo-safe"),
+            _ => None,
+        }
+    }
+
+    /// `--allowedTools` pattern for this mode, if any.
+    pub fn allowed_tools(&self) -> Option<&'static str> {
         match self {
             Self::Plan | Self::RepoSafe => {
                 Some("Bash,Glob,Grep,Read,WebFetch,WebSearch,mcp__conductor__*,mcp__*")
             }
             _ => None,
+        }
+    }
+
+    /// Convert into the opaque permission mode consumed by `runkon-runtimes`'
+    /// headless arg builder. Maps each variant to its [`Self::cli_flag_value`]
+    /// so the runtime crate never sees Claude-CLI strings at compile time.
+    pub fn to_runtime_permission_mode(self) -> runkon_runtimes::permission::PermissionMode {
+        match self.cli_flag_value() {
+            Some(v) => {
+                runkon_runtimes::permission::PermissionMode::Other(std::borrow::Cow::Borrowed(v))
+            }
+            None => runkon_runtimes::permission::PermissionMode::Default,
         }
     }
 }
@@ -1664,7 +1692,6 @@ bot_name = "my-bot"
 
     #[test]
     fn test_agent_permission_mode_ext_cli_flag() {
-        use super::AgentPermissionModeExt;
         assert_eq!(
             AgentPermissionMode::AutoMode.cli_flag(),
             "--enable-auto-mode"
@@ -1682,7 +1709,6 @@ bot_name = "my-bot"
 
     #[test]
     fn test_agent_permission_mode_ext_claude_permission_flag() {
-        use super::AgentPermissionModeExt;
         assert_eq!(
             AgentPermissionMode::AutoMode.claude_permission_flag(),
             "--enable-auto-mode"
@@ -1703,7 +1729,6 @@ bot_name = "my-bot"
 
     #[test]
     fn test_agent_permission_mode_ext_claude_permission_flag_value() {
-        use super::AgentPermissionModeExt;
         assert_eq!(
             AgentPermissionMode::AutoMode.claude_permission_flag_value(),
             None
@@ -1724,7 +1749,6 @@ bot_name = "my-bot"
 
     #[test]
     fn test_agent_permission_mode_ext_allowed_tools() {
-        use super::AgentPermissionModeExt;
         assert_eq!(AgentPermissionMode::AutoMode.allowed_tools(), None);
         assert_eq!(AgentPermissionMode::SkipPermissions.allowed_tools(), None);
         assert!(AgentPermissionMode::Plan.allowed_tools().is_some());

--- a/conductor-core/src/config.rs
+++ b/conductor-core/src/config.rs
@@ -876,6 +876,51 @@ mod tests {
     }
 
     #[test]
+    fn test_agent_permission_mode_to_runtime_permission_mode() {
+        use runkon_runtimes::permission::PermissionMode;
+        assert_eq!(
+            AgentPermissionMode::AutoMode
+                .to_runtime_permission_mode()
+                .cli_flag_value(),
+            None
+        );
+        assert_eq!(
+            AgentPermissionMode::SkipPermissions
+                .to_runtime_permission_mode()
+                .cli_flag_value(),
+            None
+        );
+        assert_eq!(
+            AgentPermissionMode::Plan
+                .to_runtime_permission_mode()
+                .cli_flag_value(),
+            Some("plan")
+        );
+        assert_eq!(
+            AgentPermissionMode::RepoSafe
+                .to_runtime_permission_mode()
+                .cli_flag_value(),
+            Some("repo-safe")
+        );
+        assert_eq!(
+            AgentPermissionMode::AutoMode.to_runtime_permission_mode(),
+            PermissionMode::Default
+        );
+        assert_eq!(
+            AgentPermissionMode::SkipPermissions.to_runtime_permission_mode(),
+            PermissionMode::Default
+        );
+        assert_eq!(
+            AgentPermissionMode::Plan.to_runtime_permission_mode(),
+            PermissionMode::Other(std::borrow::Cow::Borrowed("plan"))
+        );
+        assert_eq!(
+            AgentPermissionMode::RepoSafe.to_runtime_permission_mode(),
+            PermissionMode::Other(std::borrow::Cow::Borrowed("repo-safe"))
+        );
+    }
+
+    #[test]
     fn test_agent_permission_mode_claude_permission_flag() {
         assert_eq!(
             AgentPermissionMode::AutoMode.claude_permission_flag(),

--- a/conductor-core/src/workflow/claude_agent_executor.rs
+++ b/conductor-core/src/workflow/claude_agent_executor.rs
@@ -59,7 +59,10 @@ impl ActionExecutor for ClaudeAgentExecutor {
 
         let runtime = crate::runtime::resolve_runtime(
             &agent_def.runtime,
-            self.config.general.agent_permission_mode,
+            self.config
+                .general
+                .agent_permission_mode
+                .to_runtime_permission_mode(),
             &self.config.runtimes,
             &options,
         )?;

--- a/conductor-core/tests/script_runtime_integration.rs
+++ b/conductor-core/tests/script_runtime_integration.rs
@@ -174,7 +174,7 @@ fn test_script_runtime_resolve_via_config() {
 
     let runtime = conductor_core::runtime::resolve_runtime(
         "my-script",
-        AgentPermissionMode::default(),
+        AgentPermissionMode::default().to_runtime_permission_mode(),
         &config.runtimes,
         &options,
     );

--- a/conductor-tui/src/app/agent_execution.rs
+++ b/conductor-tui/src/app/agent_execution.rs
@@ -58,6 +58,9 @@ pub(super) fn drive_headless_run(
     on_launched: impl FnOnce(std::result::Result<String, String>) -> Action,
     success_msg: &str,
 ) {
+    let runtime_permission = config
+        .permission_mode
+        .map(|m| m.to_runtime_permission_mode());
     let spawn_params = conductor_core::agent_runtime::SpawnHeadlessParams {
         run_id: &run.id,
         working_dir: &config.working_dir,
@@ -65,7 +68,7 @@ pub(super) fn drive_headless_run(
         resume_session_id: config.resume_session_id.as_deref(),
         model: config.model.as_deref(),
         bot_name: config.bot_name.as_deref(),
-        permission_mode: config.permission_mode.as_ref(),
+        permission_mode: runtime_permission.as_ref(),
         plugin_dirs: &[],
     };
 

--- a/conductor-web/src/routes/agents.rs
+++ b/conductor-web/src/routes/agents.rs
@@ -1221,7 +1221,8 @@ pub async fn start_repo_agent(
     // DB and config locks are now dropped.
 
     // Spawn headless subprocess with repo-safe permission mode and wire stdout to SSE.
-    let repo_safe = conductor_core::config::AgentPermissionMode::RepoSafe;
+    let repo_safe =
+        conductor_core::config::AgentPermissionMode::RepoSafe.to_runtime_permission_mode();
     let spawn_params = conductor_core::agent_runtime::SpawnHeadlessParams {
         run_id: &run.id,
         working_dir: &repo_path,

--- a/conductor-web/src/routes/conversations.rs
+++ b/conductor-web/src/routes/conversations.rs
@@ -257,6 +257,7 @@ pub async fn send_message(
     let final_prompt =
         write_attachments_and_augment_prompt(&run.id, &working_dir, &prompt, &raw_attachments)?;
 
+    let runtime_permission = permission_mode.map(|m| m.to_runtime_permission_mode());
     let spawn_params = conductor_core::agent_runtime::SpawnHeadlessParams {
         run_id: &run.id,
         working_dir: &working_dir,
@@ -264,7 +265,7 @@ pub async fn send_message(
         resume_session_id: resume_session_id.as_deref(),
         model: model.as_deref(),
         bot_name: None,
-        permission_mode: permission_mode.as_ref(),
+        permission_mode: runtime_permission.as_ref(),
         plugin_dirs: &[],
     };
     spawn_headless_agent(&state, &spawn_params, None).await?;

--- a/runkon-runtimes/src/permission.rs
+++ b/runkon-runtimes/src/permission.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// Opaque permission mode forwarded through to the headless agent CLI.
 ///
@@ -12,7 +12,13 @@ use serde::{Deserialize, Serialize};
 /// `Default` produces no permission flag value; `Other(s)` forwards `s` as-is
 /// as the value argument to whichever permission flag the host adds to the
 /// CLI invocation.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `Deserialize` is intentionally absent: `PermissionMode::Other` must only
+/// be created from compile-time-known strings via the host crate's typed enum
+/// (e.g. `AgentPermissionMode::to_runtime_permission_mode`). Allowing
+/// deserialization from untrusted input would bypass that invariant and could
+/// inject arbitrary strings as CLI flags.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub enum PermissionMode {
     /// No permission flag value forwarded.
     #[default]

--- a/runkon-runtimes/src/permission.rs
+++ b/runkon-runtimes/src/permission.rs
@@ -1,31 +1,34 @@
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
-/// Controls which permission flag is passed to Claude Code when launching agent runs.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+/// Opaque permission mode forwarded through to the headless agent CLI.
+///
+/// `runkon-runtimes` deliberately does not encode any specific permission
+/// taxonomy (Claude's `plan` / `repo-safe`, etc.). Vendor-specific values
+/// live in the host crate (e.g. conductor-core's `AgentPermissionMode`) and
+/// are converted into this opaque form when constructing a `RuntimeRequest`.
+///
+/// `Default` produces no permission flag value; `Other(s)` forwards `s` as-is
+/// as the value argument to whichever permission flag the host adds to the
+/// CLI invocation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PermissionMode {
-    /// Use `--enable-auto-mode` (may prompt for permissions in headless agents).
-    AutoMode,
-    /// Use `--dangerously-skip-permissions` (default for headless agent runs).
+    /// No permission flag value forwarded.
     #[default]
-    SkipPermissions,
-    /// Use `--permission-mode plan` (read-only mode for repo-scoped agents).
-    Plan,
-    /// Use `--dangerously-skip-permissions` + `--allowedTools` read-safe pattern.
-    RepoSafe,
+    Default,
+    /// Forward this raw flag value to the headless arg builder.
+    Other(Cow<'static, str>),
 }
 
 impl PermissionMode {
-    /// Returns the optional value argument that follows the generic permission flag.
-    ///
-    /// This is the only permission-mode method retained in the portable crate because
-    /// the headless arg builder (`push_optional_agent_flags`) needs it. All other
-    /// vendor-specific flag mappings live in the host crate (conductor-core).
+    /// Returns the optional value argument that follows the host-specific
+    /// permission flag in the headless CLI invocation. `None` means no
+    /// permission flag is appended to the args.
     pub fn cli_flag_value(&self) -> Option<&str> {
         match self {
-            Self::Plan => Some("plan"),
-            Self::RepoSafe => Some("repo-safe"),
-            _ => None,
+            Self::Default => None,
+            Self::Other(s) => Some(s.as_ref()),
         }
     }
 }


### PR DESCRIPTION
Closes #2712.

Replaces `runkon-runtimes`'s four-variant `PermissionMode` (which encoded Claude CLI strings `"plan"` and `"repo-safe"` in the portable crate) with an opaque `Default | Other(Cow<'static, str>)` enum. The concrete `AgentPermissionMode` (with `AutoMode` / `SkipPermissions` / `Plan` / `RepoSafe` variants) now lives natively in `conductor-core/src/config.rs`; what was the `AgentPermissionModeExt` extension trait becomes inherent methods on the new enum.

Conversion to the opaque runtime form happens at the call boundary via `AgentPermissionMode::to_runtime_permission_mode()`, invoked anywhere a `RuntimeRequest` or `SpawnHeadlessParams` is constructed (claude_agent_executor, TUI agent execution, web `/agents` and `/conversations` routes, the script-runtime integration test).

## Acceptance criteria

- [x] No occurrences of `"plan"` or `"repo-safe"` strings in `runkon-runtimes/`
- [x] No `Plan` or `RepoSafe` enum variants exposed from the portable crate
- [x] Conductor-core continues to pass `--permission-mode plan` (etc.) through the headless arg builder via the conversion layer

## Branch context

The branch name `feat/relocate-agent-runs` is broader than this PR — issues #2711 (split `AgentRun` into a portable `RunHandle`) and #2709 (rename `claude_session_id` → `session_id`) are tracked as follow-ups on a fresh branch.

## Test plan

- [x] `cargo test --workspace` — all crates green (~3,400 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)