### PR TITLE
refactor(runtimes): split AgentRun into portable RunHandle + conductor AgentRun (#2711)

### DIFF
--- a/conductor-cli/src/handlers/agent.rs
+++ b/conductor-cli/src/handlers/agent.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use conductor_core::agent::{
-    build_startup_context, parse_events_from_line, AgentManager, AgentRunExt, PlanStep,
+    build_startup_context, parse_events_from_line, AgentManager, PlanStep,
 };
 use conductor_core::config::{load_config, Config};
 use conductor_core::github;

--- a/conductor-core/Cargo.toml
+++ b/conductor-core/Cargo.toml
@@ -8,7 +8,7 @@ description = "Core library for Conductor — multi-repo orchestration"
 
 [dependencies]
 runkon-flow = { path = "../runkon-flow", features = ["rusqlite"] }
-runkon-runtimes = { path = "../runkon-runtimes", features = ["rusqlite"] }
+runkon-runtimes = { path = "../runkon-runtimes" }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/conductor-core/src/agent/manager/plan_steps.rs
+++ b/conductor-core/src/agent/manager/plan_steps.rs
@@ -130,7 +130,7 @@ mod tests {
     use super::super::setup_db;
     use super::super::AgentManager;
     use crate::agent::status::StepStatus;
-    use crate::agent::types::{AgentRunExt, PlanStep};
+    use crate::agent::types::PlanStep;
 
     #[test]
     fn test_update_run_plan() {
@@ -484,7 +484,7 @@ mod tests {
     #[test]
     fn test_build_resume_prompt() {
         use crate::agent::status::AgentRunStatus;
-        use crate::agent::types::{AgentRun, AgentRunExt};
+        use crate::agent::types::AgentRun;
 
         let run = AgentRun {
             id: "test".to_string(),

--- a/conductor-core/src/agent/manager/queries.rs
+++ b/conductor-core/src/agent/manager/queries.rs
@@ -11,7 +11,7 @@ use super::super::db::{
     AGENT_RUN_SELECT,
 };
 use super::super::status::AgentRunStatus;
-use super::super::types::{AgentRun, AgentRunExt};
+use super::super::types::AgentRun;
 use super::AgentManager;
 
 impl<'a> AgentManager<'a> {

--- a/conductor-core/src/agent/mod.rs
+++ b/conductor-core/src/agent/mod.rs
@@ -24,9 +24,9 @@ pub use status::{
 };
 
 pub use types::{
-    ActiveAgentCounts, AgentCreatedIssue, AgentEvent, AgentRun, AgentRunEvent, AgentRunExt,
-    ClaudeJsonResult, CostPhase, FeedbackOption, FeedbackRequest, FeedbackRequestParams, LogResult,
-    PlanStep, RunTreeTotals, TicketAgentTotals, EVENT_KIND_TOOL_ERROR, META_KEY_ERROR_TEXT,
+    ActiveAgentCounts, AgentCreatedIssue, AgentEvent, AgentRun, AgentRunEvent, ClaudeJsonResult,
+    CostPhase, FeedbackOption, FeedbackRequest, FeedbackRequestParams, LogResult, PlanStep,
+    RunTreeTotals, TicketAgentTotals, EVENT_KIND_TOOL_ERROR, META_KEY_ERROR_TEXT,
 };
 
 #[cfg(test)]

--- a/conductor-core/src/agent/status.rs
+++ b/conductor-core/src/agent/status.rs
@@ -1,7 +1,149 @@
 use serde::{Deserialize, Serialize};
 
-// Re-export moved types from runkon-runtimes
-pub use runkon_runtimes::{AgentRunStatus, StepStatus};
+/// Lifecycle status of a conductor agent run.
+///
+/// Defined natively in conductor-core (not re-exported from runkon-runtimes)
+/// so that workflow-engine states like `WaitingForFeedback` — which no
+/// runtime in `runkon-runtimes` ever emits — stay out of the portable crate.
+/// Convert to the runtime-layer [`runkon_runtimes::RunStatus`] at the
+/// boundary; `WaitingForFeedback` collapses to `RunStatus::Running` since
+/// the runtime sees a paused-for-feedback run as "logically still active,
+/// not yet terminal".
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRunStatus {
+    Running,
+    WaitingForFeedback,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl std::fmt::Display for AgentRunStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Running => "running",
+            Self::WaitingForFeedback => "waiting_for_feedback",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl std::str::FromStr for AgentRunStatus {
+    type Err = String;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "running" => Ok(Self::Running),
+            "waiting_for_feedback" => Ok(Self::WaitingForFeedback),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            "cancelled" => Ok(Self::Cancelled),
+            _ => Err(format!("unknown AgentRunStatus: {s}")),
+        }
+    }
+}
+
+impl rusqlite::types::ToSql for AgentRunStatus {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
+    }
+}
+
+impl rusqlite::types::FromSql for AgentRunStatus {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        let s = String::column_result(value)?;
+        s.parse().map_err(|e: String| {
+            rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                e,
+            )))
+        })
+    }
+}
+
+impl From<AgentRunStatus> for runkon_runtimes::RunStatus {
+    fn from(s: AgentRunStatus) -> Self {
+        match s {
+            // Runtime layer doesn't model "waiting for feedback" — those runs
+            // appear "running" from its perspective; the actual subprocess has
+            // exited but the conductor-side row hasn't reached a terminal state.
+            AgentRunStatus::Running | AgentRunStatus::WaitingForFeedback => Self::Running,
+            AgentRunStatus::Completed => Self::Completed,
+            AgentRunStatus::Failed => Self::Failed,
+            AgentRunStatus::Cancelled => Self::Cancelled,
+        }
+    }
+}
+
+impl From<runkon_runtimes::RunStatus> for AgentRunStatus {
+    fn from(s: runkon_runtimes::RunStatus) -> Self {
+        match s {
+            runkon_runtimes::RunStatus::Running => Self::Running,
+            runkon_runtimes::RunStatus::Completed => Self::Completed,
+            runkon_runtimes::RunStatus::Failed => Self::Failed,
+            runkon_runtimes::RunStatus::Cancelled => Self::Cancelled,
+        }
+    }
+}
+
+/// Status of a single plan step in conductor's two-phase agent execution model.
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StepStatus {
+    #[default]
+    Pending,
+    InProgress,
+    Completed,
+    Failed,
+}
+
+impl std::fmt::Display for StepStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl std::str::FromStr for StepStatus {
+    type Err = String;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "in_progress" => Ok(Self::InProgress),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            _ => Err(format!("unknown StepStatus: {s}")),
+        }
+    }
+}
+
+impl rusqlite::types::ToSql for StepStatus {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
+    }
+}
+
+impl rusqlite::types::FromSql for StepStatus {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        let s = String::column_result(value)?;
+        s.parse().map_err(|e: String| {
+            rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                e,
+            )))
+        })
+    }
+}
 
 /// Default error message used when the agent reports an error without a message.
 pub const DEFAULT_AGENT_ERROR_MSG: &str = "Claude reported an error";

