### PR TITLE
fix(scripts): emit FLOW_OUTPUT marker — completes #2587 rename in shell scripts

### DIFF
--- a/.conductor/scripts/analyze-lint.sh
+++ b/.conductor/scripts/analyze-lint.sh
@@ -44,14 +44,14 @@ done
 
 if [ "$ERRORS" -eq 1 ]; then
   cat <<'EOF'
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["has_lint_errors"], "context": "Lint errors found"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 else
   cat <<'EOF'
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "All lint checks passed"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 fi

--- a/.conductor/scripts/apply-qualification-label.sh
+++ b/.conductor/scripts/apply-qualification-label.sh
@@ -23,7 +23,7 @@ emit_output() {
   local output
   output=$(jq -n --argjson markers "$markers" --arg context "$context" \
     '{"markers": $markers, "context": $context}')
-  printf '<<<CONDUCTOR_OUTPUT>>>\n%s\n<<<END_CONDUCTOR_OUTPUT>>>\n' "$output"
+  printf '<<<FLOW_OUTPUT>>>\n%s\n<<<END_FLOW_OUTPUT>>>\n' "$output"
 }
 
 # Detect verdict — check SHOULD CLOSE before NOT READY before READY to avoid substring collisions

--- a/.conductor/scripts/build-web.sh
+++ b/.conductor/scripts/build-web.sh
@@ -9,7 +9,7 @@ echo "=== Building conductor-web binary ==="
 cargo build --bin conductor-web
 
 cat <<'EOF'
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Built conductor-web frontend and binary successfully"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF

--- a/.conductor/scripts/capture-screenshots.sh
+++ b/.conductor/scripts/capture-screenshots.sh
@@ -30,9 +30,9 @@ for i in $(seq 1 30); do
   if ! kill -0 "$SERVER_PID" 2>/dev/null; then
     echo "ERROR: conductor-web exited unexpectedly"
     cat <<'EOF'
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Failed: conductor-web server exited before becoming ready"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
     exit 1
   fi
@@ -42,9 +42,9 @@ done
 if ! curl -sf "http://localhost:$PORT" >/dev/null 2>&1; then
   echo "ERROR: server did not become ready within 30s"
   cat <<'EOF'
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Failed: conductor-web server did not start within 30s"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
   exit 1
 fi
@@ -57,9 +57,9 @@ cd ../..
 
 if [ "$PLAYWRIGHT_EXIT" -ne 0 ]; then
   cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Playwright screenshot capture failed (exit $PLAYWRIGHT_EXIT). Screenshots dir: $SCREENSHOT_DIR"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
   exit 1
 fi
@@ -68,7 +68,7 @@ COUNT=$(find "$SCREENSHOT_DIR" -name '*.png' | wc -l | tr -d ' ')
 echo "Captured $COUNT screenshots to $SCREENSHOT_DIR"
 
 cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["screenshots_captured"], "context": "Captured $COUNT mobile screenshots to $SCREENSHOT_DIR"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF

--- a/.conductor/scripts/cargo-audit.sh
+++ b/.conductor/scripts/cargo-audit.sh
@@ -20,15 +20,15 @@ echo "Running cargo audit..."
 if cargo audit 2>&1; then
     echo "No vulnerabilities found."
     cat <<'EOF'
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "clean audit — no advisories"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 else
     echo "Vulnerabilities found!"
     cat <<'EOF'
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["has_vulnerabilities"], "context": "cargo audit found advisories"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 fi

--- a/.conductor/scripts/check-mergeability.sh
+++ b/.conductor/scripts/check-mergeability.sh
@@ -21,15 +21,15 @@ done
 
 if [ "$mergeable" = "CONFLICTING" ]; then
   cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["has_conflicts"], "context": "PR is CONFLICTING (mergeStateStatus: $merge_state) — rebase needed"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 else
   cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "PR is mergeable (mergeStateStatus: $merge_state) — no rebase needed"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 fi
 

--- a/.conductor/scripts/check-personas-exist.sh
+++ b/.conductor/scripts/check-personas-exist.sh
@@ -3,14 +3,14 @@ set -euo pipefail
 
 if [ -f docs/diagrams/personas.md ]; then
   cat <<'EOF'
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["personas_exist"], "context": "personas.md exists"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 else
   cat <<'EOF'
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "personas.md does not exist"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 fi

