### PR TITLE
refactor(agent): rename claude_session_id → session_id (#2709)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,7 +4555,6 @@ name = "runkon-runtimes"
 version = "0.9.2"
 dependencies = [
  "libc",
- "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/conductor-cli/src/handlers/agent.rs
+++ b/conductor-cli/src/handlers/agent.rs
@@ -216,9 +216,9 @@ pub(crate) fn run_agent(
         // Look up the previous run that owns this session_id
         if let Some(wt_id) = run.worktree_id.as_deref() {
             if let Ok(prev_runs) = mgr.list_for_worktree(wt_id) {
-                let prev_run = prev_runs.iter().find(|r| {
-                    r.claude_session_id.as_deref() == resume_session_id && r.id != run_id
-                });
+                let prev_run = prev_runs
+                    .iter()
+                    .find(|r| r.session_id.as_deref() == resume_session_id && r.id != run_id);
                 if let Some(prev) = prev_run {
                     if prev.has_incomplete_plan_steps() {
                         let incomplete: Vec<&PlanStep> = prev.incomplete_plan_steps();

--- a/conductor-core/src/agent/db.rs
+++ b/conductor-core/src/agent/db.rs
@@ -11,7 +11,7 @@ pub(super) const FEEDBACK_SELECT: &str =
 
 /// Shared SELECT column list for the `agent_runs` table (plain, unaliased form).
 pub(super) const AGENT_RUN_SELECT: &str =
-    "SELECT id, worktree_id, repo_id, claude_session_id, prompt, status, result_text, \
+    "SELECT id, worktree_id, repo_id, session_id, prompt, status, result_text, \
      cost_usd, num_turns, duration_ms, started_at, ended_at, log_file, \
      model, plan, parent_run_id, \
      input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens, \
@@ -37,7 +37,7 @@ macro_rules! agent_run_cols {
             $alias,
             "repo_id, ",
             $alias,
-            "claude_session_id, ",
+            "session_id, ",
             $alias,
             "prompt, ",
             $alias,
@@ -90,7 +90,7 @@ macro_rules! agent_run_cols {
             $alias,
             "repo_id, ",
             $alias,
-            "claude_session_id, ",
+            "session_id, ",
             $alias,
             "prompt, ",
             $alias,
@@ -217,7 +217,7 @@ pub(super) fn row_to_agent_run(row: &rusqlite::Row) -> rusqlite::Result<AgentRun
         id: row.get("id")?,
         worktree_id: row.get("worktree_id")?,
         repo_id: row.get("repo_id")?,
-        claude_session_id: row.get("claude_session_id")?,
+        session_id: row.get("session_id")?,
         prompt: row.get("prompt")?,
         status: row.get("status")?,
         result_text: row.get("result_text")?,
@@ -275,7 +275,7 @@ mod tests {
         "id",
         "worktree_id",
         "repo_id",
-        "claude_session_id",
+        "session_id",
         "prompt",
         "status",
         "result_text",
@@ -372,12 +372,12 @@ mod tests {
         let conn = test_db();
         conn.execute(
             "INSERT INTO agent_runs (id, prompt, status, started_at, worktree_id, repo_id, \
-             claude_session_id, result_text, cost_usd, num_turns, duration_ms, ended_at, \
+             session_id, result_text, cost_usd, num_turns, duration_ms, ended_at, \
              log_file, model, plan, parent_run_id, \
              input_tokens, output_tokens, cache_read_input_tokens, \
              cache_creation_input_tokens, bot_name) \
              VALUES (:id, :prompt, :status, :started_at, :worktree_id, :repo_id, \
-                     :claude_session_id, :result_text, :cost_usd, :num_turns, :duration_ms, :ended_at, \
+                     :session_id, :result_text, :cost_usd, :num_turns, :duration_ms, :ended_at, \
                      :log_file, :model, :plan, :parent_run_id, \
                      :input_tokens, :output_tokens, :cache_read_input_tokens, \
                      :cache_creation_input_tokens, :bot_name)",
@@ -388,7 +388,7 @@ mod tests {
                 ":started_at": "2025-01-01T00:00:00Z",
                 ":worktree_id": "wt-001",
                 ":repo_id": "repo-001",
-                ":claude_session_id": "sess-001",
+                ":session_id": "sess-001",
                 ":result_text": "all done",
                 ":cost_usd": 1.5,
                 ":num_turns": 10i64,
@@ -418,7 +418,7 @@ mod tests {
         assert_eq!(run.id, "run-001");
         assert_eq!(run.worktree_id.as_deref(), Some("wt-001"));
         assert_eq!(run.repo_id.as_deref(), Some("repo-001"));
-        assert_eq!(run.claude_session_id.as_deref(), Some("sess-001"));
+        assert_eq!(run.session_id.as_deref(), Some("sess-001"));
         assert_eq!(run.prompt, "do the thing");
         assert_eq!(run.status, crate::agent::status::AgentRunStatus::Running);
         assert_eq!(run.result_text.as_deref(), Some("all done"));
@@ -457,7 +457,7 @@ mod tests {
         assert_eq!(run.id, "run-null");
         assert!(run.worktree_id.is_none());
         assert!(run.repo_id.is_none());
-        assert!(run.claude_session_id.is_none());
+        assert!(run.session_id.is_none());
         assert!(run.result_text.is_none());
         assert!(run.cost_usd.is_none());
         assert!(run.num_turns.is_none());

--- a/conductor-core/src/agent/manager/lifecycle.rs
+++ b/conductor-core/src/agent/manager/lifecycle.rs
@@ -106,7 +106,7 @@ impl<'a> AgentManager<'a> {
             id: id.clone(),
             worktree_id: worktree_id.map(String::from),
             repo_id: repo_id.map(String::from),
-            claude_session_id: None,
+            session_id: None,
             prompt: prompt.to_string(),
             status: AgentRunStatus::Running,
             result_text: None,
@@ -170,7 +170,7 @@ impl<'a> AgentManager<'a> {
     ) -> Result<()> {
         let now = Utc::now().to_rfc3339();
         self.conn.execute(
-            "UPDATE agent_runs SET status = 'completed', claude_session_id = :session_id, \
+            "UPDATE agent_runs SET status = 'completed', session_id = :session_id, \
              result_text = :result_text, cost_usd = :cost_usd, num_turns = :num_turns, \
              duration_ms = :duration_ms, ended_at = :ended_at, \
              input_tokens = :input_tokens, output_tokens = :output_tokens, \
@@ -208,7 +208,7 @@ impl<'a> AgentManager<'a> {
         let now = Utc::now().to_rfc3339();
         self.conn.execute(
             "UPDATE agent_runs SET status = 'failed', result_text = :error, ended_at = :ended_at, \
-             claude_session_id = COALESCE(:session_id, claude_session_id) \
+             session_id = COALESCE(:session_id, session_id) \
              WHERE id = :id",
             named_params! {
                 ":error": error,
@@ -258,7 +258,7 @@ impl<'a> AgentManager<'a> {
     ///
     /// This is the authoritative write for the headless drain path. It persists
     /// `cost_usd`, `num_turns`, `duration_ms`, all token counts, and optionally
-    /// `claude_session_id` (via COALESCE so an eagerly-stored session_id is not
+    /// `session_id` (via COALESCE so an eagerly-stored session_id is not
     /// clobbered). The `AND status = 'running'` guard prevents double-writes if
     /// the subprocess has already finalized the row.
     pub fn update_run_completed_if_running_full(
@@ -271,7 +271,7 @@ impl<'a> AgentManager<'a> {
         self.conn.execute(
             "UPDATE agent_runs \
              SET status = 'completed', result_text = :result_text, ended_at = :ended_at, \
-                 claude_session_id = COALESCE(:session_id, claude_session_id), \
+                 session_id = COALESCE(:session_id, session_id), \
                  cost_usd = COALESCE(:cost_usd, cost_usd), \
                  num_turns = COALESCE(:num_turns, num_turns), \
                  duration_ms = COALESCE(:duration_ms, duration_ms), \
@@ -349,7 +349,7 @@ impl<'a> AgentManager<'a> {
     /// This enables resume even if the run fails or is cancelled.
     pub fn update_run_session_id(&self, run_id: &str, session_id: &str) -> Result<()> {
         self.conn.execute(
-            "UPDATE agent_runs SET claude_session_id = :session_id WHERE id = :id",
+            "UPDATE agent_runs SET session_id = :session_id WHERE id = :id",
             named_params! {
                 ":session_id": session_id,
                 ":id": run_id,
@@ -438,7 +438,7 @@ impl<'a> AgentManager<'a> {
     ) -> Result<()> {
         self.conn.execute(
             "UPDATE agent_runs \
-             SET model = COALESCE(:model, model), claude_session_id = COALESCE(:session_id, claude_session_id) \
+             SET model = COALESCE(:model, model), session_id = COALESCE(:session_id, session_id) \
              WHERE id = :id",
             named_params! {
                 ":model": model,
@@ -571,7 +571,7 @@ mod tests {
 
         let latest = mgr.latest_for_worktree("w1").unwrap().unwrap();
         assert_eq!(latest.status, AgentRunStatus::Completed);
-        assert_eq!(latest.claude_session_id.as_deref(), Some("sess-123"));
+        assert_eq!(latest.session_id.as_deref(), Some("sess-123"));
         assert_eq!(latest.cost_usd, Some(0.05));
     }
 
@@ -632,7 +632,7 @@ mod tests {
         let fetched = mgr.get_run(&run.id).unwrap().unwrap();
         assert_eq!(fetched.status, AgentRunStatus::Failed);
         assert_eq!(fetched.result_text.as_deref(), Some("Context exhausted"));
-        assert_eq!(fetched.claude_session_id.as_deref(), Some("sess-456"));
+        assert_eq!(fetched.session_id.as_deref(), Some("sess-456"));
     }
 
     #[test]
@@ -641,12 +641,12 @@ mod tests {
         let mgr = AgentManager::new(&conn);
 
         let run = mgr.create_run(Some("w1"), "Fix the bug", None).unwrap();
-        assert!(run.claude_session_id.is_none());
+        assert!(run.session_id.is_none());
 
         mgr.update_run_session_id(&run.id, "sess-early").unwrap();
 
         let fetched = mgr.get_run(&run.id).unwrap().unwrap();
-        assert_eq!(fetched.claude_session_id.as_deref(), Some("sess-early"));
+        assert_eq!(fetched.session_id.as_deref(), Some("sess-early"));
     }
 
     #[test]
@@ -661,7 +661,7 @@ mod tests {
         mgr.update_run_failed(&run.id, "Crashed").unwrap();
 
         let fetched = mgr.get_run(&run.id).unwrap().unwrap();
-        assert_eq!(fetched.claude_session_id.as_deref(), Some("sess-eager"));
+        assert_eq!(fetched.session_id.as_deref(), Some("sess-eager"));
     }
 
     #[test]
@@ -984,7 +984,7 @@ mod tests {
         let fetched = mgr.get_run(&run.id).unwrap().unwrap();
         assert_eq!(fetched.status, AgentRunStatus::Completed);
         assert_eq!(fetched.result_text.as_deref(), Some("All done"));
-        assert_eq!(fetched.claude_session_id.as_deref(), Some("sess-result"));
+        assert_eq!(fetched.session_id.as_deref(), Some("sess-result"));
         assert_eq!(fetched.cost_usd, Some(0.05));
         assert_eq!(fetched.num_turns, Some(3));
         assert_eq!(fetched.duration_ms, Some(5000));
@@ -1026,7 +1026,7 @@ mod tests {
         assert_eq!(fetched.status, AgentRunStatus::Completed);
         // COALESCE(NULL, "sess-early") → preserves eagerly stored session_id
         assert_eq!(
-            fetched.claude_session_id.as_deref(),
+            fetched.session_id.as_deref(),
             Some("sess-early"),
             "eagerly stored session_id must be preserved when result event has none"
         );
@@ -1091,7 +1091,7 @@ mod tests {
             Some("original-model"),
             "model should not be clobbered by NULL"
         );
-        assert_eq!(fetched.claude_session_id.as_deref(), Some("sess-abc"));
+        assert_eq!(fetched.session_id.as_deref(), Some("sess-abc"));
 
         // Update again with session_id=None — COALESCE should preserve original session
         mgr.update_run_model_and_session(&run.id, Some("new-model"), None)
@@ -1103,7 +1103,7 @@ mod tests {
             "model should be updated when not NULL"
         );
         assert_eq!(
-            fetched.claude_session_id.as_deref(),
+            fetched.session_id.as_deref(),
             Some("sess-abc"),
             "session should not be clobbered by NULL"
         );

--- a/conductor-core/src/agent/manager/plan_steps.rs
+++ b/conductor-core/src/agent/manager/plan_steps.rs
@@ -385,7 +385,7 @@ mod tests {
         assert!(fetched.needs_resume());
         assert!(fetched.has_incomplete_plan_steps());
         assert_eq!(fetched.incomplete_plan_steps().len(), 2);
-        assert_eq!(fetched.claude_session_id.as_deref(), Some("sess-abc"));
+        assert_eq!(fetched.session_id.as_deref(), Some("sess-abc"));
     }
 
     #[test]
@@ -490,7 +490,7 @@ mod tests {
             id: "test".to_string(),
             worktree_id: Some("w1".to_string()),
             repo_id: None,
-            claude_session_id: Some("sess-abc".to_string()),
+            session_id: Some("sess-abc".to_string()),
             prompt: "Fix the bug".to_string(),
             status: AgentRunStatus::Failed,
             result_text: None,

--- a/conductor-core/src/agent/manager/queries.rs
+++ b/conductor-core/src/agent/manager/queries.rs
@@ -1145,10 +1145,7 @@ mod tests {
 
         let latest = mgr.latest_repo_scoped("r1").unwrap().unwrap();
         assert_eq!(latest.id, newer.id);
-        assert_eq!(
-            latest.claude_session_id.as_deref(),
-            Some("sess-repo-latest")
-        );
+        assert_eq!(latest.session_id.as_deref(), Some("sess-repo-latest"));
     }
 
     /// Verify the auto-resume session pattern used by `start_repo_agent`:
@@ -1164,7 +1161,7 @@ mod tests {
         let resume_id = mgr
             .latest_repo_scoped("r1")
             .unwrap()
-            .and_then(|run| run.claude_session_id);
+            .and_then(|run| run.session_id);
         assert!(
             resume_id.is_none(),
             "no prior run means no session to resume"
@@ -1190,7 +1187,7 @@ mod tests {
         let resume_id = mgr
             .latest_repo_scoped("r1")
             .unwrap()
-            .and_then(|run| run.claude_session_id);
+            .and_then(|run| run.session_id);
         assert_eq!(resume_id.as_deref(), Some("sess-abc"));
 
         // Note: the `new_session=true` branch in start_repo_agent is a trivial

--- a/conductor-core/src/agent/types.rs
+++ b/conductor-core/src/agent/types.rs
@@ -59,7 +59,7 @@ pub struct AgentRun {
     pub id: String,
     pub worktree_id: Option<String>,
     pub repo_id: Option<String>,
-    pub claude_session_id: Option<String>,
+    pub session_id: Option<String>,
     pub prompt: String,
     pub status: AgentRunStatus,
     pub result_text: Option<String>,
@@ -112,7 +112,7 @@ impl AgentRun {
             status: self.status.into(),
             subprocess_pid: self.subprocess_pid,
             runtime: self.runtime.clone(),
-            session_id: self.claude_session_id.clone(),
+            session_id: self.session_id.clone(),
             result_text: self.result_text.clone(),
             started_at: self.started_at.clone(),
             ended_at: self.ended_at.clone(),
@@ -152,7 +152,7 @@ impl AgentRun {
         matches!(
             self.status,
             AgentRunStatus::Failed | AgentRunStatus::Cancelled
-        ) && self.claude_session_id.is_some()
+        ) && self.session_id.is_some()
             && self.has_incomplete_plan_steps()
     }
 
@@ -396,7 +396,7 @@ mod tests {
             id: id.to_string(),
             worktree_id: None,
             repo_id: None,
-            claude_session_id: None,
+            session_id: None,
             prompt: String::new(),
             status: AgentRunStatus::Running,
             result_text: None,
@@ -427,7 +427,7 @@ mod tests {
             id: "01JVFJT9K7XPPQ9MH6JV7XRM3M".into(),
             worktree_id: Some("wt-1".into()),
             repo_id: Some("repo-1".into()),
-            claude_session_id: Some("sess-abc".into()),
+            session_id: Some("sess-abc".into()),
             prompt: "do the thing".into(),
             status: AgentRunStatus::Completed,
             result_text: Some("done".into()),
@@ -503,8 +503,9 @@ mod tests {
         assert_eq!(handle.id, run.id);
         assert_eq!(handle.subprocess_pid, run.subprocess_pid);
         assert_eq!(handle.runtime, run.runtime);
-        // claude_session_id maps to the generic `session_id` on the portable handle.
-        assert_eq!(handle.session_id, run.claude_session_id);
+        // session_id is now a plain field copy (issue #2709 renamed the conductor
+        // column / struct field to match the portable RunHandle field name).
+        assert_eq!(handle.session_id, run.session_id);
         assert_eq!(handle.result_text, run.result_text);
         assert_eq!(handle.started_at, run.started_at);
         assert_eq!(handle.ended_at, run.ended_at);

--- a/conductor-core/src/conversation/manager.rs
+++ b/conductor-core/src/conversation/manager.rs
@@ -105,15 +105,15 @@ impl<'a> ConversationManager<'a> {
         Ok(count > 0)
     }
 
-    /// Return the `claude_session_id` of the most recent *completed* run in the
+    /// Return the `session_id` of the most recent *completed* run in the
     /// conversation, or `None` if no such run exists (fresh session).
     pub fn last_completed_session_id(&self, conversation_id: &str) -> Result<Option<String>> {
         let result: rusqlite::Result<Option<String>> = self.conn.query_row(
-            "SELECT claude_session_id FROM agent_runs \
+            "SELECT session_id FROM agent_runs \
              WHERE conversation_id = :conversation_id AND status = 'completed' \
              ORDER BY started_at DESC LIMIT 1",
             named_params! { ":conversation_id": conversation_id },
-            |row| row.get("claude_session_id"),
+            |row| row.get("session_id"),
         );
         match result {
             Ok(v) => Ok(v),

--- a/conductor-core/src/db/migrations.rs
+++ b/conductor-core/src/db/migrations.rs
@@ -5,7 +5,7 @@ use crate::error::{ConductorError, Result};
 
 /// The highest migration version this binary knows about.
 /// **When adding a new migration, update this constant to match the new version.**
-pub const LATEST_SCHEMA_VERSION: u32 = 81;
+pub const LATEST_SCHEMA_VERSION: u32 = 82;
 
 /// Legacy plan step shape used only for migrating JSON data from agent_runs.plan.
 #[derive(Deserialize)]
@@ -1238,6 +1238,38 @@ pub fn run(conn: &Connection) -> Result<()> {
             )?;
         }
         bump_version(conn, 81)?;
+    }
+
+    // Migration 082: rename agent_runs.claude_session_id → session_id.
+    // Issue #2709 — finishes aligning the conductor-side column with the
+    // already-renamed runkon-runtimes RunHandle.session_id field.
+    // Column-existence guard handles DBs that already have the new name from
+    // feature branches and partial-schema test setups that lack agent_runs.
+    if version < 82 {
+        let has_agent_runs_table: bool = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='table' AND name='agent_runs'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n > 0)
+            .unwrap_or(false);
+        // Only rename when the source column actually exists. Some unit tests
+        // build minimal agent_runs fixtures with neither the old nor the new
+        // column; the rename is a no-op there.
+        let has_old_column: bool = has_agent_runs_table
+            && conn
+                .prepare("SELECT claude_session_id FROM agent_runs LIMIT 0")
+                .is_ok();
+        let has_new_column: bool = has_agent_runs_table
+            && conn
+                .prepare("SELECT session_id FROM agent_runs LIMIT 0")
+                .is_ok();
+        if has_old_column && !has_new_column {
+            conn.execute_batch(include_str!("migrations/082_rename_claude_session_id.sql"))?;
+        }
+        bump_version(conn, 82)?;
     }
 
     Ok(())

--- a/conductor-core/src/db/migrations/082_rename_claude_session_id.sql
+++ b/conductor-core/src/db/migrations/082_rename_claude_session_id.sql
@@ -1,0 +1,12 @@
+-- Migration 082: rename agent_runs.claude_session_id → session_id.
+--
+-- Closes the second half of issue #2709. The portable runkon-runtimes
+-- `RunHandle` already uses the generic `session_id` field name (introduced in
+-- migration 081's PR for #2711). This migration aligns the conductor side so
+-- the persisted column matches the struct field and no rename happens at the
+-- boundary projection.
+--
+-- SQLite 3.25+ supports direct column renames; conductor uses 3.45+ via
+-- bundled rusqlite, so no table-rebuild dance is required.
+
+ALTER TABLE agent_runs RENAME COLUMN claude_session_id TO session_id;

--- a/conductor-core/src/notify/tests.rs
+++ b/conductor-core/src/notify/tests.rs
@@ -1643,7 +1643,7 @@ fn make_agent_run(id: &str, status: AgentRunStatus) -> AgentRun {
         id: id.to_string(),
         worktree_id: None,
         repo_id: None,
-        claude_session_id: None,
+        session_id: None,
         prompt: String::new(),
         status,
         result_text: None,

--- a/conductor-tui/src/app/agent_execution.rs
+++ b/conductor-tui/src/app/agent_execution.rs
@@ -201,8 +201,8 @@ impl App {
         // Determine resume state: either a normal resume (completed run with session_id)
         // or a needs_resume (failed/cancelled run with incomplete plan steps)
         let (resume_session_id, needs_resume) = match latest_run {
-            Some(run) if run.needs_resume() => (run.claude_session_id.clone(), true),
-            Some(run) => (run.claude_session_id.clone(), false),
+            Some(run) if run.needs_resume() => (run.session_id.clone(), true),
+            Some(run) => (run.session_id.clone(), false),
             None => (None, false),
         };
 
@@ -647,7 +647,7 @@ impl App {
             .data
             .latest_repo_agent_runs
             .get(&repo.id)
-            .and_then(|run| run.claude_session_id.clone());
+            .and_then(|run| run.session_id.clone());
 
         let title = if resume_session_id.is_some() {
             "Repo Agent (Resume)".to_string()

--- a/conductor-tui/src/app/tests/action_handler_tests.rs
+++ b/conductor-tui/src/app/tests/action_handler_tests.rs
@@ -452,7 +452,7 @@ fn show_confirm_quit_with_running_agents_includes_count() {
             id: "run1".into(),
             worktree_id: Some("wt1".into()),
             repo_id: None,
-            claude_session_id: None,
+            session_id: None,
             prompt: String::new(),
             status: conductor_core::agent::AgentRunStatus::Running,
             result_text: None,

--- a/conductor-tui/src/ui/worktree_detail.rs
+++ b/conductor-tui/src/ui/worktree_detail.rs
@@ -574,7 +574,7 @@ fn render_agent_status_line(
                 stats,
                 Style::default().fg(theme.label_secondary),
             ));
-            if let Some(ref sid) = run.claude_session_id {
+            if let Some(ref sid) = run.session_id {
                 spans.push(Span::styled(
                     format!("  session: {}", &sid[..13.min(sid.len())]),
                     Style::default().fg(theme.label_secondary),

--- a/conductor-web/src/main.rs
+++ b/conductor-web/src/main.rs
@@ -869,7 +869,7 @@ mod tests {
             id: id.to_string(),
             worktree_id: None,
             repo_id: None,
-            claude_session_id: None,
+            session_id: None,
             prompt: String::new(),
             status: AgentRunStatus::Running,
             result_text: None,

--- a/conductor-web/src/routes/agents.rs
+++ b/conductor-web/src/routes/agents.rs
@@ -749,9 +749,9 @@ pub async fn get_prompt(
     let (resume_session_id, needs_resume, incomplete_steps) = match &latest_run {
         Some(run) if run.needs_resume() => {
             let incomplete = run.incomplete_plan_steps().len();
-            (run.claude_session_id.clone(), true, incomplete)
+            (run.session_id.clone(), true, incomplete)
         }
-        Some(run) => (run.claude_session_id.clone(), false, 0),
+        Some(run) => (run.session_id.clone(), false, 0),
         None => (None, false, 0),
     };
 
@@ -1211,7 +1211,7 @@ pub async fn start_repo_agent(
         } else {
             agent_mgr
                 .latest_repo_scoped(&repo_id)?
-                .and_then(|run| run.claude_session_id)
+                .and_then(|run| run.session_id)
         };
 
         let run = agent_mgr.create_repo_run(&repo_id, &body.prompt, model.as_deref())?;


### PR DESCRIPTION
Closes #2709.

Third and final issue from the runkon-runtimes layer-violation trio (#2712 / #2711 / #2709). After PR #2721 introduced the portable `RunHandle.session_id` field with a generic name and noted that the conductor side still used the vendor-named `claude_session_id`, this PR aligns the conductor column and struct field with the portable name.

## What changes

- **Migration 082** (`agent_runs.claude_session_id` → `agent_runs.session_id`) via `ALTER TABLE RENAME COLUMN`. SQLite 3.25+ supports direct rename; conductor uses 3.45+ via bundled rusqlite, so no table-rebuild dance.
- **Column-existence guards** on both the old and new column in the migration runner handle DBs that already have the new name (feature branches) and partial-schema test fixtures that lack `agent_runs` entirely.
- **Struct field rename** on conductor's `AgentRun.claude_session_id` → `session_id`. After this, `AgentRun::to_run_handle()` becomes a plain field copy instead of a cross-name rename.
- **Call sites updated** across `conductor-cli`, `conductor-tui` (×3), `conductor-web` (×2), and `conductor-core` internals (db, manager/lifecycle, manager/queries, manager/plan_steps, conversation/manager, notify/tests, types).

## Out of scope

Historical migration `.sql` files (003, 018, 027) keep `claude_session_id` since they record the schema state at those past versions — the rename is one-way; older snapshots stay literal.

## Cargo.lock

Picks up the stale `rusqlite` dep removal on `runkon-runtimes` from #2721's feature cleanup (the `.toml` change was in that PR but the lockfile hadn't caught up).

## Test plan

- [x] `cargo test --workspace` — all crates green (~3,400 tests; 1926 in conductor-core)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)