--- a/conductor-core/src/agent/status.rs
+++ b/conductor-core/src/agent/status.rs
@@ -260,6 +260,33 @@ crate::impl_sql_enum!(FeedbackType);
 mod tests {
     use super::*;
 
+    /// `From<AgentRunStatus> for RunStatus` is exercised end-to-end by the
+    /// `to_run_handle_status_mapping_for_terminal_states` test in
+    /// `agent::types::tests`. This test guards the reverse direction
+    /// (`From<RunStatus> for AgentRunStatus`) for callers that need to map a
+    /// portable `RunHandle` status back into the conductor enum.
+    #[test]
+    fn from_run_status_maps_each_variant() {
+        for (input, expected) in [
+            (runkon_runtimes::RunStatus::Running, AgentRunStatus::Running),
+            (
+                runkon_runtimes::RunStatus::Completed,
+                AgentRunStatus::Completed,
+            ),
+            (runkon_runtimes::RunStatus::Failed, AgentRunStatus::Failed),
+            (
+                runkon_runtimes::RunStatus::Cancelled,
+                AgentRunStatus::Cancelled,
+            ),
+        ] {
+            let got: AgentRunStatus = input.into();
+            assert_eq!(
+                got, expected,
+                "RunStatus::{input:?} must map to AgentRunStatus::{expected:?}"
+            );
+        }
+    }
+
     #[test]
     fn parse_structured_plain_text() {
         let parsed = parse_feedback_marker_structured("[NEEDS_FEEDBACK] What should I do?");

--- a/conductor-core/src/agent/status.rs
+++ b/conductor-core/src/agent/status.rs
@@ -47,23 +47,7 @@ impl std::str::FromStr for AgentRunStatus {
     }
 }
 
-impl rusqlite::types::ToSql for AgentRunStatus {
-    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-        Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
-    }
-}
-
-impl rusqlite::types::FromSql for AgentRunStatus {
-    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        let s = String::column_result(value)?;
-        s.parse().map_err(|e: String| {
-            rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e,
-            )))
-        })
-    }
-}
+crate::impl_sql_enum!(AgentRunStatus);
 
 impl From<AgentRunStatus> for runkon_runtimes::RunStatus {
     fn from(s: AgentRunStatus) -> Self {
@@ -127,23 +111,7 @@ impl std::str::FromStr for StepStatus {
     }
 }
 
-impl rusqlite::types::ToSql for StepStatus {
-    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-        Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
-    }
-}
-
-impl rusqlite::types::FromSql for StepStatus {
-    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
-        let s = String::column_result(value)?;
-        s.parse().map_err(|e: String| {
-            rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e,
-            )))
-        })
-    }
-}
+crate::impl_sql_enum!(StepStatus);
 
 /// Default error message used when the agent reports an error without a message.
 pub const DEFAULT_AGENT_ERROR_MSG: &str = "Claude reported an error";

--- a/conductor-core/src/agent/status.rs
+++ b/conductor-core/src/agent/status.rs
@@ -260,6 +260,53 @@ crate::impl_sql_enum!(FeedbackType);
 mod tests {
     use super::*;
 
+    #[test]
+    fn agent_run_status_from_str_roundtrips_each_variant() {
+        for status in [
+            AgentRunStatus::Running,
+            AgentRunStatus::WaitingForFeedback,
+            AgentRunStatus::Completed,
+            AgentRunStatus::Failed,
+            AgentRunStatus::Cancelled,
+        ] {
+            let s = status.to_string();
+            let parsed: AgentRunStatus = s.parse().expect("known variant must parse");
+            assert_eq!(parsed, status, "{s:?} round-trip");
+        }
+    }
+
+    #[test]
+    fn agent_run_status_from_str_rejects_unknown() {
+        let err = "not-a-real-status".parse::<AgentRunStatus>().unwrap_err();
+        assert!(
+            err.contains("not-a-real-status"),
+            "error must echo the bad input; got {err:?}"
+        );
+    }
+
+    #[test]
+    fn step_status_from_str_roundtrips_each_variant() {
+        for status in [
+            StepStatus::Pending,
+            StepStatus::InProgress,
+            StepStatus::Completed,
+            StepStatus::Failed,
+        ] {
+            let s = status.to_string();
+            let parsed: StepStatus = s.parse().expect("known variant must parse");
+            assert_eq!(parsed, status, "{s:?} round-trip");
+        }
+    }
+
+    #[test]
+    fn step_status_from_str_rejects_unknown() {
+        let err = "wibble".parse::<StepStatus>().unwrap_err();
+        assert!(
+            err.contains("wibble"),
+            "error must echo the bad input; got {err:?}"
+        );
+    }
+
     /// `From<AgentRunStatus> for RunStatus` is exercised end-to-end by the
     /// `to_run_handle_status_mapping_for_terminal_states` test in
     /// `agent::types::tests`. This test guards the reverse direction

--- a/conductor-core/src/agent/types.rs
+++ b/conductor-core/src/agent/types.rs
@@ -431,6 +431,99 @@ mod tests {
         }
     }
 
+    /// Build a fully-populated `AgentRun` so `to_run_handle` projection can be
+    /// asserted field-by-field.
+    fn make_full_run() -> AgentRun {
+        AgentRun {
+            id: "01JVFJT9K7XPPQ9MH6JV7XRM3M".into(),
+            worktree_id: Some("wt-1".into()),
+            repo_id: Some("repo-1".into()),
+            claude_session_id: Some("sess-abc".into()),
+            prompt: "do the thing".into(),
+            status: AgentRunStatus::Completed,
+            result_text: Some("done".into()),
+            cost_usd: Some(0.42),
+            num_turns: Some(7),
+            duration_ms: Some(1234),
+            started_at: "2025-01-01T00:00:00Z".into(),
+            ended_at: Some("2025-01-01T00:01:00Z".into()),
+            log_file: Some("/tmp/log".into()),
+            model: Some("sonnet".into()),
+            plan: Some(vec![PlanStep::default()]),
+            parent_run_id: Some("parent-1".into()),
+            input_tokens: Some(100),
+            output_tokens: Some(50),
+            cache_read_input_tokens: Some(20),
+            cache_creation_input_tokens: Some(10),
+            bot_name: Some("conductor-bot".into()),
+            conversation_id: Some("conv-1".into()),
+            subprocess_pid: Some(12345),
+            runtime: "claude".into(),
+        }
+    }
+
+    #[test]
+    fn to_run_handle_projects_portable_fields() {
+        let run = make_full_run();
+        let handle = run.to_run_handle();
+
+        assert_eq!(handle.id, run.id);
+        assert_eq!(handle.subprocess_pid, run.subprocess_pid);
+        assert_eq!(handle.runtime, run.runtime);
+        // claude_session_id maps to the generic `session_id` on the portable handle.
+        assert_eq!(handle.session_id, run.claude_session_id);
+        assert_eq!(handle.result_text, run.result_text);
+        assert_eq!(handle.started_at, run.started_at);
+        assert_eq!(handle.ended_at, run.ended_at);
+        assert_eq!(handle.log_file, run.log_file);
+        assert_eq!(handle.model, run.model);
+        assert_eq!(handle.cost_usd, run.cost_usd);
+        assert_eq!(handle.num_turns, run.num_turns);
+        assert_eq!(handle.duration_ms, run.duration_ms);
+        assert_eq!(handle.input_tokens, run.input_tokens);
+        assert_eq!(handle.output_tokens, run.output_tokens);
+        assert_eq!(handle.cache_read_input_tokens, run.cache_read_input_tokens);
+        assert_eq!(
+            handle.cache_creation_input_tokens,
+            run.cache_creation_input_tokens
+        );
+        assert_eq!(handle.status, runkon_runtimes::RunStatus::Completed);
+    }
+
+    #[test]
+    fn to_run_handle_collapses_waiting_for_feedback_to_running() {
+        let mut run = make_full_run();
+        run.status = AgentRunStatus::WaitingForFeedback;
+        let handle = run.to_run_handle();
+        // The runtime layer doesn't model paused-for-feedback; it appears as
+        // "still active" — i.e. Running — to AgentRuntime callers.
+        assert_eq!(handle.status, runkon_runtimes::RunStatus::Running);
+    }
+
+    #[test]
+    fn to_run_handle_status_mapping_for_terminal_states() {
+        for (input, expected) in [
+            (AgentRunStatus::Running, runkon_runtimes::RunStatus::Running),
+            (
+                AgentRunStatus::Completed,
+                runkon_runtimes::RunStatus::Completed,
+            ),
+            (AgentRunStatus::Failed, runkon_runtimes::RunStatus::Failed),
+            (
+                AgentRunStatus::Cancelled,
+                runkon_runtimes::RunStatus::Cancelled,
+            ),
+        ] {
+            let mut run = make_full_run();
+            run.status = input;
+            assert_eq!(
+                run.to_run_handle().status,
+                expected,
+                "AgentRunStatus::{input:?} must project to RunStatus::{expected:?}"
+            );
+        }
+    }
+
     #[test]
     fn log_path_rejects_log_file_outside_log_dir() {
         let run = make_run("01JVFJT9K7XPPQ9MH6JV7XRM3M", Some("/tmp/custom.log"));

--- a/conductor-core/src/agent/types.rs
+++ b/conductor-core/src/agent/types.rs
@@ -127,6 +127,66 @@ impl AgentRun {
             cache_creation_input_tokens: self.cache_creation_input_tokens,
         }
     }
