### PR TITLE
refactor(workflow): conductor-core-owned ApprovalMode behind the gate bridge (#2669)

### DIFF
--- a/conductor-core/src/workflow/executors/gate_resolver.rs
+++ b/conductor-core/src/workflow/executors/gate_resolver.rs
@@ -7,7 +7,6 @@ use runkon_flow::traits::persistence::WorkflowPersistence;
 
 use crate::config::Config;
 use crate::error::Result;
-use runkon_flow::dsl::ApprovalMode;
 
 use super::resolvers::{
     HumanApprovalGateResolver, HumanGateKind, PrApprovalGateResolver, PrChecksGateResolver,
@@ -16,6 +15,18 @@ use super::resolvers::{
 // ---------------------------------------------------------------------------
 // Core types
 // ---------------------------------------------------------------------------
+
+/// PR-approval semantics consumed by the conductor-core gate resolvers.
+///
+/// Mirrors `runkon_flow::dsl::ApprovalMode` but is owned by conductor-core so
+/// internal executor types do not depend on the runkon-flow DSL surface
+/// directly. The bridge layer (`runkon_gate_bridge.rs`) converts via `From`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(in crate::workflow) enum ApprovalMode {
+    #[default]
+    MinApprovals,
+    ReviewDecision,
+}
 
 /// Outcome of a single poll tick from a `GateResolver`.
 #[derive(Debug)]
@@ -286,7 +297,7 @@ mod tests {
         );
     }
 
-    fn make_params(mode: runkon_flow::dsl::ApprovalMode) -> GateParams {
+    fn make_params(mode: ApprovalMode) -> GateParams {
         GateParams {
             gate_name: "test-gate".into(),
             prompt: None,
@@ -299,10 +310,7 @@ mod tests {
         }
     }
 
-    fn poll_resolver_with_unavailable_gh(
-        resolver_key: &str,
-        mode: runkon_flow::dsl::ApprovalMode,
-    ) -> GatePoll {
+    fn poll_resolver_with_unavailable_gh(resolver_key: &str, mode: ApprovalMode) -> GatePoll {
         let token_cache = Arc::new(GitHubTokenCache::new(None));
         let resolvers = build_default_gate_resolvers(
             make_test_persistence(),
@@ -326,10 +334,7 @@ mod tests {
 
     #[test]
     fn test_pr_approval_resolver_poll_returns_pending_when_gh_unavailable() {
-        let poll = poll_resolver_with_unavailable_gh(
-            "pr_approval",
-            runkon_flow::dsl::ApprovalMode::MinApprovals,
-        );
+        let poll = poll_resolver_with_unavailable_gh("pr_approval", ApprovalMode::MinApprovals);
         assert!(
             matches!(poll, GatePoll::Pending),
             "pr_approval poll must return Pending when gh is unavailable"
@@ -338,10 +343,7 @@ mod tests {
 
     #[test]
     fn test_pr_approval_resolver_poll_review_decision_pending_when_gh_unavailable() {
-        let poll = poll_resolver_with_unavailable_gh(
-            "pr_approval",
-            runkon_flow::dsl::ApprovalMode::ReviewDecision,
-        );
+        let poll = poll_resolver_with_unavailable_gh("pr_approval", ApprovalMode::ReviewDecision);
         assert!(
             matches!(poll, GatePoll::Pending),
             "pr_approval ReviewDecision poll must return Pending when gh is unavailable"
@@ -350,10 +352,7 @@ mod tests {
 
     #[test]
     fn test_pr_checks_resolver_poll_returns_pending_when_gh_unavailable() {
-        let poll = poll_resolver_with_unavailable_gh(
-            "pr_checks",
-            runkon_flow::dsl::ApprovalMode::MinApprovals,
-        );
+        let poll = poll_resolver_with_unavailable_gh("pr_checks", ApprovalMode::MinApprovals);
         assert!(
             matches!(poll, GatePoll::Pending),
             "pr_checks poll must return Pending when gh is unavailable"

--- a/conductor-core/src/workflow/executors/resolvers/human_approval.rs
+++ b/conductor-core/src/workflow/executors/resolvers/human_approval.rs
@@ -56,9 +56,8 @@ impl GateResolver for HumanApprovalGateResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::workflow::executors::gate_resolver::{GateContext, GateParams};
+    use crate::workflow::executors::gate_resolver::{ApprovalMode, GateContext, GateParams};
     use crate::workflow::persistence_sqlite::SqliteWorkflowPersistence;
-    use runkon_flow::dsl::ApprovalMode;
     use runkon_flow::traits::persistence::WorkflowPersistence;
     use rusqlite::Connection;
     use std::sync::Arc;

--- a/conductor-core/src/workflow/executors/resolvers/pr_approval.rs
+++ b/conductor-core/src/workflow/executors/resolvers/pr_approval.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
 use crate::error::Result;
-use runkon_flow::dsl::ApprovalMode;
 
 use crate::workflow::executors::gate_resolver::{
-    GateContext, GateParams, GatePoll, GateResolver, GitHubTokenCache,
+    ApprovalMode, GateContext, GateParams, GatePoll, GateResolver, GitHubTokenCache,
 };
 
 use super::GhGateCommon;
@@ -100,7 +99,6 @@ impl GateResolver for PrApprovalGateResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use runkon_flow::dsl::ApprovalMode;
     use serde_json::json;
 
     fn make_params(mode: ApprovalMode, min_approvals: u32) -> GateParams {

--- a/conductor-core/src/workflow/runkon_gate_bridge.rs
+++ b/conductor-core/src/workflow/runkon_gate_bridge.rs
@@ -16,10 +16,19 @@ use runkon_flow::traits::persistence::WorkflowPersistence as RkPersistence;
 use runkon_flow::FlowEngineBuilder;
 
 use super::executors::gate_resolver::{
-    GateContext as CoreGateContext, GateParams as CoreGateParams, GatePoll as CoreGatePoll,
-    GateResolver as CoreGateResolver, GitHubTokenCache,
+    ApprovalMode as CoreApprovalMode, GateContext as CoreGateContext, GateParams as CoreGateParams,
+    GatePoll as CoreGatePoll, GateResolver as CoreGateResolver, GitHubTokenCache,
 };
 use super::executors::resolvers::{PrApprovalGateResolver, PrChecksGateResolver};
+
+impl From<runkon_flow::dsl::ApprovalMode> for CoreApprovalMode {
+    fn from(m: runkon_flow::dsl::ApprovalMode) -> Self {
+        match m {
+            runkon_flow::dsl::ApprovalMode::MinApprovals => CoreApprovalMode::MinApprovals,
+            runkon_flow::dsl::ApprovalMode::ReviewDecision => CoreApprovalMode::ReviewDecision,
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Human gates (human_approval + human_review)
@@ -114,7 +123,7 @@ fn rk_params_to_core(params: &RkGateParams) -> CoreGateParams {
         gate_name: params.gate_name.clone(),
         prompt: params.prompt.clone(),
         min_approvals: params.min_approvals,
-        approval_mode: params.approval_mode.clone(),
+        approval_mode: params.approval_mode.clone().into(),
         options: params.options.clone(),
         timeout_secs: params.timeout_secs,
         bot_name: params.bot_name.clone(),


### PR DESCRIPTION
## Problem

`GateParams`, an internal `pub(in crate::workflow)` struct in `conductor-core/src/workflow/executors/gate_resolver.rs`, was embedding `runkon_flow::dsl::ApprovalMode` directly. This coupled conductor-core's internal executor types to the runkon-flow DSL surface without going through the bridge adapter layer (`runkon_gate_bridge.rs`).

The bridge already translated between `RkGateParams` and `CoreGateParams`, but both ended up using the **same** underlying `ApprovalMode` — so the bridge provided no isolation. Pattern mismatch with every other type conversion in this codebase.

## Change

- New conductor-core-owned `ApprovalMode` enum in `executors/gate_resolver.rs` next to `GateParams`. Same `MinApprovals` / `ReviewDecision` shape, same `Default`.
- `From<runkon_flow::dsl::ApprovalMode> for CoreApprovalMode` impl added to `runkon_gate_bridge.rs`.
- `rk_params_to_core` calls `.into()` on the approval_mode field.
- Internal users (`PrApprovalGateResolver`, `HumanApprovalGateResolver`, `gate_resolver` tests) switched to the local enum.

## Decoupling boundary

After this change, `runkon_flow::dsl::ApprovalMode` appears in conductor-core only inside `runkon_gate_bridge.rs` — the `From` impl plus one test that constructs an `RkGateParams` (which is itself a runkon-flow trait input). One doc comment in `gate_resolver.rs` references the upstream type to explain what the local enum mirrors.

```bash
$ grep -rn "runkon_flow::dsl::ApprovalMode" --include="*.rs" conductor-core/
conductor-core/src/workflow/runkon_gate_bridge.rs:24-28   # From impl
conductor-core/src/workflow/runkon_gate_bridge.rs:237     # test constructing RkGateParams
conductor-core/src/workflow/executors/gate_resolver.rs:21 # doc comment
```

## Test plan

- [x] `cargo test -p conductor-core --lib` → 1926 passed
- [x] `cargo clippy -p conductor-core --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean
- [x] `cargo build -p conductor-cli -p conductor-tui -p runkon-flow -p runkon-runtimes` → clean

Closes #2669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)