### PR TITLE
refactor(workflow): close runkon-flow public-API leaks (#2611, #2643, #2587)

### DIFF
--- a/.claude/skills/conductor-workflow-create/SKILL.md
+++ b/.claude/skills/conductor-workflow-create/SKILL.md
@@ -190,5 +190,5 @@ If validation fails:
 
 - The `targets` field in `meta` is required. Use `["worktree"]` for branch-scoped work, `["repo"]` for repository-level work.
 - Agent names in `call` statements must match the filename without `.md` (e.g., `call review-security` resolves to `.conductor/agents/review-security.md`).
-- `while` and `do {} while` conditions reference `<step-name>.<marker>` where `<step-name>` is the name of a prior `call` statement and `<marker>` is a string the agent emits in its `CONDUCTOR_OUTPUT` markers array.
+- `while` and `do {} while` conditions reference `<step-name>.<marker>` where `<step-name>` is the name of a prior `call` statement and `<marker>` is a string the agent emits in its `FLOW_OUTPUT` markers array.
 - A workflow that only calls read-only agents can still be useful — dry-run mode is safe for all agents with `can_commit: false`.

--- a/.conductor/agents/analyze-coverage.md
+++ b/.conductor/agents/analyze-coverage.md
@@ -21,5 +21,5 @@ For each finding, report:
 - Priority (high/medium/low)
 - Why this gap matters (what behavior could go untested)
 
-If you find areas that need tests, include the marker `has_missing_tests` in your CONDUCTOR_OUTPUT markers.
+If you find areas that need tests, include the marker `has_missing_tests` in your FLOW_OUTPUT markers.
 If test coverage is already sufficient, do not include that marker.

--- a/.conductor/agents/analyze-file-structure.md
+++ b/.conductor/agents/analyze-file-structure.md
@@ -95,7 +95,7 @@ Context format:
 ```
 
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["has_split_recommendations"], "context": "## File Structure Analysis\n\n### `src/app.rs` ..."}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```

--- a/.conductor/agents/analyze-mobile-ux.md
+++ b/.conductor/agents/analyze-mobile-ux.md
@@ -93,14 +93,14 @@ Emit markers based on findings:
 Also emit a `findings` JSON array in structured output so the downstream gate can present them as selectable checkboxes. Each entry is a short string that will be shown to the reviewer. Use the format `"[HIGH] <title> (<view>)"`, `"[MED] ..."`, or `"[LOW] ..."`:
 
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["has_findings", "has_high_severity"], "context": "Wrote mobile UX audit report to ~/.conductor/audits/conductor-ai/mobile-ux-audit-<date>.md — <count> findings (<high> high, <medium> medium, <low> low). Top issue: <one-line summary of worst finding>", "structured_output": {"findings": ["[HIGH] Touch targets too small on Repo Detail (iPhone 14)", "[MED] Table overflow on Activity page (Pixel 7)"]}}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```
 
 If no findings at all:
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Mobile UX audit complete — no issues found. Report at ~/.conductor/audits/conductor-ai/mobile-ux-audit-<date>.md", "structured_output": {"findings": []}}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```

--- a/.conductor/agents/analyze-per-persona.md
+++ b/.conductor/agents/analyze-per-persona.md
@@ -37,5 +37,5 @@ Full context history (personas + diagrams): {{prior_contexts}}
    - <description>
    ```
 
-6. Emit `<<<CONDUCTOR_OUTPUT>>>` with:
+6. Emit `<<<FLOW_OUTPUT>>>` with:
    - `context`: the full structured analysis

--- a/.conductor/agents/analyze-postmortem.md
+++ b/.conductor/agents/analyze-postmortem.md
@@ -72,4 +72,4 @@ Prior step context: {{prior_context}}
    - Concrete, actionable recommendations to improve workflow reliability, speed, or clarity
    - At least one suggestion per identified issue
 
-3. Emit CONDUCTOR_OUTPUT with a one-sentence summary of the top finding (e.g. "Step `implement` failed on retry 2 due to a cargo build error — no retries were configured").
+3. Emit FLOW_OUTPUT with a one-sentence summary of the top finding (e.g. "Step `implement` failed on retry 2 due to a cargo build error — no retries were configured").

--- a/.conductor/agents/assess-ticket-readiness.md
+++ b/.conductor/agents/assess-ticket-readiness.md
@@ -44,7 +44,7 @@ Write a structured assessment with:
 - For READY: a one-paragraph summary of what the agent will implement and why you are confident the ticket is unambiguous
 - For SHOULD CLOSE: a brief explanation of why the ticket is invalid, already resolved, or no longer actionable (this becomes the `close_reason`)
 
-Emit `<<<CONDUCTOR_OUTPUT>>>` with:
+Emit `<<<FLOW_OUTPUT>>>` with:
 - `context`: your full assessment text
 - `markers`: include `ticket_ready` if the ticket is ready, `has_open_questions` if it is not, `should_close` if the ticket is invalid or resolved
 - `close_reason`: (only when `should_close`) a one-sentence human-readable explanation

--- a/.conductor/agents/create-repo-issues.md
+++ b/.conductor/agents/create-repo-issues.md
@@ -99,7 +99,7 @@ If no issues were created (auth failure or no eligible items):
 - Set context to an explanation of why no issues were created.
 
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["issues_created"], "context": "Created N GitHub issues for top refactoring recommendations:\n- #123: ..."}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```

--- a/.conductor/agents/draft-gh-issue.md
+++ b/.conductor/agents/draft-gh-issue.md
@@ -23,9 +23,9 @@ User's initial idea: {{rough_idea}}
    ```
    If not authenticated, stop immediately and output:
    ```
-   <<<CONDUCTOR_OUTPUT>>>
+   <<<FLOW_OUTPUT>>>
    {"markers": [], "context": "ERROR: gh CLI is not authenticated. Run 'gh auth login' and re-run this workflow."}
-   <<<END_CONDUCTOR_OUTPUT>>>
+   <<<END_FLOW_OUTPUT>>>
    ```
 
 2. **Determine the GitHub remote** `<owner>/<repo>` for this repo:
@@ -88,12 +88,12 @@ Format your final output as:
 <full issue body in markdown>
 ```
 
-Then emit the conductor output block:
+Then emit the flow output block:
 
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Draft issue: <title>\nLabels: <labels>\nAssignee: <assignee>\nBody:\n<full body>"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```
 
 Include the complete draft in the `context` field so the next step can create the issue from it.

--- a/.conductor/agents/draft-release-notes.md
+++ b/.conductor/agents/draft-release-notes.md
@@ -35,4 +35,4 @@ Prior step context: {{prior_context}}
 
    Keep the entry concise. Prefer one clear sentence per bullet. Avoid jargon unless it matches the repo's existing CHANGELOG style.
 
-4. Emit `<<<CONDUCTOR_OUTPUT>>>` with the full draft release notes entry as the `context` string. This is the primary output of the workflow — write the complete entry in the context field so it is captured as the workflow result.
+4. Emit `<<<FLOW_OUTPUT>>>` with the full draft release notes entry as the `context` string. This is the primary output of the workflow — write the complete entry in the context field so it is captured as the workflow result.

--- a/.conductor/agents/eval-ux-interaction.md
+++ b/.conductor/agents/eval-ux-interaction.md
@@ -36,4 +36,4 @@ RECOMMENDATIONS:
 
 Repeat for each dimension. End with top 5 priority interaction improvements.
 
-Include `has_review_issues` in CONDUCTOR_OUTPUT markers if any dimension scores below 70.
+Include `has_review_issues` in FLOW_OUTPUT markers if any dimension scores below 70.

--- a/.conductor/agents/eval-ux-layout.md
+++ b/.conductor/agents/eval-ux-layout.md
@@ -38,4 +38,4 @@ RECOMMENDATIONS:
 
 Repeat for each dimension. End with an overall assessment and top 5 priority improvements.
 
-Include `has_review_issues` in CONDUCTOR_OUTPUT markers if any dimension scores below 70.
+Include `has_review_issues` in FLOW_OUTPUT markers if any dimension scores below 70.

--- a/.conductor/agents/eval-ux-synthesizer.md
+++ b/.conductor/agents/eval-ux-synthesizer.md
@@ -60,5 +60,5 @@ Full context history: {{prior_contexts}}
 
 Each improvement item should include: the specific file(s) to change, what to change, and why it matters.
 
-If the overall score is below 70, include `has_blocking_findings` in CONDUCTOR_OUTPUT markers.
+If the overall score is below 70, include `has_blocking_findings` in FLOW_OUTPUT markers.
 Include `has_review_issues` if any critical issues are found.

--- a/.conductor/agents/eval-ux-visual.md
+++ b/.conductor/agents/eval-ux-visual.md
@@ -36,4 +36,4 @@ RECOMMENDATIONS:
 
 Repeat for each dimension. End with top 5 priority visual improvements.
 
-Include `has_review_issues` in CONDUCTOR_OUTPUT markers if any dimension scores below 70.
+Include `has_review_issues` in FLOW_OUTPUT markers if any dimension scores below 70.

--- a/.conductor/agents/extract-personas.md
+++ b/.conductor/agents/extract-personas.md
@@ -47,5 +47,5 @@ You are a personas analyst. Your job is to scan the codebase for all distinct us
    git commit -m "docs: add personas.md for diagram workflows"
    ```
 
-6. Emit `<<<CONDUCTOR_OUTPUT>>>` with:
+6. Emit `<<<FLOW_OUTPUT>>>` with:
    - `context`: summary of personas found and written

--- a/.conductor/agents/fetch-ticket-context.md
+++ b/.conductor/agents/fetch-ticket-context.md
@@ -58,7 +58,7 @@ If the fetch fails, fall back to `git log --oneline -20`.
 
 ## Step 6 — Output
 
-Emit `<<<CONDUCTOR_OUTPUT>>>` with a `context` string containing:
+Emit `<<<FLOW_OUTPUT>>>` with a `context` string containing:
 - Full ticket title and body
 - Summary of all linked/blocking issues and their states
 - The resolved `base_branch` (from linked PR, or the worktree's configured target branch)

--- a/.conductor/agents/file-ux-issues.md
+++ b/.conductor/agents/file-ux-issues.md
@@ -53,21 +53,21 @@ Gate feedback (if provided): {{gate_feedback}}
 ## Output
 
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["issues_filed"], "context": "Created <N> GitHub issues for high-severity mobile UX findings: <list of issue numbers/titles>"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```
 
 If dry-run:
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Dry run — would create <N> issues for high-severity findings: <titles>"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```
 
 If no high-severity findings were found in the report:
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "No high-severity findings to file issues for"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```

--- a/.conductor/agents/file-vulnerability-issues.md
+++ b/.conductor/agents/file-vulnerability-issues.md
@@ -57,21 +57,21 @@ Prior step context: {{prior_context}}
 ## Output
 
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["issues_filed"], "context": "Filed <N> GitHub issues for security advisories: <comma-separated RUSTSEC IDs>"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```
 
 If dry-run:
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Dry run — would file <N> issues: <comma-separated RUSTSEC IDs>"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```
 
 If no advisories were found in the JSON output:
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "No advisories found in cargo audit --json output"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```

--- a/.conductor/agents/fix-ci-failures.md
+++ b/.conductor/agents/fix-ci-failures.md
@@ -17,7 +17,7 @@ Run:
 gh pr checks
 ```
 