+
+    /// Returns the log file path for this run.
+    pub fn log_path(&self) -> Result<PathBuf> {
+        match self.log_file.as_deref() {
+            Some(path) => {
+                let resolved = lexical_normalize(PathBuf::from(path));
+                let log_dir = lexical_normalize(crate::config::agent_log_dir());
+                if resolved.starts_with(&log_dir) {
+                    Ok(resolved)
+                } else {
+                    Err(crate::error::ConductorError::Agent(format!(
+                        "log_file path is outside agent log directory: {path}"
+                    )))
+                }
+            }
+            None => crate::config::agent_log_path(&self.id),
+        }
+    }
+
+    /// Returns true if this run ended (failed/cancelled) with incomplete plan steps
+    /// and has a session_id available for resume.
+    pub fn needs_resume(&self) -> bool {
+        matches!(
+            self.status,
+            AgentRunStatus::Failed | AgentRunStatus::Cancelled
+        ) && self.claude_session_id.is_some()
+            && self.has_incomplete_plan_steps()
+    }
+
+    /// Returns true if the run has a plan with at least one incomplete step.
+    pub fn has_incomplete_plan_steps(&self) -> bool {
+        self.plan
+            .as_ref()
+            .is_some_and(|steps| steps.iter().any(|s| !s.done))
+    }
+
+    /// Returns the incomplete plan steps (not yet done).
+    pub fn incomplete_plan_steps(&self) -> Vec<&PlanStep> {
+        self.plan
+            .as_ref()
+            .map(|steps| steps.iter().filter(|s| !s.done).collect())
+            .unwrap_or_default()
+    }
+
+    /// Build a resume prompt from the remaining plan steps.
+    pub fn build_resume_prompt(&self) -> String {
+        let incomplete = self.incomplete_plan_steps();
+        if incomplete.is_empty() {
+            return "Continue where you left off.".to_string();
+        }
+
+        let mut prompt = String::from(
+            "Continue where you left off. The following plan steps remain incomplete:\n",
+        );
+        for (i, step) in incomplete.iter().enumerate() {
+            prompt.push_str(&format!("{}. {}\n", i + 1, step.description));
+        }
+        prompt.push_str("\nPlease complete these remaining steps.");
+        prompt
+    }
 }
 
 /// Resolves `..` and `.` components without touching the filesystem so that
@@ -148,80 +208,9 @@ fn lexical_normalize(path: PathBuf) -> PathBuf {
     out.iter().collect()
 }
 
-/// Extension trait for `AgentRun` that provides conductor-specific functionality.
-pub trait AgentRunExt {
-    /// Returns the log file path for this run.
-    fn log_path(&self) -> Result<PathBuf>;
-
-    /// Returns true if this run ended (failed/cancelled) with incomplete plan steps
-    /// and has a session_id available for resume.
-    fn needs_resume(&self) -> bool;
-
-    /// Returns true if the run has a plan with at least one incomplete step.
-    fn has_incomplete_plan_steps(&self) -> bool;
-
-    /// Returns the incomplete plan steps (not yet done).
-    fn incomplete_plan_steps(&self) -> Vec<&PlanStep>;
-
-    /// Build a resume prompt from the remaining plan steps.
-    fn build_resume_prompt(&self) -> String;
-}
-
-impl AgentRunExt for AgentRun {
-    fn log_path(&self) -> Result<PathBuf> {
-        match self.log_file.as_deref() {
-            Some(path) => {
-                let resolved = lexical_normalize(PathBuf::from(path));
-                let log_dir = lexical_normalize(crate::config::agent_log_dir());
-                if resolved.starts_with(&log_dir) {
-                    Ok(resolved)
-                } else {
-                    Err(crate::error::ConductorError::Agent(format!(
-                        "log_file path is outside agent log directory: {path}"
-                    )))
-                }
-            }
-            None => crate::config::agent_log_path(&self.id),
-        }
-    }
-
-    fn needs_resume(&self) -> bool {
-        matches!(
-            self.status,
-            AgentRunStatus::Failed | AgentRunStatus::Cancelled
-        ) && self.claude_session_id.is_some()
-            && self.has_incomplete_plan_steps()
-    }
-
-    fn has_incomplete_plan_steps(&self) -> bool {
-        self.plan
-            .as_ref()
-            .is_some_and(|steps| steps.iter().any(|s| !s.done))
-    }
-
-    fn incomplete_plan_steps(&self) -> Vec<&PlanStep> {
-        self.plan
-            .as_ref()
-            .map(|steps| steps.iter().filter(|s| !s.done).collect())
-            .unwrap_or_default()
-    }
-
-    fn build_resume_prompt(&self) -> String {
-        let incomplete = self.incomplete_plan_steps();
-        if incomplete.is_empty() {
-            return "Continue where you left off.".to_string();
-        }
-
-        let mut prompt = String::from(
-            "Continue where you left off. The following plan steps remain incomplete:\n",
-        );
-        for (i, step) in incomplete.iter().enumerate() {
-            prompt.push_str(&format!("{}. {}\n", i + 1, step.description));
-        }
-        prompt.push_str("\nPlease complete these remaining steps.");
-        prompt
-    }
-}
+// `AgentRunExt` was removed in favour of inherent methods on `AgentRun` once
+// the type became native to conductor-core (the extension trait pattern was
+// only needed while `AgentRun` was a re-export from runkon-runtimes).
 
 /// Parsed JSON result from `claude -p --output-format json`.
 #[derive(Debug, Deserialize)]

--- a/conductor-core/src/agent/types.rs
+++ b/conductor-core/src/agent/types.rs
@@ -463,6 +463,50 @@ mod tests {
     }
 
     #[test]