--- a/.conductor/scripts/collect-file-sizes.sh
+++ b/.conductor/scripts/collect-file-sizes.sh
@@ -27,7 +27,7 @@ emit_empty() {
   local output
   output=$(jq -n --arg focus "$focus" \
     '{"markers": [], "context": ("No source files found after applying exclusions and focus filter \"" + $focus + "\".")}')
-  printf '<<<CONDUCTOR_OUTPUT>>>\n%s\n<<<END_CONDUCTOR_OUTPUT>>>\n' "$output"
+  printf '<<<FLOW_OUTPUT>>>\n%s\n<<<END_FLOW_OUTPUT>>>\n' "$output"
 }
 
 if [ -z "$filtered" ]; then
@@ -59,4 +59,4 @@ context=$(printf 'Found %s source files. Threshold: %s lines. Focus filter: "%s"
 
 output=$(jq -n --arg context "$context" '{"markers": ["has_files"], "context": $context}')
 
-printf '<<<CONDUCTOR_OUTPUT>>>\n%s\n<<<END_CONDUCTOR_OUTPUT>>>\n' "$output"
+printf '<<<FLOW_OUTPUT>>>\n%s\n<<<END_FLOW_OUTPUT>>>\n' "$output"

--- a/.conductor/scripts/comment-ticket-assessment.sh
+++ b/.conductor/scripts/comment-ticket-assessment.sh
@@ -25,7 +25,7 @@ emit_output() {
   local output
   output=$(jq -n --argjson markers "$markers" --arg context "$context" \
     '{"markers": $markers, "context": $context}')
-  printf '<<<CONDUCTOR_OUTPUT>>>\n%s\n<<<END_CONDUCTOR_OUTPUT>>>\n' "$output"
+  printf '<<<FLOW_OUTPUT>>>\n%s\n<<<END_FLOW_OUTPUT>>>\n' "$output"
 }
 
 # Detect verdict from markers in {{prior_contexts}} JSON array.

--- a/.conductor/scripts/commit-diagrams.sh
+++ b/.conductor/scripts/commit-diagrams.sh
@@ -5,16 +5,16 @@ git add docs/diagrams/
 
 if git diff --cached --quiet; then
   cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "No diagram changes to commit"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 else
   committed_files=$(git diff --cached --name-only)
   git commit -m "docs: update diagrams for ticket $TICKET"
   cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Committed diagram files: $committed_files"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 fi

--- a/.conductor/scripts/create-gh-issue.sh
+++ b/.conductor/scripts/create-gh-issue.sh
@@ -10,7 +10,7 @@ emit_output() {
   local output
   output=$(jq -n --argjson markers "$markers" --arg context "$context" \
     '{"markers": $markers, "context": $context}')
-  printf '<<<CONDUCTOR_OUTPUT>>>\n%s\n<<<END_CONDUCTOR_OUTPUT>>>\n' "$output"
+  printf '<<<FLOW_OUTPUT>>>\n%s\n<<<END_FLOW_OUTPUT>>>\n' "$output"
 }
 
 # Parse title from "Draft issue: <title>" line
@@ -24,14 +24,14 @@ fi
 # Parse labels from "Labels: <comma-separated or empty>" line
 LABELS_LINE=$(echo "$PRIOR_OUTPUT" | grep -m1 '^Labels:' | sed 's/^Labels: //')
 
-# Parse body — everything after the "Body:" line, stripping trailing CONDUCTOR_OUTPUT block
+# Parse body — everything after the "Body:" line, stripping trailing FLOW_OUTPUT block
 tmp=$(mktemp)
 trap 'rm -f "$tmp"' EXIT
 
 echo "$PRIOR_OUTPUT" \
   | sed -n '/^Body:$/,$ p' \
   | tail -n +2 \
-  | sed '/^<<<CONDUCTOR_OUTPUT>>>/,$ d' \
+  | sed '/^<<<FLOW_OUTPUT>>>/,$ d' \
   > "$tmp"
 
 # Build label args

--- a/.conductor/scripts/detect-db-migrations.sh
+++ b/.conductor/scripts/detect-db-migrations.sh
@@ -19,14 +19,14 @@ count=${#migration_files[@]}
 if [ "$count" -gt 0 ]; then
   file_list=$(IFS=", "; echo "${migration_files[*]}")
   cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["has_db_migrations"], "context": "Found ${count} migration file(s) in diff: ${file_list}"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 else
   cat <<'EOF'
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "No migration files in diff"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 fi

--- a/.conductor/scripts/detect-file-types.sh
+++ b/.conductor/scripts/detect-file-types.sh
@@ -29,14 +29,14 @@ count=${#code_files[@]}
 if [ "$count" -gt 0 ]; then
   file_list=$(IFS=", "; echo "${code_files[*]}")
   cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["has_code_changes"], "context": "Found ${count} code file(s) in diff: ${file_list}"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 else
   cat <<'EOF'
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "No code files in diff"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 fi

--- a/.conductor/scripts/fetch-agent-logs.sh
+++ b/.conductor/scripts/fetch-agent-logs.sh
@@ -86,7 +86,7 @@ while IFS= read -r line; do
 done <<< "$run_output"
 
 cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Fetched ${logs_fetched} agent log(s) for failed steps"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF

--- a/.conductor/scripts/fetch-pr-context.sh
+++ b/.conductor/scripts/fetch-pr-context.sh
@@ -8,12 +8,12 @@ pr_json=$(gh pr view "${PR_NUMBER}" --json title,body,labels,author,milestone,cl
 max_diff_chars=50000
 pr_diff=$(gh pr diff "${PR_NUMBER}" | head -c "$max_diff_chars")
 
-# Build context string and emit CONDUCTOR_OUTPUT with proper JSON escaping
+# Build context string and emit FLOW_OUTPUT with proper JSON escaping
 context=$(printf '## PR Metadata\n```json\n%s\n```\n\n## PR Diff\n```diff\n%s\n```' "$pr_json" "$pr_diff")
 output=$(jq -n --arg context "$context" '{"markers": [], "context": $context}')
 
 cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 ${output}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF

--- a/.conductor/scripts/fetch-run-data.sh
+++ b/.conductor/scripts/fetch-run-data.sh
@@ -66,7 +66,7 @@ if [[ -n "$elapsed" ]]; then
 fi
 
 cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "${context}"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF

--- a/.conductor/scripts/file-debug-issues.sh
+++ b/.conductor/scripts/file-debug-issues.sh
@@ -14,9 +14,9 @@ SUMMARY=$(echo "${PRIOR_OUTPUT}" | jq -r '.summary // ""')
 if [ "${ISSUE_COUNT}" -eq 0 ]; then
   echo "No issues to file."
   cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "No issues to file — diagnosis found no actionable fixes"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
   exit 0
 fi
@@ -90,7 +90,7 @@ ${DESCRIPTION}
 done < <(echo "${ISSUES}" | jq -c '.[]')
 
 cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Filed ${filed} issue(s), skipped ${skipped} duplicate(s). ${filed_urls}"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF

--- a/.conductor/scripts/push-and-pr.sh
+++ b/.conductor/scripts/push-and-pr.sh
@@ -30,9 +30,9 @@ git fetch origin "$base" --quiet
 ahead=$(git rev-list --count "origin/$base..HEAD")
 if [ "$ahead" -eq 0 ]; then
   cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["no_changes"], "context": "No commits ahead of $base — nothing to push or PR"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
   exit 0
 fi
@@ -55,7 +55,7 @@ fi
 rm -f "$pr_create_err"
 
 cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "PR is open at $pr_url"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF

--- a/.conductor/scripts/push-rebased.sh
+++ b/.conductor/scripts/push-rebased.sh
@@ -5,7 +5,7 @@ git push -u --force-with-lease origin HEAD
 branch=$(git rev-parse --abbrev-ref HEAD)
 
 cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["pulled_new_commits"], "context": "Pushed rebased branch: $branch"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF

--- a/.conductor/scripts/push.sh
+++ b/.conductor/scripts/push.sh
@@ -8,7 +8,7 @@ branch=$(git rev-parse --abbrev-ref HEAD)
 echo "Pushed branch: $branch"
 
 if echo "$push_output" | grep -q "Everything up-to-date"; then
-  echo "<<<CONDUCTOR_OUTPUT>>> {\"markers\": []}"
+  echo "<<<FLOW_OUTPUT>>> {\"markers\": []}"
 else
-  echo "<<<CONDUCTOR_OUTPUT>>> {\"markers\": [\"pushed_new_commits\"]}"
+  echo "<<<FLOW_OUTPUT>>> {\"markers\": [\"pushed_new_commits\"]}"
 fi

--- a/.conductor/scripts/read-diagrams.sh
+++ b/.conductor/scripts/read-diagrams.sh
@@ -28,7 +28,7 @@ done
 json_content=$(printf '%s' "$content" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')
 
 cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": ${json_content}}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF

--- a/.conductor/scripts/read-personas.sh
+++ b/.conductor/scripts/read-personas.sh
@@ -21,7 +21,7 @@ fi
 json_content=$(printf '%s' "${prefix}${content}" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))')
 
 cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": ${json_content}}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF

--- a/.conductor/scripts/sync-with-base.sh
+++ b/.conductor/scripts/sync-with-base.sh
@@ -7,9 +7,9 @@ git fetch origin
 
 if [ -z "$(git log HEAD..origin/${BASE} --oneline)" ]; then
   cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["is_up_to_date"], "context": "Branch is already up to date with origin/${BASE}"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
   exit 0
 fi
@@ -19,9 +19,9 @@ git rebase origin/${BASE} || rebase_exit=$?
 
 if [ $rebase_exit -eq 0 ]; then
   cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": [], "context": "Rebased onto origin/${BASE}"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
   exit 0
 fi
@@ -30,8 +30,8 @@ conflict_files=$(git diff --name-only --diff-filter=U | tr '\n' ' ' | sed 's/ $/
 git rebase --abort
 
 cat <<EOF
-<<<CONDUCTOR_OUTPUT>>>
+<<<FLOW_OUTPUT>>>
 {"markers": ["has_conflicts"], "context": "Rebase conflicted on: $conflict_files"}
-<<<END_CONDUCTOR_OUTPUT>>>
+<<<END_FLOW_OUTPUT>>>
 EOF
 exit 0


### PR DESCRIPTION
## Regression introduced by #2726

PR #2726 (Wave 1B of the layer-violation cluster) renamed \`<<<CONDUCTOR_OUTPUT>>>\` → \`<<<FLOW_OUTPUT>>>\` for portability. The sed pass scoped to \`.rs\` / \`.md\` / \`.wf\` files and missed \`*.sh\`. All 23 scripts in \`.conductor/scripts/\` kept emitting the old marker while \`parse_flow_output\` now expects the new one — every script step's markers and context fall through to empty.

## Observed impact

Workflow run \`01KQDXB440DPX7JNBDW934V1C4\` (review-pr on PR #2729):

\`\`\`
position  step_name                role     status     markers_out
--------  ----------------------   -------  ---------  -----------
0         detect-db-migrations     script   completed  []          ← lost
1         detect-file-types        script   completed  []          ← lost
2         review-architecture      actor    completed  []
3         review-dry-abstraction   actor    completed  []
4         review-security          actor    skipped               ← due to lost marker
5         review-performance       actor    skipped               ← "
6         review-error-handling    actor    skipped               ← "
7         review-test-coverage     actor    skipped               ← "
8         review-db-migrations     actor    skipped               ← "
9         review-aggregator        actor    completed  ["approved"]
10        submit-review            script   completed  []
\`\`\`

\`detect-file-types\` correctly emitted \`{"markers": ["has_code_changes"], "context": "Found 5 code file(s)…"}\` in stdout (visible in \`context_out\`), but the parser couldn't find the renamed sentinel, so \`markers_out\` is empty. The \`if = "detect-file-types.has_code_changes"\` guards on five reviewers all evaluated false and skipped — even though five Rust files were in the diff.

## Fix

Apply the same rename to the 23 \`.sh\` files. The single remaining reference in \`conductor-core/src/db/migrations/021_workflow_redesign.sql\` is a comment in an immutable migration — left intact.

## Verification

\`\`\`bash
$ find . -type f -not -path "./target/*" -exec grep -lI "CONDUCTOR_OUTPUT" {} \;
./conductor-core/src/db/migrations/021_workflow_redesign.sql   # immutable, OK
\`\`\`

## Test plan

- [x] Mass rename verified — only the immutable SQL migration retains the old name (comment, harmless).
- [x] \`cargo build -p conductor-core\` clean (this PR only touches shell scripts).
- [ ] Re-run \`review-pr\` on PR #2729 after merge to confirm the full reviewer set fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)