-If all checks pass (no failures), emit `has_failures: false` in CONDUCTOR_OUTPUT and stop — no further work needed.
+If all checks pass (no failures), emit `has_failures: false` in FLOW_OUTPUT and stop — no further work needed.
 
 ### 2. Fetch failure logs
 
@@ -49,7 +49,7 @@ Classify each failure as **fixable** or **not fixable**:
 - Failures in unrelated services or jobs
 - Any failure whose root cause is outside the PR's file set
 
-If **any** failure is not fixable, output a clear explanation of what failed and why it cannot be fixed, then exit with a non-zero status (do NOT emit `has_failures` in CONDUCTOR_OUTPUT — let the workflow surface the error to the user).
+If **any** failure is not fixable, output a clear explanation of what failed and why it cannot be fixed, then exit with a non-zero status (do NOT emit `has_failures` in FLOW_OUTPUT — let the workflow surface the error to the user).
 
 ### 4. Fix the code
 
@@ -94,15 +94,15 @@ If `--watch` is not available or times out, poll manually with `gh pr checks` in
 ### 8. Report result
 
 After checks complete:
-- If all pass → emit `has_failures: false` in CONDUCTOR_OUTPUT.
-- If any still fail → emit `has_failures: true` in CONDUCTOR_OUTPUT (the outer workflow will run another iteration, up to 3 total).
+- If all pass → emit `has_failures: false` in FLOW_OUTPUT.
+- If any still fail → emit `has_failures: true` in FLOW_OUTPUT (the outer workflow will run another iteration, up to 3 total).
 
-## CONDUCTOR_OUTPUT format
+## FLOW_OUTPUT format
 
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "<one sentence summary>"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```
 
 Use `"markers": ["has_failures"]` when CI is still failing; use `"markers": []` when all checks pass.

--- a/.conductor/agents/generate-diagram-files.md
+++ b/.conductor/agents/generate-diagram-files.md
@@ -41,5 +41,5 @@ Diagram types to generate: {{types}}
    git commit -m "docs: generate {{types}} diagrams"
    ```
 
-5. Emit `<<<CONDUCTOR_OUTPUT>>>` with:
+5. Emit `<<<FLOW_OUTPUT>>>` with:
    - `context`: list of files written and a one-sentence summary of each

--- a/.conductor/agents/identify-affected-diagrams.md
+++ b/.conductor/agents/identify-affected-diagrams.md
@@ -27,5 +27,5 @@ Prior step context (ticket details): {{prior_context}}
 
 4. If `{{types}}` is non-empty, restrict to only those types.
 
-5. Emit `<<<CONDUCTOR_OUTPUT>>>` with:
+5. Emit `<<<FLOW_OUTPUT>>>` with:
    - `context`: comma-separated list of affected diagram filenames and a one-sentence reason for each

--- a/.conductor/agents/identify-large-files.md
+++ b/.conductor/agents/identify-large-files.md
@@ -61,7 +61,7 @@ If no files exceed the threshold:
 - Set context to: `No files exceed the threshold of {{threshold_lines}} lines. Repository appears well-structured.`
 
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["has_large_files"], "context": "## Large Files (>= {{threshold_lines}} lines)\n\n| File | Lines | Category | Est. % Tests | Notes |\n..."}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```

--- a/.conductor/agents/read-ticket.md
+++ b/.conductor/agents/read-ticket.md
@@ -55,7 +55,7 @@ The ticket is: {{ticket}}
    - Key decisions are deferred ("TBD", "decide later")
    - It references work that hasn't been done yet
 
-8. Emit `<<<CONDUCTOR_OUTPUT>>>` with:
+8. Emit `<<<FLOW_OUTPUT>>>` with:
    - `markers`: include `is_refined` if the ticket is ready for autonomous diagram updates
    - `context`: ticket title, brief summary of the change, and (if not refined) a numbered list of specific open questions. Also include:
      - `Figma context:` heading with any found Figma URLs (or "none" if none found)

--- a/.conductor/agents/report-coverage.md
+++ b/.conductor/agents/report-coverage.md
@@ -25,4 +25,4 @@ Write the comment body to `/tmp/coverage-report.md` before posting. The comment 
 
 Keep the comment concise and actionable. Use markdown formatting.
 
-After posting the comment, output a summary in your CONDUCTOR_OUTPUT context field.
+After posting the comment, output a summary in your FLOW_OUTPUT context field.

--- a/.conductor/agents/report-open-questions.md
+++ b/.conductor/agents/report-open-questions.md
@@ -29,5 +29,5 @@ Prior step context (ticket assessment with open questions): {{prior_context}}
 
 4. Do not write any files or make any git changes.
 
-5. Emit `<<<CONDUCTOR_OUTPUT>>>` with:
+5. Emit `<<<FLOW_OUTPUT>>>` with:
    - `context`: the formatted open questions block above

--- a/.conductor/agents/review-aggregator.md
+++ b/.conductor/agents/review-aggregator.md
@@ -46,7 +46,7 @@ Steps:
 
 ## Phase 2 — Produce output
 
-3. Produce your CONDUCTOR_OUTPUT with the correct structured fields so the workflow engine can derive outcome markers automatically from the schema:
+3. Produce your FLOW_OUTPUT with the correct structured fields so the workflow engine can derive outcome markers automatically from the schema:
 
    - Set `overall_approved: false` if **any** reviewer is classified as blocking in Phase 1 (i.e. has `has_review_issues` marker OR has critical/warning findings in `structured_output`). Set `overall_approved: true` only if no reviewer is blocking.
    - Populate `reviewed_by` with a comma-separated string of human-readable reviewer display names (e.g. "DB Migrations, Security, Performance") for each reviewer that ran and returned results.

--- a/.conductor/agents/rt-aggregator.md
+++ b/.conductor/agents/rt-aggregator.md
@@ -36,7 +36,7 @@ Steps:
    - Subtract 15 if reviewers disagree on blocking status
    - Minimum 0
 
-5. Produce CONDUCTOR_OUTPUT with structured fields:
+5. Produce FLOW_OUTPUT with structured fields:
    - `verdict`: "pass" or "fail"
    - `confidence`: number 0-100
    - `consensus_mode`: "consensus" or "discussion"

--- a/.conductor/agents/rt-security-auth.md
+++ b/.conductor/agents/rt-security-auth.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Non-security code quality issues
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/rt-security-input-validation.md
+++ b/.conductor/agents/rt-security-input-validation.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Theoretical attacks requiring local system access (tool runs locally)
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/rt-security-supply-chain.md
+++ b/.conductor/agents/rt-security-supply-chain.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Existing dependencies that haven't changed
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/rt-strategic-architect.md
+++ b/.conductor/agents/rt-strategic-architect.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Performance issues (handled by scalability reviewer)
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/rt-strategic-maintainability.md
+++ b/.conductor/agents/rt-strategic-maintainability.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Minor style preferences already enforced by rustfmt/clippy
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/rt-strategic-scalability.md
+++ b/.conductor/agents/rt-strategic-scalability.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Security concerns (handled by security roundtable)
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/rt-testing-coverage.md
+++ b/.conductor/agents/rt-testing-coverage.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Integration or E2E test gaps (handled by integration reviewer)
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/rt-testing-integration.md
+++ b/.conductor/agents/rt-testing-integration.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Code quality in non-test files
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/rt-testing-regression.md
+++ b/.conductor/agents/rt-testing-regression.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Code quality or style issues
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/rt-ui-accessibility.md
+++ b/.conductor/agents/rt-ui-accessibility.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Content or naming choices
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/rt-ui-consistency.md
+++ b/.conductor/agents/rt-ui-consistency.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Implementation details or code quality
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/rt-ui-usability.md
+++ b/.conductor/agents/rt-ui-usability.md
@@ -23,4 +23,4 @@ Do NOT flag:
 - Code architecture or implementation details
 
 Produce structured output with findings, each having file, line, severity (critical/warning), and message.
-If you find critical or warning issues, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning issues, include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/agents/synthesize-repo-report.md
+++ b/.conductor/agents/synthesize-repo-report.md
@@ -66,7 +66,7 @@ List any large files that are generated, data files, or have only L-effort split
 Set context to the full markdown report text (truncated to ~2000 chars if very long, with a note that the full report is in `analysis-report.md`).
 
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "# Repo Analysis Report\n\n## Executive Summary\n..."}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```

--- a/.conductor/agents/update-diagram-files.md
+++ b/.conductor/agents/update-diagram-files.md
@@ -27,5 +27,5 @@ Prior step context (ticket summary + affected diagrams): {{prior_context}}
    git diff --cached docs/diagrams/
    ```
 
-6. Emit `<<<CONDUCTOR_OUTPUT>>>` with:
+6. Emit `<<<FLOW_OUTPUT>>>` with:
    - `context`: list of files updated, a one-sentence description of what changed in each, and the full `git diff --cached` output so the reviewer can inspect the exact changes

--- a/.conductor/agents/write-analysis-report.md
+++ b/.conductor/agents/write-analysis-report.md
@@ -59,5 +59,5 @@ Prior step context (per-persona UX analysis): {{prior_context}}
    git commit -m "docs: add UX analysis report <date>"
    ```
 
-8. Emit `<<<CONDUCTOR_OUTPUT>>>` with:
+8. Emit `<<<FLOW_OUTPUT>>>` with:
    - `context`: path to the written report and a one-sentence summary of the top finding