+    fn is_active_true_for_running_and_waiting_for_feedback() {
+        let mut run = make_full_run();
+        run.status = AgentRunStatus::Running;
+        assert!(run.is_active(), "Running must be active");
+        run.status = AgentRunStatus::WaitingForFeedback;
+        assert!(run.is_active(), "WaitingForFeedback must be active");
+    }
+
+    #[test]
+    fn is_active_false_for_terminal_statuses() {
+        let mut run = make_full_run();
+        for status in [
+            AgentRunStatus::Completed,
+            AgentRunStatus::Failed,
+            AgentRunStatus::Cancelled,
+        ] {
+            run.status = status;
+            assert!(
+                !run.is_active(),
+                "{status:?} is terminal and must not be active"
+            );
+        }
+    }
+
+    #[test]
+    fn is_waiting_for_feedback_only_true_for_that_variant() {
+        let mut run = make_full_run();
+        run.status = AgentRunStatus::WaitingForFeedback;
+        assert!(run.is_waiting_for_feedback());
+        for status in [
+            AgentRunStatus::Running,
+            AgentRunStatus::Completed,
+            AgentRunStatus::Failed,
+            AgentRunStatus::Cancelled,
+        ] {
+            run.status = status;
+            assert!(
+                !run.is_waiting_for_feedback(),
+                "{status:?} is not WaitingForFeedback"
+            );
+        }
+    }
+
+    #[test]
     fn to_run_handle_projects_portable_fields() {
         let run = make_full_run();
         let handle = run.to_run_handle();

--- a/conductor-core/src/agent/types.rs
+++ b/conductor-core/src/agent/types.rs
@@ -2,11 +2,132 @@ use std::path::{Component, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use super::status::{FeedbackStatus, FeedbackType};
+use super::status::{AgentRunStatus, FeedbackStatus, FeedbackType, StepStatus};
 use crate::error::Result;
 
-// Re-export moved types from runkon-runtimes
-pub use runkon_runtimes::{AgentRun, PlanStep};
+/// A single step in an agent's two-phase execution plan.
+///
+/// Defined natively in conductor-core (not re-exported from runkon-runtimes)
+/// since plan-step semantics are conductor's two-phase agent execution
+/// model, not a portable runtime concept.
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanStep {
+    /// ULID primary key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub description: String,
+    /// Backward-compat flag derived from `status == StepStatus::Completed`.
+    #[serde(default)]
+    pub done: bool,
+    #[serde(default)]
+    pub status: StepStatus,
+    /// Ordering within the run's plan (0-based).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<String>,
+}
+
+impl Default for PlanStep {
+    fn default() -> Self {
+        Self {
+            id: None,
+            description: String::new(),
+            done: false,
+            status: StepStatus::Pending,
+            position: None,
+            started_at: None,
+            completed_at: None,
+        }
+    }
+}
+
+/// A single agent run as conductor persists it.
+///
+/// Defined natively here (not re-exported from runkon-runtimes) so that
+/// conductor-domain fields (`worktree_id`, `repo_id`, `conversation_id`,
+/// `parent_run_id`, `bot_name`, `plan`) and the conductor-only
+/// `WaitingForFeedback` status stay out of the portable crate. The runtime
+/// layer sees a [`runkon_runtimes::RunHandle`] subset; conversion happens at
+/// the boundary in [`SqliteHostAdapter`](crate::runtime::adapter::SqliteHostAdapter).
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentRun {
+    pub id: String,
+    pub worktree_id: Option<String>,
+    pub repo_id: Option<String>,
+    pub claude_session_id: Option<String>,
+    pub prompt: String,
+    pub status: AgentRunStatus,
+    pub result_text: Option<String>,
+    pub cost_usd: Option<f64>,
+    pub num_turns: Option<i64>,
+    pub duration_ms: Option<i64>,
+    pub started_at: String,
+    pub ended_at: Option<String>,
+    pub log_file: Option<String>,
+    pub model: Option<String>,
+    pub plan: Option<Vec<PlanStep>>,
+    pub parent_run_id: Option<String>,
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub cache_read_input_tokens: Option<i64>,
+    pub cache_creation_input_tokens: Option<i64>,
+    pub bot_name: Option<String>,
+    pub conversation_id: Option<String>,
+    pub subprocess_pid: Option<i64>,
+    #[serde(default = "default_runtime_field")]
+    pub runtime: String,
+}
+
+fn default_runtime_field() -> String {
+    "claude".to_string()
+}
+
+impl AgentRun {
+    /// Returns true if this run is currently active (running or waiting for feedback).
+    pub fn is_active(&self) -> bool {
+        matches!(
+            self.status,
+            AgentRunStatus::Running | AgentRunStatus::WaitingForFeedback
+        )
+    }
+
+    /// Returns true if this run is waiting for human feedback.
+    pub fn is_waiting_for_feedback(&self) -> bool {
+        self.status == AgentRunStatus::WaitingForFeedback
+    }
+
+    /// Project this conductor record into the portable [`runkon_runtimes::RunHandle`]
+    /// subset consumed by the runtime layer (`AgentRuntime` / `RunTracker` traits).
+    /// Drops conductor-domain fields (`worktree_id`, `repo_id`, `prompt`, `plan`,
+    /// `parent_run_id`, `bot_name`, `conversation_id`) and collapses
+    /// `WaitingForFeedback` to `Running`.
+    pub fn to_run_handle(&self) -> runkon_runtimes::RunHandle {
+        runkon_runtimes::RunHandle {
+            id: self.id.clone(),
+            status: self.status.into(),
+            subprocess_pid: self.subprocess_pid,
+            runtime: self.runtime.clone(),
+            session_id: self.claude_session_id.clone(),
+            result_text: self.result_text.clone(),
+            started_at: self.started_at.clone(),
+            ended_at: self.ended_at.clone(),
+            log_file: self.log_file.clone(),
+            model: self.model.clone(),
+            cost_usd: self.cost_usd,
+            num_turns: self.num_turns,
+            duration_ms: self.duration_ms,
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            cache_read_input_tokens: self.cache_read_input_tokens,
+            cache_creation_input_tokens: self.cache_creation_input_tokens,
+        }
+    }
+}
 
 /// Resolves `..` and `.` components without touching the filesystem so that
 /// `starts_with` checks cannot be bypassed by paths like
@@ -65,7 +186,6 @@ impl AgentRunExt for AgentRun {
     }
 
     fn needs_resume(&self) -> bool {
-        use runkon_runtimes::AgentRunStatus;
         matches!(
             self.status,
             AgentRunStatus::Failed | AgentRunStatus::Cancelled

--- a/conductor-core/src/notify/transitions.rs
+++ b/conductor-core/src/notify/transitions.rs
@@ -132,7 +132,7 @@ pub fn detect_agent_terminal_transitions<'a>(
                 });
             }
         }
-        seen.insert(run.id.clone(), run.status.clone());
+        seen.insert(run.id.clone(), run.status);
     }
 
     *initialized = true;

--- a/conductor-core/src/runtime/adapter.rs
+++ b/conductor-core/src/runtime/adapter.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use runkon_runtimes::tracker::{RunEventSink, RunTracker, RuntimeEvent};
-use runkon_runtimes::{AgentRun, RuntimeError};
+use runkon_runtimes::{RunHandle, RuntimeError};
 use rusqlite::Connection;
 
 use crate::agent::types::LogResult;
@@ -64,8 +64,14 @@ impl RunTracker for SqliteHostAdapter {
         self.with_mgr(|mgr| mgr.update_run_failed_if_running(run_id, reason))
     }
 
-    fn get_run(&self, run_id: &str) -> Result<Option<AgentRun>, RuntimeError> {
-        self.with_mgr(|mgr| mgr.get_run(run_id))
+    fn get_run(&self, run_id: &str) -> Result<Option<RunHandle>, RuntimeError> {
+        // The runtime layer only needs the RunHandle subset; project the full
+        // conductor AgentRun down at the boundary so worktree_id / repo_id /
+        // prompt / plan etc. never cross into runkon-runtimes.
+        self.with_mgr(|mgr| {
+            mgr.get_run(run_id)
+                .map(|opt| opt.map(|r| r.to_run_handle()))
+        })
     }
 }
 
@@ -187,7 +193,7 @@ mod tests {
         let run = adapter.get_run(run_id).unwrap();
         assert!(run.is_some());
         let run = run.unwrap();
-        assert_eq!(run.status, runkon_runtimes::AgentRunStatus::Cancelled);
+        assert_eq!(run.status, runkon_runtimes::RunStatus::Cancelled);
     }
 
     #[test]
@@ -203,7 +209,7 @@ mod tests {
         let run = adapter.get_run(run_id).unwrap();
         assert!(run.is_some());
         let run = run.unwrap();
-        assert_eq!(run.status, runkon_runtimes::AgentRunStatus::Failed);
+        assert_eq!(run.status, runkon_runtimes::RunStatus::Failed);
     }
 
     #[test]
@@ -224,7 +230,7 @@ mod tests {
         assert!(run.is_some());
         let run = run.unwrap();
         assert_eq!(run.model, Some("sonnet".to_string()));
-        assert_eq!(run.claude_session_id, Some("sess-123".to_string()));
+        assert_eq!(run.session_id, Some("sess-123".to_string()));
     }
 
     #[test]
@@ -251,7 +257,7 @@ mod tests {
         let run = adapter.get_run(run_id).unwrap();
         assert!(run.is_some());
         let run = run.unwrap();
-        assert_eq!(run.status, runkon_runtimes::AgentRunStatus::Completed);
+        assert_eq!(run.status, runkon_runtimes::RunStatus::Completed);
         assert_eq!(run.result_text, Some("done".to_string()));
         assert_eq!(run.cost_usd, Some(0.42));
     }
@@ -273,7 +279,7 @@ mod tests {
         let run = adapter.get_run(run_id).unwrap();
         assert!(run.is_some());
         let run = run.unwrap();
-        assert_eq!(run.status, runkon_runtimes::AgentRunStatus::Failed);
+        assert_eq!(run.status, runkon_runtimes::RunStatus::Failed);
     }
 
     #[test]

--- a/conductor-core/src/workflow/claude_agent_executor.rs
+++ b/conductor-core/src/workflow/claude_agent_executor.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use crate::agent::AgentRunStatus;
 use crate::config::{agent_log_path, Config};
 use crate::error::{ConductorError, Result};
 use crate::runtime::adapter::SqliteHostAdapter;
@@ -8,6 +7,7 @@ use crate::runtime::{PollError, RuntimeOptions};
 use crate::workflow::action_executor::{
     ActionExecutor, ActionOutput, ActionParams, ExecutionContext,
 };
+use runkon_runtimes::RunStatus;
 
 /// Wraps `AgentRuntime` dispatch behind the `ActionExecutor` trait.
 ///
@@ -95,7 +95,7 @@ impl ActionExecutor for ClaudeAgentExecutor {
             }
         };
 
-        let succeeded = completed.status == AgentRunStatus::Completed;
+        let succeeded = completed.status == RunStatus::Completed;
 
         let (markers, context, structured_output) =
             crate::workflow::output::interpret_agent_output(

--- a/conductor-core/tests/cli_runtime_integration.rs
+++ b/conductor-core/tests/cli_runtime_integration.rs
@@ -108,10 +108,7 @@ fn test_cli_runtime_success() {
         .expect("poll must succeed");
 
     assert_eq!(result.runtime.as_str(), "cli");
-    assert_eq!(
-        result.status,
-        conductor_core::agent::AgentRunStatus::Completed
-    );
+    assert_eq!(result.status, runkon_runtimes::RunStatus::Completed);
     assert!(
         result.subprocess_pid.is_some(),
         "subprocess_pid must be persisted so is_alive() and orphan reaper can track the run"
@@ -147,7 +144,7 @@ fn assert_nonzero_exit_maps_to_failed(exit_code: i32, run_id_prefix: &str) {
 
     assert_eq!(
         result.status,
-        conductor_core::agent::AgentRunStatus::Failed,
+        runkon_runtimes::RunStatus::Failed,
         "exit code {exit_code} must map to a failed run"
     );
 }
@@ -215,10 +212,7 @@ exit 0"#
         .poll(&run_id, None, Duration::from_secs(10))
         .expect("stdin poll must succeed");
 
-    assert_eq!(
-        result.status,
-        conductor_core::agent::AgentRunStatus::Completed
-    );
+    assert_eq!(result.status, runkon_runtimes::RunStatus::Completed);
     let _ = f; // keep tempfile alive
 }
 
@@ -301,13 +295,14 @@ fn test_cli_runtime_cancel_kills_process_and_marks_cancelled() {
         run.subprocess_pid.is_some(),
         "subprocess_pid must be set after spawn"
     );
-    assert!(runtime.is_alive(&run), "run must be alive before cancel");
+    let handle = run.to_run_handle();
+    assert!(runtime.is_alive(&handle), "run must be alive before cancel");
 
-    runtime.cancel(&run).expect("cancel must succeed");
+    runtime.cancel(&handle).expect("cancel must succeed");
 
     // Process should be gone.
     assert!(
-        !runtime.is_alive(&run),
+        !runtime.is_alive(&handle),
         "run must not be alive after cancel"
     );
 
@@ -345,7 +340,7 @@ fn test_cli_runtime_cancel_with_no_pid_marks_cancelled() {
     let _ = runtime.spawn_validated(&dummy_req);
 
     runtime
-        .cancel(&run)
+        .cancel(&run.to_run_handle())
         .expect("cancel must succeed when subprocess_pid is None");
 
     assert_run_cancelled(&db_guard, &run_id);
@@ -403,7 +398,7 @@ fn test_cli_runtime_poll_handles_unreadable_output_file() {
 
     assert_eq!(
         result.status,
-        conductor_core::agent::AgentRunStatus::Completed,
+        runkon_runtimes::RunStatus::Completed,
         "run must be Completed when process exits 0 even if output file is unreadable"
     );
 }
@@ -436,7 +431,7 @@ fn test_cli_runtime_poll_handles_unreadable_output_file_on_error_exit() {
 
     assert_eq!(
         result.status,
-        conductor_core::agent::AgentRunStatus::Failed,
+        runkon_runtimes::RunStatus::Failed,
         "run must be Failed when process exits 1 even if output file is unreadable"
     );
     assert!(

--- a/conductor-core/tests/script_runtime_integration.rs
+++ b/conductor-core/tests/script_runtime_integration.rs
@@ -38,10 +38,7 @@ fn test_script_runtime_success() {
         .poll(&run_id, None, Duration::from_secs(5))
         .expect("poll must succeed");
 
-    assert_eq!(
-        result.status,
-        conductor_core::agent::AgentRunStatus::Completed
-    );
+    assert_eq!(result.status, runkon_runtimes::RunStatus::Completed);
     let text = result.result_text.expect("result_text must be set");
     assert!(
         text.contains("hello"),
@@ -68,10 +65,7 @@ fn test_script_runtime_captures_conductor_prompt() {
         .poll(&run_id, None, Duration::from_secs(5))
         .expect("poll must succeed");
 
-    assert_eq!(
-        result.status,
-        conductor_core::agent::AgentRunStatus::Completed
-    );
+    assert_eq!(result.status, runkon_runtimes::RunStatus::Completed);
     let text = result.result_text.expect("result_text must be set");
     assert!(
         text.contains("my-unique-prompt-string"),

--- a/conductor-tui/src/app/agent_execution.rs
+++ b/conductor-tui/src/app/agent_execution.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use conductor_core::agent::{AgentManager, AgentRun, AgentRunExt, FeedbackRequest};
+use conductor_core::agent::{AgentManager, AgentRun, FeedbackRequest};
 use conductor_core::config::AutoStartAgent;
 use conductor_core::tickets::build_agent_prompt;
 use conductor_core::worktree::{WorktreeCreateOptions, WorktreeManager};

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -4,7 +4,6 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
 use ratatui::Frame;
 
-use conductor_core::agent::AgentRunExt;
 use conductor_core::worktree::WorktreeStatus;
 
 use super::helpers::shorten_paths;

--- a/conductor-web/src/routes/agents.rs
+++ b/conductor-web/src/routes/agents.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use conductor_core::agent::{
     parse_agent_log, AgentCreatedIssue, AgentEvent, AgentManager, AgentRun, AgentRunEvent,
-    AgentRunExt, AgentRunStatus, FeedbackRequest, RunTreeTotals, TicketAgentTotals,
+    AgentRunStatus, FeedbackRequest, RunTreeTotals, TicketAgentTotals,
 };
 use conductor_core::error::ConductorError;
 use conductor_core::repo::RepoManager;

--- a/runkon-runtimes/Cargo.toml
+++ b/runkon-runtimes/Cargo.toml
@@ -7,7 +7,6 @@ repository.workspace = true
 description = "Portable agent runtime harness — spawn, poll, and cancel agents without depending on conductor's full domain"
 
 [features]
-rusqlite = ["dep:rusqlite"]
 utoipa = ["dep:utoipa"]
 
 [dependencies]
@@ -16,7 +15,6 @@ serde_json = "1"
 thiserror = "2"
 tracing = "0.1"
 libc = "0.2"
-rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 utoipa = { version = "5", optional = true }
 
 [dev-dependencies]

--- a/runkon-runtimes/src/lib.rs
+++ b/runkon-runtimes/src/lib.rs
@@ -16,6 +16,6 @@ pub use agent_def::{AgentDef, AgentRole};
 pub use config::RuntimeConfig;
 pub use error::{Result, RuntimeError};
 pub use permission::PermissionMode;
-pub use run::{AgentRun, AgentRunStatus, PlanStep, StepStatus};
+pub use run::{RunHandle, RunStatus};
 pub use runtime::{AgentRuntime, PollError, RuntimeOptions, RuntimeRequest};
 pub use tracker::{NoopEventSink, RunEventSink, RunTracker, RuntimeEvent};

--- a/runkon-runtimes/src/run.rs
+++ b/runkon-runtimes/src/run.rs
@@ -1,22 +1,26 @@
 use serde::{Deserialize, Serialize};
 
-/// Status of an agent run.
+/// Lifecycle status of a runtime-spawned agent.
+///
+/// Vendor-neutral: only the four states that any runtime in this crate
+/// (`ClaudeRuntime`, `CliRuntime`, `ScriptRuntime`) needs to emit. Host
+/// applications layering richer states on top (conductor's
+/// `WaitingForFeedback` for paused-for-human-input runs, etc.) keep them in
+/// their own enum and convert at the boundary.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum AgentRunStatus {
+pub enum RunStatus {
     Running,
-    WaitingForFeedback,
     Completed,
     Failed,
     Cancelled,
 }
 
-impl std::fmt::Display for AgentRunStatus {
+impl std::fmt::Display for RunStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             Self::Running => "running",
-            Self::WaitingForFeedback => "waiting_for_feedback",
             Self::Completed => "completed",
             Self::Failed => "failed",
             Self::Cancelled => "cancelled",
@@ -25,176 +29,78 @@ impl std::fmt::Display for AgentRunStatus {
     }
 }
 
-impl std::str::FromStr for AgentRunStatus {
+impl std::str::FromStr for RunStatus {
     type Err = String;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
             "running" => Ok(Self::Running),
-            "waiting_for_feedback" => Ok(Self::WaitingForFeedback),
             "completed" => Ok(Self::Completed),
             "failed" => Ok(Self::Failed),
             "cancelled" => Ok(Self::Cancelled),
-            _ => Err(format!("unknown AgentRunStatus: {s}")),
+            _ => Err(format!("unknown RunStatus: {s}")),
         }
     }
-}
-
-#[cfg(feature = "rusqlite")]
-macro_rules! impl_rusqlite_string_enum {
-    ($ty:ty) => {
-        impl rusqlite::types::ToSql for $ty {
-            fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-                Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
-            }
-        }
-
-        impl rusqlite::types::FromSql for $ty {
-            fn column_result(
-                value: rusqlite::types::ValueRef<'_>,
-            ) -> rusqlite::types::FromSqlResult<Self> {
-                let s = String::column_result(value)?;
-                s.parse().map_err(|e: String| {
-                    rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        e,
-                    )))
-                })
-            }
-        }
-    };
 }
 
 #[cfg(feature = "rusqlite")]
 mod rusqlite_impl {
-    use super::AgentRunStatus;
-    impl_rusqlite_string_enum!(AgentRunStatus);
-}
+    use super::RunStatus;
 
-/// Status of a single plan step.
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum StepStatus {
-    #[default]
-    Pending,
-    InProgress,
-    Completed,
-    Failed,
-}
-
-impl std::fmt::Display for StepStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            Self::Pending => "pending",
-            Self::InProgress => "in_progress",
-            Self::Completed => "completed",
-            Self::Failed => "failed",
-        };
-        write!(f, "{s}")
+    impl rusqlite::types::ToSql for RunStatus {
+        fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+            Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
+        }
     }
-}
 
-impl std::str::FromStr for StepStatus {
-    type Err = String;
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        match s {
-            "pending" => Ok(Self::Pending),
-            "in_progress" => Ok(Self::InProgress),
-            "completed" => Ok(Self::Completed),
-            "failed" => Ok(Self::Failed),
-            _ => Err(format!("unknown StepStatus: {s}")),
+    impl rusqlite::types::FromSql for RunStatus {
+        fn column_result(
+            value: rusqlite::types::ValueRef<'_>,
+        ) -> rusqlite::types::FromSqlResult<Self> {
+            let s = String::column_result(value)?;
+            s.parse().map_err(|e: String| {
+                rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    e,
+                )))
+            })
         }
     }
 }
 