--- a/.conductor/agents/write-postmortem-report.md
+++ b/.conductor/agents/write-postmortem-report.md
@@ -34,4 +34,4 @@ Prior step context: {{prior_context}}
    ls .conductor/postmortems/
    ```
 
-5. Emit CONDUCTOR_OUTPUT with context: the path to the written report, e.g. `.conductor/postmortems/{{workflow_run_id}}.md`.
+5. Emit FLOW_OUTPUT with context: the path to the written report, e.g. `.conductor/postmortems/{{workflow_run_id}}.md`.

--- a/.conductor/prompts/off-diff-findings.md
+++ b/.conductor/prompts/off-diff-findings.md
@@ -2,6 +2,6 @@
 
 While reviewing, you may encounter issues in unchanged or removed code that are real problems but should NOT block this PR (e.g., pre-existing bugs, tech debt, or design flaws in unmodified files).
 
-For each such finding, populate the `off_diff_findings` field in your CONDUCTOR_OUTPUT. Off-diff findings do NOT affect whether this PR gets approved — they are filed as separate GitHub issues.
+For each such finding, populate the `off_diff_findings` field in your FLOW_OUTPUT. Off-diff findings do NOT affect whether this PR gets approved — they are filed as separate GitHub issues.
 
 Only include `critical` or `warning` severity findings in `off_diff_findings`. Suggestion-level findings in off-diff code should be omitted entirely — they will not be filed as GitHub issues.

--- a/.conductor/prompts/review-diff-scope.md
+++ b/.conductor/prompts/review-diff-scope.md
@@ -30,7 +30,7 @@ Severity guide:
 
 Only flag `critical` or `warning` issues. Do not emit suggestion-level or style findings.
 
-Your `CONDUCTOR_OUTPUT` `context` field must be a **JSON object** (not plain text) so the aggregator can parse it. Use this structure:
+Your `FLOW_OUTPUT` `context` field must be a **JSON object** (not plain text) so the aggregator can parse it. Use this structure:
 
 ```json
 {
@@ -61,5 +61,5 @@ Your `CONDUCTOR_OUTPUT` `context` field must be a **JSON object** (not plain tex
 - `off_diff_findings`: issues in **unchanged/removed code** — never affect `approved`, filed as separate GitHub issues; only include `critical` or `warning` severity
 - Omit `off_diff_findings` entirely if there are none
 
-If you find **critical** or **warning** `findings`, include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find **critical** or **warning** `findings`, include `has_review_issues` in your FLOW_OUTPUT markers.
 If you find no findings, do NOT include that marker.

--- a/.conductor/prompts/roundtable-context.md
+++ b/.conductor/prompts/roundtable-context.md
@@ -38,7 +38,7 @@ For each finding, self-assess your evidence:
 
 Prefer Verified findings. Only include Inferred/Assumed findings for critical issues.
 
-Your `CONDUCTOR_OUTPUT` `context` field must be a **JSON object** with this structure:
+Your `FLOW_OUTPUT` `context` field must be a **JSON object** with this structure:
 
 ```json
 {
@@ -56,4 +56,4 @@ Your `CONDUCTOR_OUTPUT` `context` field must be a **JSON object** with this stru
 }
 ```
 
-If you find critical or warning findings, set `approved: false` and include `has_review_issues` in your CONDUCTOR_OUTPUT markers.
+If you find critical or warning findings, set `approved: false` and include `has_review_issues` in your FLOW_OUTPUT markers.

--- a/.conductor/workflows/update-diagrams/agents/push-and-pr.md
+++ b/.conductor/workflows/update-diagrams/agents/push-and-pr.md
@@ -32,5 +32,5 @@ Prior step context: {{prior_context}}
 
 6. Capture the PR URL (from the `gh pr create` output or `gh pr view --json url -q .url`).
 
-7. Emit `<<<CONDUCTOR_OUTPUT>>>` with:
+7. Emit `<<<FLOW_OUTPUT>>>` with:
    - `context`: the PR URL and a one-sentence description of what was merged

--- a/conductor-core/src/schema_config/mod.rs
+++ b/conductor-core/src/schema_config/mod.rs
@@ -1,7 +1,7 @@
 //! Schema-based structured output for workflow agents.
 //!
 //! Schemas live in `.conductor/schemas/<name>.yaml` and define the JSON shape
-//! that an agent's `CONDUCTOR_OUTPUT` block must conform to. The workflow engine
+//! that an agent's `FLOW_OUTPUT` block must conform to. The workflow engine
 //! uses schemas to:
 //!
 //! 1. Generate schema-specific output instructions in the agent prompt

--- a/conductor-core/src/schema_config/prompt.rs
+++ b/conductor-core/src/schema_config/prompt.rs
@@ -11,13 +11,13 @@ pub fn generate_prompt_instructions(schema: &OutputSchema) -> String {
         "When you have finished your work, output the following block exactly as the\n\
          last thing in your response. Do not include this block in code examples or\n\
          anywhere else — only as the final output.\n\n\
-         <<<CONDUCTOR_OUTPUT>>>\n",
+         <<<FLOW_OUTPUT>>>\n",
     );
 
     let json_example = generate_json_example(&schema.fields, 0);
     out.push_str(&json_example);
 
-    out.push_str("\n<<<END_CONDUCTOR_OUTPUT>>>\n");
+    out.push_str("\n<<<END_FLOW_OUTPUT>>>\n");
 
     // Add field descriptions as hints
     let hints = generate_field_hints(&schema.fields, "");

--- a/conductor-core/src/schema_config/tests.rs
+++ b/conductor-core/src/schema_config/tests.rs
@@ -111,7 +111,7 @@ fields:
 fn test_validate_valid_output() {
     let schema = parse_schema_content(TEST_SCHEMA_YAML, "test").unwrap();
     let json = r#"
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {
   "findings": [
     {
@@ -125,7 +125,7 @@ fn test_validate_valid_output() {
   "approved": false,
   "summary": "Found 1 high severity issue"
 }
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
     let result = parse_structured_output(json, &schema).unwrap();
     assert_eq!(result.context, "Found 1 high severity issue");
@@ -138,12 +138,12 @@ fn test_validate_valid_output() {
 fn test_validate_missing_required_field() {
     let schema = parse_schema_content(TEST_SCHEMA_YAML, "test").unwrap();
     let json = r#"
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {
   "findings": [],
   "summary": "All good"
 }
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
     let result = parse_structured_output(json, &schema);
     assert!(result.is_err());
@@ -154,13 +154,13 @@ fn test_validate_missing_required_field() {
 fn test_validate_wrong_type() {
     let schema = parse_schema_content(TEST_SCHEMA_YAML, "test").unwrap();
     let json = r#"
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {
   "findings": [],
   "approved": "yes",
   "summary": "All good"
 }
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
     let result = parse_structured_output(json, &schema);
     assert!(result.is_err());
@@ -171,7 +171,7 @@ fn test_validate_wrong_type() {
 fn test_validate_invalid_enum() {
     let schema = parse_schema_content(TEST_SCHEMA_YAML, "test").unwrap();
     let json = r#"
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {
   "findings": [
     {
@@ -185,7 +185,7 @@ fn test_validate_invalid_enum() {
   "approved": true,
   "summary": "test"
 }
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
     let result = parse_structured_output(json, &schema);
     assert!(result.is_err());
@@ -197,14 +197,14 @@ fn test_lenient_parsing_code_fences() {
     let schema =
         parse_schema_content("fields:\n  name: string\n  count: number\n", "test").unwrap();
     let json = r#"
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 ```json
 {
   "name": "hello",
   "count": 42
 }
 ```
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
     let result = parse_structured_output(json, &schema);
     assert!(result.is_ok());
@@ -215,12 +215,12 @@ fn test_lenient_parsing_trailing_commas() {
     let schema =
         parse_schema_content("fields:\n  name: string\n  count: number\n", "test").unwrap();
     let json = r#"
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {
   "name": "hello",
   "count": 42,
 }
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
     let result = parse_structured_output(json, &schema);
     assert!(result.is_ok());
@@ -279,8 +279,8 @@ fn test_prompt_generation() {
     let schema =
         parse_schema_content("fields:\n  approved: boolean\n  summary: string\n", "test").unwrap();
     let prompt = generate_prompt_instructions(&schema);
-    assert!(prompt.contains("<<<CONDUCTOR_OUTPUT>>>"));
-    assert!(prompt.contains("<<<END_CONDUCTOR_OUTPUT>>>"));
+    assert!(prompt.contains("<<<FLOW_OUTPUT>>>"));
+    assert!(prompt.contains("<<<END_FLOW_OUTPUT>>>"));
     assert!(prompt.contains("\"approved\""));
     assert!(prompt.contains("\"summary\""));
 }
@@ -541,23 +541,23 @@ fn test_schema_ref_backslash_treated_as_path() {
 #[test]
 fn test_parse_structured_output_no_block() {
     let schema = parse_schema_content("fields:\n  name: string\n", "test").unwrap();
-    let result = parse_structured_output("This output has no CONDUCTOR_OUTPUT block", &schema);
+    let result = parse_structured_output("This output has no FLOW_OUTPUT block", &schema);
     assert!(result.is_err());
     assert!(result
         .unwrap_err()
         .to_string()
-        .contains("No <<<CONDUCTOR_OUTPUT>>>"));
+        .contains("No <<<FLOW_OUTPUT>>>"));
 }
 
 #[test]
 fn test_parse_structured_output_missing_end_marker() {
     let schema = parse_schema_content("fields:\n  name: string\n", "test").unwrap();
     let result = parse_structured_output(
-        "<<<CONDUCTOR_OUTPUT>>>\n{\"name\": \"hello\"}\nno end marker here",
+        "<<<FLOW_OUTPUT>>>\n{\"name\": \"hello\"}\nno end marker here",
         &schema,
     );
     assert!(result.is_err());
-    assert!(result.unwrap_err().to_string().contains("CONDUCTOR_OUTPUT"));
+    assert!(result.unwrap_err().to_string().contains("FLOW_OUTPUT"));
 }
 
 #[test]
@@ -766,15 +766,15 @@ fn test_parse_structured_output_skips_code_examples() {
 
     let text = r#"Here is how to emit output:
 ```bash
-echo '<<<CONDUCTOR_OUTPUT>>>'
+echo '<<<FLOW_OUTPUT>>>'
 echo '{"summary": "fake"}'
-echo '<<<END_CONDUCTOR_OUTPUT>>>'
+echo '<<<END_FLOW_OUTPUT>>>'
 ```
 
 Actual output:
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"summary": "real result"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
     let result = parse_structured_output(text, &schema).unwrap();
     assert_eq!(result.context, "real result");
@@ -787,19 +787,19 @@ fn test_parse_structured_output_multiple_complete_blocks() {
     let schema = parse_schema_content(schema_yaml, "test").unwrap();
 
     let text = r#"Example 1:
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"summary": "first example"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 
 Example 2:
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"summary": "second example"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 
 Real output:
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"summary": "the actual result"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
     let result = parse_structured_output(text, &schema).unwrap();
     assert_eq!(result.context, "the actual result");
@@ -812,11 +812,11 @@ fn test_parse_structured_output_code_fenced() {
     let schema = parse_schema_content(schema_yaml, "test").unwrap();
 
     let text = r#"Here is my output:
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 ```json
 {"summary": "fenced result"}
 ```
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
     let result = parse_structured_output(text, &schema).unwrap();
     assert_eq!(result.context, "fenced result");
@@ -894,7 +894,7 @@ fn test_parse_scalar_array_enum() {
 fn test_validate_scalar_array() {
     let yaml = "fields:\n  tags:\n    type: array\n    items: string\n";
     let schema = parse_schema_content(yaml, "test").unwrap();
-    let json = "<<<CONDUCTOR_OUTPUT>>>\n{\"tags\": [\"a\", \"b\"]}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let json = "<<<FLOW_OUTPUT>>>\n{\"tags\": [\"a\", \"b\"]}\n<<<END_FLOW_OUTPUT>>>";
     let result = parse_structured_output(json, &schema);
     assert!(result.is_ok());
 }
@@ -903,7 +903,7 @@ fn test_validate_scalar_array() {
 fn test_validate_scalar_array_rejects_wrong_type() {
     let yaml = "fields:\n  tags:\n    type: array\n    items: string\n";
     let schema = parse_schema_content(yaml, "test").unwrap();
-    let json = "<<<CONDUCTOR_OUTPUT>>>\n{\"tags\": [1, 2]}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let json = "<<<FLOW_OUTPUT>>>\n{\"tags\": [1, 2]}\n<<<END_FLOW_OUTPUT>>>";
     let result = parse_structured_output(json, &schema);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("expected string"));
@@ -921,7 +921,7 @@ fn test_prompt_scalar_array() {
 fn test_validate_enum_scalar_array_valid() {
     let yaml = "fields:\n  status:\n    type: array\n    items: \"enum(a,b)\"\n";
     let schema = parse_schema_content(yaml, "test").unwrap();
-    let json = "<<<CONDUCTOR_OUTPUT>>>\n{\"status\": [\"a\"]}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let json = "<<<FLOW_OUTPUT>>>\n{\"status\": [\"a\"]}\n<<<END_FLOW_OUTPUT>>>";
     let result = parse_structured_output(json, &schema);
     assert!(result.is_ok());
 }
@@ -930,7 +930,7 @@ fn test_validate_enum_scalar_array_valid() {
 fn test_validate_enum_scalar_array_rejects_invalid_value() {
     let yaml = "fields:\n  status:\n    type: array\n    items: \"enum(a,b)\"\n";
     let schema = parse_schema_content(yaml, "test").unwrap();
-    let json = "<<<CONDUCTOR_OUTPUT>>>\n{\"status\": [\"c\"]}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let json = "<<<FLOW_OUTPUT>>>\n{\"status\": [\"c\"]}\n<<<END_FLOW_OUTPUT>>>";
     let result = parse_structured_output(json, &schema);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("is not one of"));
@@ -940,7 +940,7 @@ fn test_validate_enum_scalar_array_rejects_invalid_value() {
 fn test_validate_enum_scalar_array_rejects_wrong_type() {
     let yaml = "fields:\n  status:\n    type: array\n    items: \"enum(a,b)\"\n";
     let schema = parse_schema_content(yaml, "test").unwrap();
-    let json = "<<<CONDUCTOR_OUTPUT>>>\n{\"status\": [123]}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let json = "<<<FLOW_OUTPUT>>>\n{\"status\": [123]}\n<<<END_FLOW_OUTPUT>>>";
     let result = parse_structured_output(json, &schema);
     assert!(result.is_err());
     assert!(result
@@ -1007,10 +1007,10 @@ fn test_validate_scalar_array_number() {
     let yaml = "fields:\n  scores:\n    type: array\n    items: number\n";
     let schema = parse_schema_content(yaml, "test").unwrap();
 
-    let ok = "<<<CONDUCTOR_OUTPUT>>>\n{\"scores\": [1, 2.5, 3]}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let ok = "<<<FLOW_OUTPUT>>>\n{\"scores\": [1, 2.5, 3]}\n<<<END_FLOW_OUTPUT>>>";
     assert!(parse_structured_output(ok, &schema).is_ok());
 
-    let bad = "<<<CONDUCTOR_OUTPUT>>>\n{\"scores\": [\"nope\"]}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let bad = "<<<FLOW_OUTPUT>>>\n{\"scores\": [\"nope\"]}\n<<<END_FLOW_OUTPUT>>>";
     let err = parse_structured_output(bad, &schema)
         .unwrap_err()
         .to_string();
@@ -1022,10 +1022,10 @@ fn test_validate_scalar_array_boolean() {
     let yaml = "fields:\n  flags:\n    type: array\n    items: boolean\n";
     let schema = parse_schema_content(yaml, "test").unwrap();
 
-    let ok = "<<<CONDUCTOR_OUTPUT>>>\n{\"flags\": [true, false]}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let ok = "<<<FLOW_OUTPUT>>>\n{\"flags\": [true, false]}\n<<<END_FLOW_OUTPUT>>>";
     assert!(parse_structured_output(ok, &schema).is_ok());
 
-    let bad = "<<<CONDUCTOR_OUTPUT>>>\n{\"flags\": [\"yes\"]}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let bad = "<<<FLOW_OUTPUT>>>\n{\"flags\": [\"yes\"]}\n<<<END_FLOW_OUTPUT>>>";
     let err = parse_structured_output(bad, &schema)
         .unwrap_err()
         .to_string();
@@ -1108,15 +1108,15 @@ fields:
 "#;
     let schema = parse_schema_content(schema_yaml, "test").unwrap();
 
-    // The description field value contains <<<CONDUCTOR_OUTPUT>>> — rfind would
+    // The description field value contains <<<FLOW_OUTPUT>>> — rfind would
     // have selected that inner occurrence as the block start, causing a parse failure.
     let text = r#"Some preamble text.
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {
   "summary": "all good",
-  "description": "output block looks like <<<CONDUCTOR_OUTPUT>>> but is inside JSON"
+  "description": "output block looks like <<<FLOW_OUTPUT>>> but is inside JSON"
 }
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
     let result = parse_structured_output(text, &schema).unwrap();
     assert_eq!(result.context, "all good");
@@ -1249,9 +1249,9 @@ fn test_parse_structured_output_swift_keypath() {
     let schema_yaml = "fields:\n  summary:\n    type: string\n";
     let schema = parse_schema_content(schema_yaml, "test").unwrap();
     let text = r#"Done.
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"summary": "Add @Environment(\.openURL) button to the toolbar"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
     let result = parse_structured_output(text, &schema);
     assert!(

--- a/conductor-core/src/schema_config/validation.rs
+++ b/conductor-core/src/schema_config/validation.rs
@@ -20,7 +20,7 @@ pub struct StructuredOutput {
     pub json_string: String,
 }
 
-/// Find the start position of the real `<<<CONDUCTOR_OUTPUT>>>` block.
+/// Find the start position of the real `<<<FLOW_OUTPUT>>>` block.
 ///
 /// Returns the position of the last occurrence of `marker` where the immediately
 /// following content (after trimming whitespace) starts with `{`, `[`, or a markdown
@@ -28,7 +28,7 @@ pub struct StructuredOutput {
 /// - Occurrences inside sentences or code examples are not followed by JSON
 /// - Occurrences inside a JSON field value appear mid-string, not at a JSON boundary
 /// - The real block start is always immediately followed by JSON or a code-fenced JSON block
-pub fn find_conductor_output_start(text: &str, marker: &str) -> Option<usize> {
+pub fn find_flow_output_start(text: &str, marker: &str) -> Option<usize> {
     let mut last_valid = None;
     let mut search_pos = 0;
     while let Some(rel) = text[search_pos..].find(marker) {
@@ -42,7 +42,7 @@ pub fn find_conductor_output_start(text: &str, marker: &str) -> Option<usize> {
     last_valid
 }
 
-/// Extract and clean the raw JSON string from a `<<<CONDUCTOR_OUTPUT>>>` block.
+/// Extract and clean the raw JSON string from a `<<<FLOW_OUTPUT>>>` block.
 ///
 /// Finds the last valid start marker occurrence, slices to the end marker,
 /// trims whitespace, and strips markdown code fences. Returns `None` if no
@@ -51,10 +51,10 @@ pub fn find_conductor_output_start(text: &str, marker: &str) -> Option<usize> {
 /// Trailing-comma stripping is intentionally omitted here — callers that need
 /// it (e.g. `parse_structured_output`) apply it themselves.
 pub fn extract_output_block(text: &str) -> Option<String> {
-    let start_marker = "<<<CONDUCTOR_OUTPUT>>>";
-    let end_marker = "<<<END_CONDUCTOR_OUTPUT>>>";
+    let start_marker = "<<<FLOW_OUTPUT>>>";
+    let end_marker = "<<<END_FLOW_OUTPUT>>>";
 
-    let start = find_conductor_output_start(text, start_marker)?;
+    let start = find_flow_output_start(text, start_marker)?;
     let json_start = start + start_marker.len();
     let end = text[json_start..].find(end_marker)?;
     let raw = text[json_start..json_start + end].trim();
@@ -62,11 +62,11 @@ pub fn extract_output_block(text: &str) -> Option<String> {
     Some(strip_code_fences(raw))
 }
 
-/// Parse the `<<<CONDUCTOR_OUTPUT>>>` block as structured JSON, validate against
+/// Parse the `<<<FLOW_OUTPUT>>>` block as structured JSON, validate against
 /// the schema, and derive markers.
 pub fn parse_structured_output(text: &str, schema: &OutputSchema) -> Result<StructuredOutput> {
     let cleaned = extract_output_block(text).ok_or_else(|| {
-        ConductorError::Schema("No <<<CONDUCTOR_OUTPUT>>> block found in agent output".to_string())
+        ConductorError::Schema("No <<<FLOW_OUTPUT>>> block found in agent output".to_string())
     })?;
 
     // Strip trailing commas (common LLM artifact)
@@ -75,7 +75,7 @@ pub fn parse_structured_output(text: &str, schema: &OutputSchema) -> Result<Stru
     let cleaned = fix_backslash_escapes(&cleaned);
 
     let value: serde_json::Value = serde_json::from_str(&cleaned)
-        .map_err(|e| ConductorError::Schema(format!("Invalid JSON in CONDUCTOR_OUTPUT: {e}")))?;
+        .map_err(|e| ConductorError::Schema(format!("Invalid JSON in FLOW_OUTPUT: {e}")))?;
 
     // Validate against schema
     validate_value(&value, &schema.fields)?;
@@ -133,7 +133,7 @@ fn derive_context(value: &serde_json::Value, schema: &OutputSchema) -> String {
 ///
 /// This is used by the direct API execution path (see `api_call.rs`) where the
 /// Anthropic API has already enforced schema conformance via `tool_use`. There is
-/// no `<<<CONDUCTOR_OUTPUT>>>` block to extract and no JSON validation step needed —
+/// no `<<<FLOW_OUTPUT>>>` block to extract and no JSON validation step needed —
 /// the value is already a clean, schema-conformant JSON object.
 pub fn derive_output_from_value(
     value: serde_json::Value,
@@ -178,9 +178,9 @@ pub fn strip_code_fences(s: &str) -> String {
 // ---------------------------------------------------------------------------
 
 fn validate_value(value: &serde_json::Value, fields: &[FieldDef]) -> Result<()> {
-    let obj = value.as_object().ok_or_else(|| {
-        ConductorError::Schema("CONDUCTOR_OUTPUT must be a JSON object".to_string())
-    })?;
+    let obj = value
+        .as_object()
+        .ok_or_else(|| ConductorError::Schema("FLOW_OUTPUT must be a JSON object".to_string()))?;
 
     for field in fields {
         match obj.get(&field.name) {

--- a/conductor-core/src/workflow/mod.rs
+++ b/conductor-core/src/workflow/mod.rs
@@ -39,7 +39,7 @@ pub use constants::{
     REGRESSION_FAILURE_RATE_THRESHOLD_PP, REGRESSION_MIN_RECENT_RUNS, STEP_ROLE_FOREACH,
     STEP_ROLE_WORKFLOW,
 };
-pub use runkon_flow::constants::CONDUCTOR_OUTPUT_INSTRUCTION;
+pub use runkon_flow::constants::FLOW_OUTPUT_INSTRUCTION;
 /// Returns the list of variable keys that the workflow engine injects automatically
 /// from run context (ticket and repo metadata, plus `workflow_run_id`).
 ///
@@ -56,7 +56,7 @@ pub use coordinator::{
 pub use estimation::{Confidence, Estimate, LiveEstimate, StepEstimates};
 pub use manager::recovery::{ReapedStaleRun, StaleWorkflowRun};
 pub use manager::{InvalidWorkflowEntry, StepMetrics, WorkflowManager};
-pub use output::{parse_conductor_output, ConductorOutput};
+pub use output::{parse_flow_output, FlowOutput};
 pub use runkon_flow::traits::persistence::{
     FanOutItemStatus, FanOutItemUpdate, GateApprovalState, NewRun, NewStep, StepUpdate,
     WorkflowPersistence,

--- a/conductor-core/src/workflow/mod.rs
+++ b/conductor-core/src/workflow/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod api_call_executor;
 mod batch_validate;
 pub mod channel_event_sink;
 pub use channel_event_sink::ChannelEventSink;
+pub use runkon_flow::events::EventSink;
 pub(crate) mod claude_agent_executor;
 pub(crate) mod constants;
 pub(crate) mod coordinator;

--- a/conductor-core/src/workflow/output.rs
+++ b/conductor-core/src/workflow/output.rs
@@ -1,8 +1,8 @@
-pub use runkon_flow::helpers::{parse_conductor_output, ConductorOutput};
+pub use runkon_flow::helpers::{parse_flow_output, FlowOutput};
 
 use crate::schema_config::OutputSchema;
 
-/// Interpret agent output using a schema (if present) or generic `CONDUCTOR_OUTPUT` parsing.
+/// Interpret agent output using a schema (if present) or generic `FLOW_OUTPUT` parsing.
 ///
 /// Returns `(markers, context, structured_json)`. The `succeeded` flag controls whether
 /// a schema validation failure is treated as an error (`Err`) or silently falls back.
@@ -24,16 +24,12 @@ pub(super) fn interpret_agent_output(
             }
             _ => {
                 // No output block found or parsing error on a failed run — fall back
-                let fallback = result_text
-                    .and_then(parse_conductor_output)
-                    .unwrap_or_default();
+                let fallback = result_text.and_then(parse_flow_output).unwrap_or_default();
                 Ok((fallback.markers, fallback.context, None))
             }
         }
     } else {
-        let output = result_text
-            .and_then(parse_conductor_output)
-            .unwrap_or_default();
+        let output = result_text.and_then(parse_flow_output).unwrap_or_default();
         Ok((output.markers, output.context, None))
     }
 }

--- a/conductor-core/src/workflow/prompt_builder.rs
+++ b/conductor-core/src/workflow/prompt_builder.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::schema_config;
 
-use super::CONDUCTOR_OUTPUT_INSTRUCTION;
+use super::FLOW_OUTPUT_INSTRUCTION;
 
 fn substitute_variables_impl(
     template: &str,
@@ -115,7 +115,7 @@ fn build_prompt_core(
             prompt.push_str(&schema_config::generate_prompt_instructions(s));
         }
         None => {
-            prompt.push_str(CONDUCTOR_OUTPUT_INSTRUCTION);
+            prompt.push_str(FLOW_OUTPUT_INSTRUCTION);
         }
     }
     prompt

--- a/conductor-core/src/workflow/tests/mod.rs
+++ b/conductor-core/src/workflow/tests/mod.rs
@@ -17,7 +17,7 @@ pub(super) fn completed_keys_from_steps(
         .collect()
 }
 pub(super) use super::manager::WorkflowManager;
-pub(super) use super::output::{interpret_agent_output, parse_conductor_output};
+pub(super) use super::output::{interpret_agent_output, parse_flow_output};
 pub(super) use super::prompt_builder::substitute_variables;
 pub(super) use super::types::{MetadataEntry, StepKey, WorkflowResumeInput};
 pub(super) use super::*;

--- a/conductor-core/src/workflow/tests/output.rs
+++ b/conductor-core/src/workflow/tests/output.rs
@@ -3,14 +3,14 @@
 use super::*;
 
 #[test]
-fn test_parse_conductor_output() {
+fn test_parse_flow_output() {
     let text = r#"Here is my analysis...
 
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["has_review_issues", "has_critical_issues"], "context": "Found 2 issues in src/lib.rs"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
-    let output = parse_conductor_output(text).unwrap();
+    let output = parse_flow_output(text).unwrap();
     assert_eq!(
         output.markers,
         vec!["has_review_issues", "has_critical_issues"]
@@ -19,31 +19,32 @@ fn test_parse_conductor_output() {
 }
 
 #[test]
-fn test_parse_conductor_output_missing() {
-    assert!(parse_conductor_output("no output block here").is_none());
+fn test_parse_flow_output_missing() {
+    assert!(parse_flow_output("no output block here").is_none());
 }
 
 #[test]
-fn test_parse_conductor_output_no_markers() {
-    let text = "<<<CONDUCTOR_OUTPUT>>>\n{\"markers\": [], \"context\": \"All good\"}\n<<<END_CONDUCTOR_OUTPUT>>>";
-    let output = parse_conductor_output(text).unwrap();
+fn test_parse_flow_output_no_markers() {
+    let text =
+        "<<<FLOW_OUTPUT>>>\n{\"markers\": [], \"context\": \"All good\"}\n<<<END_FLOW_OUTPUT>>>";
+    let output = parse_flow_output(text).unwrap();
     assert!(output.markers.is_empty());
     assert_eq!(output.context, "All good");
 }
 
 #[test]
-fn test_parse_conductor_output_marker_in_field_value() {
+fn test_parse_flow_output_marker_in_field_value() {
     // The real block has the marker string inside a field value — must still parse correctly.
     let text = r#"The agent output block:
-<<<CONDUCTOR_OUTPUT>>>
-{"markers": ["real"], "context": "actual output with <<<CONDUCTOR_OUTPUT>>> mentioned inside"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
+{"markers": ["real"], "context": "actual output with <<<FLOW_OUTPUT>>> mentioned inside"}
+<<<END_FLOW_OUTPUT>>>
 "#;
-    let output = parse_conductor_output(text).unwrap();
+    let output = parse_flow_output(text).unwrap();
     assert_eq!(output.markers, vec!["real"]);
     assert_eq!(
         output.context,
-        "actual output with <<<CONDUCTOR_OUTPUT>>> mentioned inside"
+        "actual output with <<<FLOW_OUTPUT>>> mentioned inside"
     );
 }
 
@@ -97,7 +98,8 @@ fn test_workflow_step_status_roundtrip() {
 #[test]
 fn test_interpret_agent_output_schema_valid() {
     let schema = make_test_schema();
-    let text = "<<<CONDUCTOR_OUTPUT>>>\n{\"approved\": true, \"summary\": \"all good\"}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let text =
+        "<<<FLOW_OUTPUT>>>\n{\"approved\": true, \"summary\": \"all good\"}\n<<<END_FLOW_OUTPUT>>>";
     let (markers, context, json) = interpret_agent_output(Some(text), Some(&schema), true).unwrap();
     assert_eq!(context, "all good");
     assert!(json.is_some());
@@ -109,7 +111,7 @@ fn test_interpret_agent_output_schema_valid() {
 fn test_interpret_agent_output_schema_validation_fails_succeeded() {
     let schema = make_test_schema();
     // Missing required field "approved"
-    let text = "<<<CONDUCTOR_OUTPUT>>>\n{\"summary\": \"oops\"}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let text = "<<<FLOW_OUTPUT>>>\n{\"summary\": \"oops\"}\n<<<END_FLOW_OUTPUT>>>";
     let result = interpret_agent_output(Some(text), Some(&schema), true);
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("structured output validation"));
@@ -119,10 +121,10 @@ fn test_interpret_agent_output_schema_validation_fails_succeeded() {
 fn test_interpret_agent_output_schema_validation_fails_not_succeeded_falls_back() {
     let schema = make_test_schema();
     // Missing required field — but succeeded=false so it falls back
-    let text = "<<<CONDUCTOR_OUTPUT>>>\n{\"summary\": \"oops\"}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let text = "<<<FLOW_OUTPUT>>>\n{\"summary\": \"oops\"}\n<<<END_FLOW_OUTPUT>>>";
     let (markers, context, json) =
         interpret_agent_output(Some(text), Some(&schema), false).unwrap();
-    // Falls back to generic parse_conductor_output which doesn't find markers/context
+    // Falls back to generic parse_flow_output which doesn't find markers/context
     assert!(json.is_none());
     assert!(markers.is_empty());
     assert!(context.is_empty());
@@ -130,7 +132,7 @@ fn test_interpret_agent_output_schema_validation_fails_not_succeeded_falls_back(
 
 #[test]
 fn test_interpret_agent_output_no_schema_generic_parsing() {
-    let text = "<<<CONDUCTOR_OUTPUT>>>\n{\"markers\": [\"done\"], \"context\": \"finished\"}\n<<<END_CONDUCTOR_OUTPUT>>>";
+    let text = "<<<FLOW_OUTPUT>>>\n{\"markers\": [\"done\"], \"context\": \"finished\"}\n<<<END_FLOW_OUTPUT>>>";
     let (markers, context, json) = interpret_agent_output(Some(text), None, true).unwrap();
     assert_eq!(markers, vec!["done"]);
     assert_eq!(context, "finished");
@@ -151,18 +153,18 @@ fn test_interpret_agent_output_no_text() {
 // Regression tests for invalid backslash escape handling
 // ---------------------------------------------------------------------------
 
-/// `parse_conductor_output` must succeed when a field value contains `\.`
+/// `parse_flow_output` must succeed when a field value contains `\.`
 /// (Swift key-path syntax), which is not a valid JSON escape sequence.
 #[test]
-fn test_parse_conductor_output_backslash_in_context() {
-    let text = r#"<<<CONDUCTOR_OUTPUT>>>
+fn test_parse_flow_output_backslash_in_context() {
+    let text = r#"<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Added @Environment(\.openURL) to toolbar"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
-    let output = parse_conductor_output(text);
+    let output = parse_flow_output(text);
     assert!(
         output.is_some(),
-        "parse_conductor_output must succeed with bare backslash in context"
+        "parse_flow_output must succeed with bare backslash in context"
     );
     let output = output.unwrap();
     assert!(
@@ -178,7 +180,7 @@ fn test_interpret_agent_output_backslash_succeeded_true() {
     let schema = make_test_schema();
     // `\.` in the summary field — invalid JSON escape that the sanitizer must fix.
     let text =
-        "<<<CONDUCTOR_OUTPUT>>>\n{\"approved\": true, \"summary\": \"Use @Environment(\\.openURL)\"}\n<<<END_CONDUCTOR_OUTPUT>>>";
+        "<<<FLOW_OUTPUT>>>\n{\"approved\": true, \"summary\": \"Use @Environment(\\.openURL)\"}\n<<<END_FLOW_OUTPUT>>>";
     let result = interpret_agent_output(Some(text), Some(&schema), true);
     assert!(
         result.is_ok(),

--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -39,7 +39,7 @@ This inverts VISION's human-first premise explicitly. Downstream consequences:
 
 - `CLAUDE.md`'s worktree workflow block is CLI-centric and reflects the human-first era — agents increasingly drive worktree creation via MCP.
 - TUI-centric features like the Features tab are candidates for folding into general Workflows views.
-- Small MCP improvements (typed `data` in `CONDUCTOR_OUTPUT`, `CONDUCTOR_RUN_ID` scoping, a `conductor://worktree/context` resource) are higher leverage than equivalent TUI work.
+- Small MCP improvements (typed `data` in `FLOW_OUTPUT`, `CONDUCTOR_RUN_ID` scoping, a `conductor://worktree/context` resource) are higher leverage than equivalent TUI work.
 
 ### 4. Library-first until measured
 

--- a/docs/runkon-flow-platform-spec.md
+++ b/docs/runkon-flow-platform-spec.md
@@ -123,7 +123,7 @@ pub struct ActionOutput {
 ```
 
 **Conductor's implementation:** `ClaudeAgentExecutor` — resolves the agent `.md` file,
-builds the prompt, spawns a headless subprocess (PID-based), polls for `CONDUCTOR_OUTPUT`,
+builds the prompt, spawns a headless subprocess (PID-based), polls for `FLOW_OUTPUT`,
 and maps the result to `ActionOutput`.
 
 **Communication harness implementations:** `SendEmailExecutor`, `PostSlackExecutor`,
@@ -812,7 +812,7 @@ out of scope.
 
 ### `conductor-core` (conductor's harness layer)
 
-- `ClaudeAgentExecutor` — agent `.md` resolution, headless subprocess spawn, `CONDUCTOR_OUTPUT` parsing
+- `ClaudeAgentExecutor` — agent `.md` resolution, headless subprocess spawn, `FLOW_OUTPUT` parsing
 - `TicketsProvider`, `ReposProvider`, `WorkflowRunsProvider`, `WorktreesProvider`
 - `PrApprovalGateResolver`, `PrChecksGateResolver`, `HumanApprovalGateResolver`
 - `WorktreeRunContext` — resolves conductor-specific injected variables
@@ -924,7 +924,7 @@ breakage. Existing behavior is preserved end-to-end; every step should keep the
   `agent_runtime/`, so `ClaudeAgentExecutor` is a thin wrapper around the
   existing `try_spawn_headless_run` entry point plus the direct-API path.
 - Keep `ActionOutput` shape aligned with what `output.rs` already parses from
-  `CONDUCTOR_OUTPUT` blocks (markers + context + metadata) — don't redesign
+  `FLOW_OUTPUT` blocks (markers + context + metadata) — don't redesign
   during extraction.
 - Prerequisite: decide sync vs. async (Open Q #2) before starting this step.
 

--- a/docs/workflow/engine.md
+++ b/docs/workflow/engine.md
@@ -200,7 +200,7 @@ while review.has_review_issues {
 
 A condition is either `<step>.<marker>` or a bare identifier naming a boolean
 input. For `if` with a `step.marker` condition, the engine checks whether the
-named step's most recent `CONDUCTOR_OUTPUT` includes that marker string in its
+named step's most recent `FLOW_OUTPUT` includes that marker string in its
 `markers` array. For a boolean input condition, the body executes when the
 input value is `"true"`. `unless` is the inverse — the body executes when the
 condition is **absent** or **false**.
@@ -676,12 +676,12 @@ for the full rules, including `on_fail` and `parallel` usage.
 ## Structured output
 
 Every agent prompt is automatically appended with instructions to emit a
-`CONDUCTOR_OUTPUT` block:
+`FLOW_OUTPUT` block:
 
 ```
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["has_review_issues"], "context": "Found 3 issues in auth module"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 ```
 
 The engine finds the **last** occurrence of the delimiters and parses the JSON
@@ -813,7 +813,7 @@ by the parent.
 
 ### Output
 
-The sub-workflow's final step's `CONDUCTOR_OUTPUT` (markers + context) becomes
+The sub-workflow's final step's `FLOW_OUTPUT` (markers + context) becomes
 the output of the `call workflow` step in the parent. This means:
 
 - Downstream `if`/`while` conditions in the parent can reference markers from
@@ -965,7 +965,7 @@ For each agent invocation:
 
 1. Agent `.md` body (with `{{variable}}` substitution)
 2. `with` snippets (each snippet also goes through variable substitution)
-3. Schema output instructions / `CONDUCTOR_OUTPUT` block
+3. Schema output instructions / `FLOW_OUTPUT` block
 
 Snippets are separated from the main prompt and from each other with a blank
 line (`\n\n`).
@@ -1357,7 +1357,7 @@ both fields around its body before returning.
 |---|---|---|
 | `iteration` | INTEGER | Loop iteration counter (default 0) |
 | `parallel_group_id` | TEXT | Groups concurrent steps |
-| `context_out` | TEXT | `CONDUCTOR_OUTPUT` context field |
+| `context_out` | TEXT | `FLOW_OUTPUT` context field |
 | `markers_out` | TEXT | JSON array of emitted markers |
 | `retry_count` | INTEGER | Number of retries attempted |
 | `gate_type` | TEXT | Gate variant |

--- a/docs/workflow/prompt-snippets.md
+++ b/docs/workflow/prompt-snippets.md
@@ -67,7 +67,7 @@ When the engine builds an agent's final prompt, it assembles:
 
 1. Agent `.md` body (with `{{variable}}` substitution)
 2. `with` snippets, each trimmed and joined with `\n\n` (also variable-substituted)
-3. Schema output instructions / `CONDUCTOR_OUTPUT` block
+3. Schema output instructions / `FLOW_OUTPUT` block
 
 Snippets go through the same `{{variable}}` substitution as the agent body,
 so they can reference workflow inputs and prior context:

--- a/docs/workflow/structured-agent-output.md
+++ b/docs/workflow/structured-agent-output.md
@@ -1,7 +1,7 @@
 # Structured Agent Output
 
 This document describes an optional structured output system for workflow
-agents. It builds on the existing `CONDUCTOR_OUTPUT` mechanism by allowing
+agents. It builds on the existing `FLOW_OUTPUT` mechanism by allowing
 workflows to define output schemas that the engine injects into agent prompts,
 then parses, validates, and acts on programmatically.
 
@@ -9,7 +9,7 @@ then parses, validates, and acts on programmatically.
 
 ## Motivation
 
-The current `CONDUCTOR_OUTPUT` block serves two purposes:
+The current `FLOW_OUTPUT` block serves two purposes:
 
 1. **Control flow** — markers drive `if`/`while` conditions
 2. **Context threading** — a free-text summary passed to the next step
@@ -119,7 +119,7 @@ parallel {
 }
 ```
 
-When no `output` is specified, the default `CONDUCTOR_OUTPUT` markers + context
+When no `output` is specified, the default `FLOW_OUTPUT` markers + context
 behavior applies. No breaking change.
 
 ### Schema resolution
@@ -148,7 +148,7 @@ call review-security { output = "./custom/schemas/my-review.yaml" }
 
 When a `call` has an `output` schema, the engine generates JSON output
 instructions from the schema and appends them to the agent's prompt (replacing
-the generic `CONDUCTOR_OUTPUT` instructions).
+the generic `FLOW_OUTPUT` instructions).
 
 For the `review-findings` schema, the appended instructions would be:
 
@@ -157,7 +157,7 @@ When you have finished your work, output the following block exactly as the
 last thing in your response. Do not include this block in code examples or
 anywhere else — only as the final output.
 
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {
   "findings": [
     {
@@ -172,14 +172,14 @@ anywhere else — only as the final output.
   "approved": true,
   "summary": "one or two sentence summary of your review"
 }
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 
 The "findings" array should contain one entry per issue found. If there are
 no issues, return an empty array and set "approved" to true.
 "suggestion" is optional and may be omitted.
 ```
 
-The delimiters remain `<<<CONDUCTOR_OUTPUT>>>` / `<<<END_CONDUCTOR_OUTPUT>>>`
+The delimiters remain `<<<FLOW_OUTPUT>>>` / `<<<END_FLOW_OUTPUT>>>`
 for consistency. The only change is the shape of the JSON between them.
 
 ---
@@ -465,7 +465,7 @@ points:
    the schema definition
 2. **Prompt building** (`build_agent_prompt`) — if the call has an `output`
    schema, generate schema-specific output instructions instead of the generic
-   `CONDUCTOR_OUTPUT` instructions
+   `FLOW_OUTPUT` instructions
 3. **Output parsing** — parse the JSON between delimiters, validate against
    schema, extract derived markers and context
 4. **Step record** — store the full structured output in

--- a/runkon-flow/src/constants.rs
+++ b/runkon-flow/src/constants.rs
@@ -3,14 +3,14 @@ pub const STEP_ROLE_WORKFLOW: &str = "workflow";
 pub const STEP_ROLE_GATE: &str = "gate";
 pub const STEP_ROLE_AGENT: &str = "agent";
 
-pub const CONDUCTOR_OUTPUT_INSTRUCTION: &str = r#"
+pub const FLOW_OUTPUT_INSTRUCTION: &str = r#"
 When you have finished your work, output the following block exactly as the
 last thing in your response. Do not include this block in code examples or
 anywhere else — only as the final output.
 
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": ""}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 
 markers: array of string signals consumed by the workflow engine
          (e.g. ["has_review_issues", "has_critical_issues"])

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::cancellation::CancellationToken;
-use crate::constants::CONDUCTOR_OUTPUT_INSTRUCTION;
+use crate::constants::FLOW_OUTPUT_INSTRUCTION;
 use crate::dsl::{InputType, OnFail, WorkflowDef, WorkflowNode};
 use crate::engine_error::{EngineError, Result};
 use crate::events::{EngineEvent, EventSink};
@@ -885,9 +885,9 @@ pub fn build_variable_map(state: &ExecutionState) -> HashMap<&str, String> {
     crate::prompt_builder::build_variable_map(state)
 }
 
-/// Generate the CONDUCTOR_OUTPUT instruction (used when no schema is set).
-pub fn conductor_output_instruction() -> &'static str {
-    CONDUCTOR_OUTPUT_INSTRUCTION
+/// Generate the FLOW_OUTPUT instruction (used when no schema is set).
+pub fn flow_output_instruction() -> &'static str {
+    FLOW_OUTPUT_INSTRUCTION
 }
 
 #[cfg(test)]

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -347,7 +347,7 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
             duration_ms
         );
 
-        let (markers, context) = crate::helpers::parse_conductor_output(&stdout)
+        let (markers, context) = crate::helpers::parse_flow_output(&stdout)
             .map(|out| (out.markers, out.context))
             .unwrap_or_else(|| {
                 let ctx = stdout.chars().take(2000).collect();
@@ -509,17 +509,17 @@ mod tests {
         }
     }
 
-    /// When the script emits a valid CONDUCTOR_OUTPUT block, markers and context
+    /// When the script emits a valid FLOW_OUTPUT block, markers and context
     /// must be extracted and stored on the step record.
     #[test]
-    fn conductor_output_markers_propagate_to_step_record() {
+    fn flow_output_markers_propagate_to_step_record() {
         let (persistence, run_id) = make_persistence();
         let mut state = make_state(Arc::clone(&persistence), run_id.clone());
         // Use printf to avoid shell newline differences across platforms.
         let script = concat!(
-            "printf '<<<CONDUCTOR_OUTPUT>>>\\n",
+            "printf '<<<FLOW_OUTPUT>>>\\n",
             r#"{"markers":["test_passed"],"context":"step ctx"}"#,
-            "\\n<<<END_CONDUCTOR_OUTPUT>>>\\n'"
+            "\\n<<<END_FLOW_OUTPUT>>>\\n'"
         );
         let node = make_node("check", script);
         execute_script(&mut state, &node, 0).unwrap();
@@ -537,10 +537,10 @@ mod tests {
         assert_eq!(step.context_out.as_deref(), Some("step ctx"));
     }
 
-    /// When the script produces no CONDUCTOR_OUTPUT block, context falls back to
+    /// When the script produces no FLOW_OUTPUT block, context falls back to
     /// raw stdout truncated to 2000 characters.
     #[test]
-    fn falls_back_to_raw_stdout_when_no_conductor_output_block() {
+    fn falls_back_to_raw_stdout_when_no_flow_output_block() {
         let (persistence, run_id) = make_persistence();
         let mut state = make_state(Arc::clone(&persistence), run_id.clone());
         let node = make_node("info", "echo 'plain output'");

--- a/runkon-flow/src/helpers.rs
+++ b/runkon-flow/src/helpers.rs
@@ -6,23 +6,23 @@ use serde::{Deserialize, Serialize};
 use crate::engine::ExecutionState;
 
 // ---------------------------------------------------------------------------
-// Conductor output block parsing
+// Flow output block parsing
 // ---------------------------------------------------------------------------
 
-/// Parsed `<<<CONDUCTOR_OUTPUT>>>` block.
+/// Parsed `<<<FLOW_OUTPUT>>>` block.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ConductorOutput {
+pub struct FlowOutput {
     #[serde(default)]
     pub markers: Vec<String>,
     #[serde(default)]
     pub context: String,
 }
 
-/// Extract markers and context from a `<<<CONDUCTOR_OUTPUT>>> … <<<END_CONDUCTOR_OUTPUT>>>`
+/// Extract markers and context from a `<<<FLOW_OUTPUT>>> … <<<END_FLOW_OUTPUT>>>`
 /// block embedded in `text`. Returns `None` when no valid block is found.
-pub fn parse_conductor_output(text: &str) -> Option<ConductorOutput> {
-    const START: &str = "<<<CONDUCTOR_OUTPUT>>>";
-    const END: &str = "<<<END_CONDUCTOR_OUTPUT>>>";
+pub fn parse_flow_output(text: &str) -> Option<FlowOutput> {
+    const START: &str = "<<<FLOW_OUTPUT>>>";
+    const END: &str = "<<<END_FLOW_OUTPUT>>>";
 
     // Find the last START marker whose content starts with `{`, `[`, or a markdown
     // code fence (``` …) — guards against occurrences inside JSON string values or
@@ -54,11 +54,11 @@ pub fn parse_conductor_output(text: &str) -> Option<ConductorOutput> {
     let cleaned = strip_trailing_commas(raw);
     let cleaned = fix_backslash_escapes(&cleaned);
 
-    serde_json::from_str::<ConductorOutput>(&cleaned)
+    serde_json::from_str::<FlowOutput>(&cleaned)
         .map_err(|e| {
             let snippet: String = cleaned.chars().take(200).collect();
             tracing::warn!(
-                "parse_conductor_output: invalid JSON in CONDUCTOR_OUTPUT block: {e}\n  snippet: {snippet}"
+                "parse_flow_output: invalid JSON in FLOW_OUTPUT block: {e}\n  snippet: {snippet}"
             );
         })
         .ok()
@@ -307,19 +307,19 @@ pub fn find_max_completed_while_iteration(state: &ExecutionState, node: &WhileNo
 
 #[cfg(test)]
 mod parse_tests {
-    use super::parse_conductor_output;
+    use super::parse_flow_output;
 
     #[test]
     fn parses_well_formed_block_with_markers_and_context() {
         let text = concat!(
             "some preamble\n",
-            "<<<CONDUCTOR_OUTPUT>>>\n",
+            "<<<FLOW_OUTPUT>>>\n",
             r#"{"markers":["a","b"],"context":"hello world"}"#,
             "\n",
-            "<<<END_CONDUCTOR_OUTPUT>>>\n",
+            "<<<END_FLOW_OUTPUT>>>\n",
             "some suffix"
         );
-        let out = parse_conductor_output(text).unwrap();
+        let out = parse_flow_output(text).unwrap();
         assert_eq!(out.markers, vec!["a", "b"]);
         assert_eq!(out.context, "hello world");
     }
@@ -327,12 +327,12 @@ mod parse_tests {
     #[test]
     fn strips_trailing_commas_before_braces() {
         let text = concat!(
-            "<<<CONDUCTOR_OUTPUT>>>\n",
+            "<<<FLOW_OUTPUT>>>\n",
             r#"{"markers":["x",],"context":"ctx",}"#,
             "\n",
-            "<<<END_CONDUCTOR_OUTPUT>>>"
+            "<<<END_FLOW_OUTPUT>>>"
         );
-        let out = parse_conductor_output(text).unwrap();
+        let out = parse_flow_output(text).unwrap();
         assert_eq!(out.markers, vec!["x"]);
         assert_eq!(out.context, "ctx");
     }
@@ -342,12 +342,12 @@ mod parse_tests {
         // \p is not a valid JSON escape sequence; fix_backslash_escapes doubles it
         // so the JSON becomes parseable.
         let text = concat!(
-            "<<<CONDUCTOR_OUTPUT>>>\n",
+            "<<<FLOW_OUTPUT>>>\n",
             r#"{"markers":[],"context":"C:\path\to\file"}"#,
             "\n",
-            "<<<END_CONDUCTOR_OUTPUT>>>"
+            "<<<END_FLOW_OUTPUT>>>"
         );
-        let out = parse_conductor_output(text).unwrap();
+        let out = parse_flow_output(text).unwrap();
         // Successfully parsed despite the invalid backslash sequences.
         assert!(out.context.contains("path"));
     }
@@ -357,45 +357,45 @@ mod parse_tests {
         // \\ is a valid JSON escape for a literal backslash; fix_backslash_escapes
         // must not corrupt it into an unparseable sequence.
         let text = concat!(
-            "<<<CONDUCTOR_OUTPUT>>>\n",
+            "<<<FLOW_OUTPUT>>>\n",
             r#"{"markers":[],"context":"C:\\Users\\dev"}"#,
             "\n",
-            "<<<END_CONDUCTOR_OUTPUT>>>"
+            "<<<END_FLOW_OUTPUT>>>"
         );
-        let out = parse_conductor_output(text).unwrap();
+        let out = parse_flow_output(text).unwrap();
         assert_eq!(out.context, r"C:\Users\dev");
     }
 
     #[test]
     fn strips_markdown_code_fence() {
         let text = concat!(
-            "<<<CONDUCTOR_OUTPUT>>>\n",
+            "<<<FLOW_OUTPUT>>>\n",
             "```json\n",
             r#"{"markers":["fenced"],"context":"fenced context"}"#,
             "\n",
             "```\n",
-            "<<<END_CONDUCTOR_OUTPUT>>>"
+            "<<<END_FLOW_OUTPUT>>>"
         );
-        let out = parse_conductor_output(text).unwrap();
+        let out = parse_flow_output(text).unwrap();
         assert_eq!(out.markers, vec!["fenced"]);
         assert_eq!(out.context, "fenced context");
     }
 
     #[test]
     fn returns_none_when_no_block_present() {
-        assert!(parse_conductor_output("no conductor output block here").is_none());
-        assert!(parse_conductor_output("").is_none());
+        assert!(parse_flow_output("no flow output block here").is_none());
+        assert!(parse_flow_output("").is_none());
     }
 
     #[test]
     fn markers_field_missing_defaults_to_empty_vec() {
         let text = concat!(
-            "<<<CONDUCTOR_OUTPUT>>>\n",
+            "<<<FLOW_OUTPUT>>>\n",
             r#"{"context":"only context, no markers"}"#,
             "\n",
-            "<<<END_CONDUCTOR_OUTPUT>>>"
+            "<<<END_FLOW_OUTPUT>>>"
         );
-        let out = parse_conductor_output(text).unwrap();
+        let out = parse_flow_output(text).unwrap();
         assert!(out.markers.is_empty());
         assert_eq!(out.context, "only context, no markers");
     }
@@ -403,12 +403,12 @@ mod parse_tests {
     #[test]
     fn context_field_missing_defaults_to_empty_string() {
         let text = concat!(
-            "<<<CONDUCTOR_OUTPUT>>>\n",
+            "<<<FLOW_OUTPUT>>>\n",
             r#"{"markers":["m1"]}"#,
             "\n",
-            "<<<END_CONDUCTOR_OUTPUT>>>"
+            "<<<END_FLOW_OUTPUT>>>"
         );
-        let out = parse_conductor_output(text).unwrap();
+        let out = parse_flow_output(text).unwrap();
         assert_eq!(out.markers, vec!["m1"]);
         assert_eq!(out.context, "");
     }
@@ -416,33 +416,33 @@ mod parse_tests {
     #[test]
     fn marker_in_field_value_finds_real_block() {
         let text = r#"Some agent output.
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {
   "markers": ["done"],
-  "context": "saw <<<CONDUCTOR_OUTPUT>>> in the log and handled it"
+  "context": "saw <<<FLOW_OUTPUT>>> in the log and handled it"
 }
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
-        let out = parse_conductor_output(text).unwrap();
+        let out = parse_flow_output(text).unwrap();
         assert_eq!(out.markers, vec!["done"]);
-        assert!(out.context.contains("<<<CONDUCTOR_OUTPUT>>>"));
+        assert!(out.context.contains("<<<FLOW_OUTPUT>>>"));
     }
 
     #[test]
     fn skips_code_examples_finds_real_block() {
         let text = r#"Here is how to emit output:
 ```bash
-echo '<<<CONDUCTOR_OUTPUT>>>'
+echo '<<<FLOW_OUTPUT>>>'
 echo '{"markers": ["fake"], "context": "example"}'
-echo '<<<END_CONDUCTOR_OUTPUT>>>'
+echo '<<<END_FLOW_OUTPUT>>>'
 ```
 
 Actual output:
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["real"], "context": "this is the real result"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
-        let out = parse_conductor_output(text).unwrap();
+        let out = parse_flow_output(text).unwrap();
         assert_eq!(out.markers, vec!["real"]);
         assert_eq!(out.context, "this is the real result");
     }
@@ -450,21 +450,21 @@ Actual output:
     #[test]
     fn multiple_complete_blocks_returns_last() {
         let text = r#"Example 1:
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["example1"], "context": "first example"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 
 Example 2:
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["example2"], "context": "second example"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 
 Real output:
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["real"], "context": "the actual result"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 "#;
-        let out = parse_conductor_output(text).unwrap();
+        let out = parse_flow_output(text).unwrap();
         assert_eq!(out.markers, vec!["real"]);
         assert_eq!(out.context, "the actual result");
     }
@@ -472,11 +472,11 @@ Real output:
     #[test]
     fn malformed_json_returns_none() {
         let text = concat!(
-            "<<<CONDUCTOR_OUTPUT>>>\n",
+            "<<<FLOW_OUTPUT>>>\n",
             "{markers: [\"done\"]}\n",
-            "<<<END_CONDUCTOR_OUTPUT>>>\n"
+            "<<<END_FLOW_OUTPUT>>>\n"
         );
-        assert!(parse_conductor_output(text).is_none());
+        assert!(parse_flow_output(text).is_none());
     }
 
     #[test]
@@ -484,13 +484,13 @@ Real output:
         // Direct deserialization is stricter than the old manual extraction:
         // a "markers" field that is a string instead of an array must fail.
         let text = concat!(
-            "<<<CONDUCTOR_OUTPUT>>>\n",
+            "<<<FLOW_OUTPUT>>>\n",
             r#"{"markers":"not-an-array","context":"ok"}"#,
             "\n",
-            "<<<END_CONDUCTOR_OUTPUT>>>\n"
+            "<<<END_FLOW_OUTPUT>>>\n"
         );
         assert!(
-            parse_conductor_output(text).is_none(),
+            parse_flow_output(text).is_none(),
             "markers field with non-array type should cause parse failure"
         );
     }
@@ -499,13 +499,13 @@ Real output:
     fn context_field_with_wrong_type_returns_none() {
         // A "context" field that is a number instead of a string must fail.
         let text = concat!(
-            "<<<CONDUCTOR_OUTPUT>>>\n",
+            "<<<FLOW_OUTPUT>>>\n",
             r#"{"markers":["m1"],"context":42}"#,
             "\n",
-            "<<<END_CONDUCTOR_OUTPUT>>>\n"
+            "<<<END_FLOW_OUTPUT>>>\n"
         );
         assert!(
-            parse_conductor_output(text).is_none(),
+            parse_flow_output(text).is_none(),
             "context field with non-string type should cause parse failure"
         );
     }


### PR DESCRIPTION
First two PRs of the layer-violation cluster cleanup. Both close public-API surface area in `runkon-flow` that would otherwise need a semver-major break post-`0.1.0-alpha` publication.

## Wave 1A — re-export `EventSink` from `conductor_core::workflow` (#2611)

`WorkflowExecConfig::event_sinks` is typed `Vec<Arc<dyn runkon_flow::events::EventSink>>` and `ChannelEventSink` is already re-exported from `conductor_core::workflow`, but `EventSink` was not — so binary callers coercing `Arc<ChannelEventSink>` to `Arc<dyn EventSink>` had to add `runkon-flow` as a direct Cargo dep just to name the trait. One-line re-export closes the boundary.

Out of scope on the same issue: **#2628** (`SqliteWorkflowPersistence` should be `pub(crate)`) was already addressed silently by Phase 4 step 4.3 (PR #2719) — verified `pub(crate) mod persistence_sqlite` with no public re-export and no binary references.

## Wave 1B — rename `CONDUCTOR_OUTPUT` → `FLOW_OUTPUT` (#2643, #2587)

`runkon-flow` advertises a "portable workflow execution engine" but the agent-output protocol was conductor-branded throughout. A second harness built on `runkon-flow` would prompt its agents to emit `<<<CONDUCTOR_OUTPUT>>>` blocks — confusing, and breaks the portability guarantee.

Workspace-wide rename:

| Old | New |
|---|---|
| `<<<CONDUCTOR_OUTPUT>>>` | `<<<FLOW_OUTPUT>>>` |
| `<<<END_CONDUCTOR_OUTPUT>>>` | `<<<END_FLOW_OUTPUT>>>` |
| `CONDUCTOR_OUTPUT_INSTRUCTION` | `FLOW_OUTPUT_INSTRUCTION` |
| `parse_conductor_output()` | `parse_flow_output()` |
| `ConductorOutput` | `FlowOutput` |
| `conductor_output_instruction()` | `flow_output_instruction()` |
| `find_conductor_output_start()` | `find_flow_output_start()` |

Touches 65 files across:
- runkon-flow source (4 files)
- conductor-core source (8 files including `schema_config/`, which has its own embedded marker block)
- 50+ `.conductor/agents/*.md` files documenting the marker for the LLM
- prompts, skill, docs

The marker strings are injected at runtime into each agent's system prompt **and** referenced in agent `.md` files as guidance. Both layers must rename together — partial rename gives the LLM contradictory instructions.

### Migration risk

In-flight agent runs that already saw the old prompt will emit `<<<CONDUCTOR_OUTPUT>>>` while the parser looks for `<<<FLOW_OUTPUT>>>` — those will fall back to raw stdout. Avoid deploying mid-workflow.

## Wave 0 housekeeping (no code in this PR)

Triaged and closed four stale issues that were addressed by recent merges to `release/0.10.0` (which doesn't auto-close issues — only `main` does):

- #2712 — `PermissionMode` Claude-strings (closed by PR #2720)
- #2711 — `AgentRun`/`AgentRunStatus` conductor-domain leak (closed by PR #2721)
- #2709 — `claude_session_id` → `session_id` rename (closed by PR #2723)
- #2628 — `SqliteWorkflowPersistence` visibility (closed silently by PR #2719)

Filed #2725 for the residual `bot_name` Claude-CLI flag pass-through carved out of #2711.

## Test plan

- [x] `cargo test -p runkon-flow --lib` → 227 passed
- [x] `cargo test -p conductor-core --lib` → 1926 passed
- [x] `cargo clippy --all-targets -- -D warnings` → clean on `runkon-flow` and `conductor-core`
- [x] `cargo fmt --all --check` → clean
- [x] `cargo build` → clean for `conductor-cli`, `conductor-tui`, `runkon-runtimes` (conductor-web requires bun build, unrelated)

Closes #2611, #2643, #2587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)