-#[cfg(feature = "rusqlite")]
-mod rusqlite_impl_step {
-    use super::StepStatus;
-    impl_rusqlite_string_enum!(StepStatus);
-}
-
-/// A single step in an agent's two-phase execution plan.
+/// Handle to a runtime-spawned agent run, carrying only the fields any
+/// runtime in this crate (or a host like conductor) actually reads through
+/// the [`AgentRuntime`](crate::runtime::AgentRuntime) trait.
+///
+/// Richer host-domain records (e.g. conductor's `AgentRun` with
+/// `worktree_id`, `repo_id`, `prompt`, plan steps, etc.) live in the host
+/// crate and are converted to / from `RunHandle` at the boundary by the
+/// [`RunTracker`](crate::tracker::RunTracker) implementation.
+///
+/// `session_id` is the host-supplied resume identifier (e.g. Claude's
+/// session id) — the field name is generic so non-Claude runtimes can store
+/// their own resumable identifier here without a vendor-named field
+/// surfacing in this crate.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PlanStep {
-    /// ULID primary key.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
-    pub description: String,
-    /// Backward-compat flag derived from `status == StepStatus::Completed`.
-    #[serde(default)]
-    pub done: bool,
-    #[serde(default)]
-    pub status: StepStatus,
-    /// Ordering within the run's plan (0-based).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub position: Option<i64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub started_at: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub completed_at: Option<String>,
-}
-
-impl Default for PlanStep {
-    fn default() -> Self {
-        Self {
-            id: None,
-            description: String::new(),
-            done: false,
-            status: StepStatus::Pending,
-            position: None,
-            started_at: None,
-            completed_at: None,
-        }
-    }
-}
-
-/// A single agent run.
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentRun {
+pub struct RunHandle {
     pub id: String,
-    pub worktree_id: Option<String>,
-    pub repo_id: Option<String>,
-    pub claude_session_id: Option<String>,
-    pub prompt: String,
-    pub status: AgentRunStatus,
+    pub status: RunStatus,
+    pub subprocess_pid: Option<i64>,
+    /// Name of the runtime that spawned this run (`"claude"`, `"cli"`,
+    /// `"script"`, or a host-defined value).
+    pub runtime: String,
+    /// Resumable session id captured by the runtime (vendor-neutral name).
+    pub session_id: Option<String>,
     pub result_text: Option<String>,
-    pub cost_usd: Option<f64>,
-    pub num_turns: Option<i64>,
-    pub duration_ms: Option<i64>,
     pub started_at: String,
     pub ended_at: Option<String>,
     pub log_file: Option<String>,
     pub model: Option<String>,
-    pub plan: Option<Vec<PlanStep>>,
-    pub parent_run_id: Option<String>,
+    pub cost_usd: Option<f64>,
+    pub num_turns: Option<i64>,
+    pub duration_ms: Option<i64>,
     pub input_tokens: Option<i64>,
     pub output_tokens: Option<i64>,
     pub cache_read_input_tokens: Option<i64>,
     pub cache_creation_input_tokens: Option<i64>,
-    pub bot_name: Option<String>,
-    pub conversation_id: Option<String>,
-    pub subprocess_pid: Option<i64>,
-    #[serde(default = "default_runtime_field")]
-    pub runtime: String,
-}
-
-fn default_runtime_field() -> String {
-    "claude".to_string()
-}
-
-impl AgentRun {
-    /// Returns true if this run is currently active (running or waiting for feedback).
-    pub fn is_active(&self) -> bool {
-        matches!(
-            self.status,
-            AgentRunStatus::Running | AgentRunStatus::WaitingForFeedback
-        )
-    }
-
-    /// Returns true if this run is waiting for human feedback.
-    pub fn is_waiting_for_feedback(&self) -> bool {
-        self.status == AgentRunStatus::WaitingForFeedback
-    }
 }

--- a/runkon-runtimes/src/run.rs
+++ b/runkon-runtimes/src/run.rs
@@ -42,31 +42,6 @@ impl std::str::FromStr for RunStatus {
     }
 }
 
-#[cfg(feature = "rusqlite")]
-mod rusqlite_impl {
-    use super::RunStatus;
-
-    impl rusqlite::types::ToSql for RunStatus {
-        fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-            Ok(rusqlite::types::ToSqlOutput::from(self.to_string()))
-        }
-    }
-
-    impl rusqlite::types::FromSql for RunStatus {
-        fn column_result(
-            value: rusqlite::types::ValueRef<'_>,
-        ) -> rusqlite::types::FromSqlResult<Self> {
-            let s = String::column_result(value)?;
-            s.parse().map_err(|e: String| {
-                rusqlite::types::FromSqlError::Other(Box::new(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    e,
-                )))
-            })
-        }
-    }
-}
-
 /// Handle to a runtime-spawned agent run, carrying only the fields any
 /// runtime in this crate (or a host like conductor) actually reads through
 /// the [`AgentRuntime`](crate::runtime::AgentRuntime) trait.

--- a/runkon-runtimes/src/runtime/claude.rs
+++ b/runkon-runtimes/src/runtime/claude.rs
@@ -8,7 +8,7 @@ use crate::error::{Result, RuntimeError};
 use crate::headless::{DrainOutcome, SpawnHeadlessParams};
 use crate::permission::PermissionMode;
 use crate::process_utils;
-use crate::run::AgentRun;
+use crate::run::RunHandle;
 use crate::tracker::{RunEventSink, RunTracker};
 
 use super::{AgentRuntime, PollError, RuntimeRequest};
@@ -100,7 +100,7 @@ impl AgentRuntime for ClaudeRuntime {
         run_id: &str,
         shutdown: Option<&Arc<AtomicBool>>,
         step_timeout: Duration,
-    ) -> std::result::Result<AgentRun, PollError> {
+    ) -> std::result::Result<RunHandle, PollError> {
         #[cfg(unix)]
         {
             poll_unix(self, run_id, shutdown, step_timeout)
@@ -114,7 +114,7 @@ impl AgentRuntime for ClaudeRuntime {
         }
     }
 
-    fn is_alive(&self, run: &AgentRun) -> bool {
+    fn is_alive(&self, run: &RunHandle) -> bool {
         #[cfg(unix)]
         if let Some(pid) = run.subprocess_pid {
             return process_utils::pid_is_alive(pid as u32);
@@ -123,7 +123,7 @@ impl AgentRuntime for ClaudeRuntime {
         false
     }
 
-    fn cancel(&self, run: &AgentRun) -> Result<()> {
+    fn cancel(&self, run: &RunHandle) -> Result<()> {
         #[cfg(unix)]
         {
             if let Some(h) = self.handle.lock().unwrap_or_else(|e| e.into_inner()).take() {
@@ -145,7 +145,7 @@ fn poll_unix(
     run_id: &str,
     shutdown: Option<&Arc<AtomicBool>>,
     step_timeout: Duration,
-) -> std::result::Result<AgentRun, PollError> {
+) -> std::result::Result<RunHandle, PollError> {
     let handle = rt
         .handle
         .lock()
@@ -313,7 +313,7 @@ mod tests {
         fn mark_failed_if_running(&self, _run_id: &str, _reason: &str) -> Result<()> {
             Ok(())
         }
-        fn get_run(&self, _run_id: &str) -> Result<Option<AgentRun>> {
+        fn get_run(&self, _run_id: &str) -> Result<Option<RunHandle>> {
             Ok(None)
         }
     }

--- a/runkon-runtimes/src/runtime/cli.rs
+++ b/runkon-runtimes/src/runtime/cli.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use crate::config::RuntimeConfig;
 use crate::error::{Result, RuntimeError};
 use crate::process_utils;
-use crate::run::AgentRun;
+use crate::run::RunHandle;
 use crate::tracker::{RunEventSink, RunTracker, RuntimeEvent};
 
 use super::{AgentRuntime, PollError, RuntimeRequest};
@@ -140,7 +140,7 @@ impl AgentRuntime for CliRuntime {
         run_id: &str,
         shutdown: Option<&Arc<AtomicBool>>,
         step_timeout: Duration,
-    ) -> std::result::Result<AgentRun, PollError> {
+    ) -> std::result::Result<RunHandle, PollError> {
         let mut state = self
             .state
             .lock()
@@ -271,7 +271,7 @@ impl AgentRuntime for CliRuntime {
         }
     }
 
-    fn is_alive(&self, run: &AgentRun) -> bool {
+    fn is_alive(&self, run: &RunHandle) -> bool {
         #[cfg(unix)]
         if let Some(pid) = run.subprocess_pid {
             return process_utils::pid_is_alive(pid as u32);
@@ -280,7 +280,7 @@ impl AgentRuntime for CliRuntime {
         false
     }
 
-    fn cancel(&self, run: &AgentRun) -> Result<()> {
+    fn cancel(&self, run: &RunHandle) -> Result<()> {
         let child = self
             .state
             .lock()

--- a/runkon-runtimes/src/runtime/mod.rs
+++ b/runkon-runtimes/src/runtime/mod.rs
@@ -12,7 +12,7 @@ use crate::agent_def::AgentDef;
 use crate::config::RuntimeConfig;
 use crate::error::{Result, RuntimeError};
 use crate::permission::PermissionMode;
-use crate::run::AgentRun;
+use crate::run::RunHandle;
 use crate::tracker::{RunEventSink, RunTracker};
 
 /// Sealed capability token for `AgentRuntime::spawn_impl`.
@@ -42,13 +42,13 @@ pub trait AgentRuntime {
         run_id: &str,
         shutdown: Option<&Arc<AtomicBool>>,
         step_timeout: std::time::Duration,
-    ) -> std::result::Result<AgentRun, PollError>;
+    ) -> std::result::Result<RunHandle, PollError>;
 
     /// Returns true if the agent process / session represented by `run` is still live.
-    fn is_alive(&self, run: &AgentRun) -> bool;
+    fn is_alive(&self, run: &RunHandle) -> bool;
 
     /// Forcibly cancel the agent represented by `run`.
-    fn cancel(&self, run: &AgentRun) -> Result<()>;
+    fn cancel(&self, run: &RunHandle) -> Result<()>;
 }
 
 /// Per-invocation parameters passed to `AgentRuntime::spawn`.
@@ -201,7 +201,7 @@ mod tests {
         fn mark_failed_if_running(&self, _run_id: &str, _reason: &str) -> Result<()> {
             Ok(())
         }
-        fn get_run(&self, _run_id: &str) -> Result<Option<AgentRun>> {
+        fn get_run(&self, _run_id: &str) -> Result<Option<RunHandle>> {
             Ok(None)
         }
     }
@@ -325,34 +325,27 @@ pub(crate) fn record_pid_and_runtime(
 
 #[cfg(test)]
 pub mod test_util {
-    use crate::run::{AgentRun, AgentRunStatus};
+    use crate::run::{RunHandle, RunStatus};
 
-    pub fn make_test_run(runtime: &str, subprocess_pid: Option<i64>) -> AgentRun {
-        AgentRun {
+    pub fn make_test_run(runtime: &str, subprocess_pid: Option<i64>) -> RunHandle {
+        RunHandle {
             id: "test-run".to_string(),
-            worktree_id: None,
-            repo_id: None,
-            claude_session_id: None,
-            prompt: "p".to_string(),
-            status: AgentRunStatus::Running,
+            status: RunStatus::Running,
+            subprocess_pid,
+            runtime: runtime.to_string(),
+            session_id: None,
             result_text: None,
-            cost_usd: None,
-            num_turns: None,
-            duration_ms: None,
             started_at: "2024-01-01T00:00:00Z".to_string(),
             ended_at: None,
             log_file: None,
             model: None,
-            plan: None,
-            parent_run_id: None,
+            cost_usd: None,
+            num_turns: None,
+            duration_ms: None,
             input_tokens: None,
             output_tokens: None,
             cache_read_input_tokens: None,
             cache_creation_input_tokens: None,
-            bot_name: None,
-            conversation_id: None,
-            subprocess_pid,
-            runtime: runtime.to_string(),
         }
     }
 }

--- a/runkon-runtimes/src/runtime/script.rs
+++ b/runkon-runtimes/src/runtime/script.rs
@@ -5,8 +5,7 @@ use std::time::Duration;
 
 use crate::config::RuntimeConfig;
 use crate::error::{Result, RuntimeError};
-use crate::run::AgentRun;
-use crate::run::AgentRunStatus;
+use crate::run::{RunHandle, RunStatus};
 use crate::tracker::{RunEventSink, RunTracker, RuntimeEvent};
 
 use super::{AgentRuntime, PollError, RuntimeRequest};
@@ -88,7 +87,7 @@ impl AgentRuntime for ScriptRuntime {
         run_id: &str,
         shutdown: Option<&Arc<AtomicBool>>,
         step_timeout: Duration,
-    ) -> std::result::Result<AgentRun, PollError> {
+    ) -> std::result::Result<RunHandle, PollError> {
         let mut state = self
             .state
             .lock()
@@ -208,12 +207,12 @@ impl AgentRuntime for ScriptRuntime {
                         })?;
 
                     return match run.status {
-                        AgentRunStatus::Failed => Err(PollError::Failed(
+                        RunStatus::Failed => Err(PollError::Failed(
                             run.result_text
                                 .clone()
                                 .unwrap_or_else(|| "script failed".to_string()),
                         )),
-                        AgentRunStatus::Completed => Ok(run),
+                        RunStatus::Completed => Ok(run),
                         _ => Err(PollError::NoResult),
                     };
                 }
@@ -231,11 +230,11 @@ impl AgentRuntime for ScriptRuntime {
         }
     }
 
-    fn is_alive(&self, _run: &AgentRun) -> bool {
+    fn is_alive(&self, _run: &RunHandle) -> bool {
         false
     }
 
-    fn cancel(&self, run: &AgentRun) -> Result<()> {
+    fn cancel(&self, run: &RunHandle) -> Result<()> {
         if let Some(mut state) = self.state.lock().unwrap_or_else(|e| e.into_inner()).take() {
             let _ = state.child.kill();
         }

--- a/runkon-runtimes/src/tracker.rs
+++ b/runkon-runtimes/src/tracker.rs
@@ -1,5 +1,5 @@
 use crate::error::RuntimeError;
-use crate::run::AgentRun;
+use crate::run::RunHandle;
 
 /// Lifecycle tracking for a spawned agent run.
 ///
@@ -10,7 +10,7 @@ pub trait RunTracker: Send + Sync {
     fn record_runtime(&self, run_id: &str, runtime_name: &str) -> Result<(), RuntimeError>;
     fn mark_cancelled(&self, run_id: &str) -> Result<(), RuntimeError>;
     fn mark_failed_if_running(&self, run_id: &str, reason: &str) -> Result<(), RuntimeError>;
-    fn get_run(&self, run_id: &str) -> Result<Option<AgentRun>, RuntimeError>;
+    fn get_run(&self, run_id: &str) -> Result<Option<RunHandle>, RuntimeError>;
 }
 
 /// Best-effort streaming progress sink for agent stdout events.


### PR DESCRIPTION
Closes #2711.

`runkon-runtimes` was carrying conductor-domain fields and states that no runtime in the crate ever reads or sets. This PR splits the type so the portable crate sees only what it needs, and the rich record lives in conductor-core.

## What moves where

**`runkon-runtimes` (portable):**
- New `RunHandle` struct — only fields runtimes actually use (`id`, `status`, `subprocess_pid`, `runtime`, `session_id`, `result_text`, `started_at`/`ended_at`, `log_file`, `model`, cost/token metrics).
- New `RunStatus` enum — 4 variants (`Running`, `Completed`, `Failed`, `Cancelled`). No `WaitingForFeedback`.
- `RunTracker::get_run()` returns `RunHandle`.
- `AgentRuntime::{poll, is_alive, cancel}` operate on `&RunHandle`.
- Removed: `AgentRun`, `AgentRunStatus`, `PlanStep`, `StepStatus`.

**`conductor-core` (rich, native):**
- `AgentRun`, `PlanStep` defined natively in `agent/types.rs` (no longer re-exported).
- `AgentRunStatus`, `StepStatus` defined natively in `agent/status.rs`.
- `AgentRun::to_run_handle()` projects the rich record into the portable subset.
- `From<AgentRunStatus> for RunStatus` collapses `WaitingForFeedback → Running` for the runtime view (paused-for-feedback runs appear "still active" to the runtime layer).
- `SqliteHostAdapter::get_run()` converts `AgentRun → RunHandle` at the boundary so `worktree_id` / `repo_id` / `prompt` / `plan` never cross into `runkon-runtimes`.

## Acceptance criteria

- [x] `runkon-runtimes` builds and passes tests with no `worktree_id` / `repo_id` / `conversation_id` / `parent_run_id` / `claude_session_id` / `plan` references on persisted records.
- [x] `AgentRunStatus::WaitingForFeedback` lives in `conductor-core`, not the portable crate.
- [x] `SqliteHostAdapter` round-trips the full conductor `AgentRun` unchanged through `AgentManager::get_run()` for conductor-internal callers, projecting to `RunHandle` only when the trait is invoked.

## Out of scope

- `bot_name` survives in `RuntimeRequest` / `SpawnHeadlessParams` as a Claude-CLI flag pass-through (input parameter, not a persisted field). Separate concern from the `AgentRun` layer leak.
- Issue #2709 (rename `claude_session_id` → `session_id` on conductor's `AgentRun` + DB column) is a separate follow-up. The portable side already uses the generic `session_id` name on `RunHandle`; conductor-core's `AgentRun` and the `agent_runs` table still use `claude_session_id` until that migration lands.

## Test plan

- [x] `cargo test --workspace` — all crates green (~3,400 tests; 1915 in conductor-core)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)