### PR TITLE
fix(engine): tick heartbeat during parallel/foreach waits (#2731)

### DIFF
--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -152,6 +152,64 @@ impl ExecutionState {
         Arc::new(AtomicI64::new(0))
     }
 
+    /// Throttled heartbeat tick + external cancel check.
+    ///
+    /// Bumps `last_heartbeat` in persistence at most once every 5 seconds and
+    /// polls for cross-process cancellation via `persistence.is_run_cancelled`.
+    /// On external cancel, sets `self.cancellation` and returns
+    /// `Err(EngineError::Cancelled)`.
+    ///
+    /// Callers that own the engine main loop use `?` to propagate cancellation
+    /// up. Wait loops that need to drain in-flight work (parallel, foreach)
+    /// can call this best-effort and rely on `self.cancellation.is_cancelled()`
+    /// for their controlled exit — the cancellation token is set by this
+    /// helper before the `Err` is returned.
+    ///
+    /// Without this being called from inside long-running wait loops (parallel
+    /// blocks, foreach fan-out), the heartbeat goes stale during multi-minute
+    /// waits and the watchdog reaper races the engine after >60 s — see #2731.
+    pub fn tick_heartbeat_throttled(&self) -> Result<()> {
+        use crate::cancellation_reason::CancellationReason;
+
+        let now_secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_else(|e| {
+                tracing::warn!("system clock regressed: {e}; heartbeat suppressed");
+                e.duration()
+            })
+            .as_secs() as i64;
+        let last = self.last_heartbeat_at.load(Ordering::Relaxed);
+        if now_secs - last < 5 {
+            return Ok(());
+        }
+        self.last_heartbeat_at.store(now_secs, Ordering::Relaxed);
+        match self.persistence.is_run_cancelled(&self.workflow_run_id) {
+            Ok(true) => {
+                tracing::info!(
+                    "Workflow run {} cancelled externally, stopping execution",
+                    self.workflow_run_id
+                );
+                self.cancellation
+                    .cancel(CancellationReason::UserRequested(None));
+                return Err(EngineError::Cancelled(CancellationReason::UserRequested(
+                    None,
+                )));
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    "Database error during cancellation check for workflow run {}: {}",
+                    self.workflow_run_id,
+                    e
+                );
+            }
+        }
+        if let Err(e) = self.persistence.tick_heartbeat(&self.workflow_run_id) {
+            tracing::warn!("tick_heartbeat failed (non-fatal): {e}");
+        }
+        Ok(())
+    }
+
     /// Project this state into the narrow surface a `ChildWorkflowRunner`
     /// implementation needs to spawn a child run.
     pub fn child_workflow_context(&self) -> ChildWorkflowContext {
@@ -505,7 +563,6 @@ pub fn execute_nodes(
     nodes: &[WorkflowNode],
     respect_fail_fast: bool,
 ) -> Result<()> {
-    use crate::cancellation_reason::CancellationReason;
     for node in nodes {
         if respect_fail_fast && !state.all_succeeded && state.exec_config.fail_fast {
             break;
@@ -514,47 +571,7 @@ pub fn execute_nodes(
         if state.cancellation.is_cancelled() {
             return state.cancellation.error_if_cancelled();
         }
-        // Throttled cancel check + heartbeat tick — both hit the DB, so gate them together
-        // at most once every 5 seconds using the existing heartbeat timestamp.
-        {
-            let now_secs = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_else(|e| {
-                    tracing::warn!("system clock regressed: {e}; heartbeat suppressed");
-                    e.duration()
-                })
-                .as_secs() as i64;
-            let last = state.last_heartbeat_at.load(Ordering::Relaxed);
-            if now_secs - last >= 5 {
-                state.last_heartbeat_at.store(now_secs, Ordering::Relaxed);
-                // Cross-process: DB polling for Cancelling status written by another process.
-                match state.persistence.is_run_cancelled(&state.workflow_run_id) {
-                    Ok(true) => {
-                        tracing::info!(
-                            "Workflow run {} cancelled externally, stopping execution",
-                            state.workflow_run_id
-                        );
-                        state
-                            .cancellation
-                            .cancel(CancellationReason::UserRequested(None));
-                        return Err(EngineError::Cancelled(CancellationReason::UserRequested(
-                            None,
-                        )));
-                    }
-                    Ok(false) => {}
-                    Err(e) => {
-                        tracing::warn!(
-                            "Database error during cancellation check for workflow run {}: {}",
-                            state.workflow_run_id,
-                            e
-                        );
-                    }
-                }
-                if let Err(e) = state.persistence.tick_heartbeat(&state.workflow_run_id) {
-                    tracing::warn!("tick_heartbeat failed (non-fatal): {e}");
-                }
-            }
-        }
+        state.tick_heartbeat_throttled()?;
         execute_single_node(state, node, 0)?;
     }
     Ok(())
@@ -1241,6 +1258,108 @@ mod tests {
         assert!(
             Arc::ptr_eq(&ctx.event_sinks, &sinks),
             "event_sinks slice should be shared via Arc, not cloned"
+        );
+    }
+
+    use crate::test_helpers::CountingPersistence;
+
+    /// Build a minimal ExecutionState wired to a CountingPersistence.
+    fn make_state_with_counting_persistence(
+        cp: std::sync::Arc<CountingPersistence>,
+        run_id: String,
+    ) -> ExecutionState {
+        use crate::cancellation::CancellationToken;
+        use crate::traits::script_env_provider::NoOpScriptEnvProvider;
+        use crate::types::WorkflowExecConfig;
+
+        ExecutionState {
+            persistence: cp as Arc<dyn crate::traits::persistence::WorkflowPersistence>,
+            action_registry: Arc::new(crate::traits::action_executor::ActionRegistry::new(
+                HashMap::new(),
+                None,
+            )),
+            script_env_provider: Arc::new(NoOpScriptEnvProvider),
+            workflow_run_id: run_id,
+            workflow_name: "wf".into(),
+            worktree_ctx: WorktreeContext {
+                worktree_id: None,
+                working_dir: String::new(),
+                repo_path: String::new(),
+                ticket_id: None,
+                repo_id: None,
+                extra_plugin_dirs: vec![],
+            },
+            model: None,
+            exec_config: WorkflowExecConfig::default(),
+            inputs: HashMap::new(),
+            parent_run_id: String::new(),
+            depth: 0,
+            target_label: None,
+            step_results: HashMap::new(),
+            contexts: vec![],
+            position: 0,
+            all_succeeded: true,
+            total_cost: 0.0,
+            total_turns: 0,
+            total_duration_ms: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_read_input_tokens: 0,
+            total_cache_creation_input_tokens: 0,
+            last_gate_feedback: None,
+            block_output: None,
+            block_with: vec![],
+            resume_ctx: None,
+            default_bot_name: None,
+            triggered_by_hook: false,
+            schema_resolver: None,
+            child_runner: None,
+            last_heartbeat_at: ExecutionState::new_heartbeat(),
+            registry: Arc::new(crate::traits::item_provider::ItemProviderRegistry::new()),
+            event_sinks: Arc::from(vec![]),
+            cancellation: CancellationToken::new(),
+            current_execution_id: Arc::new(std::sync::Mutex::new(None)),
+        }
+    }
+
+    /// First call must tick (initial state has last_heartbeat_at = 0, far enough
+    /// in the past to clear the 5 s gate). An immediate second call must NOT
+    /// tick — it falls inside the 5 s throttle window.
+    #[test]
+    fn tick_heartbeat_throttled_first_call_ticks_second_call_throttled() {
+        let cp = Arc::new(CountingPersistence::new());
+        let state = make_state_with_counting_persistence(Arc::clone(&cp), "run-1".into());
+
+        assert_eq!(cp.tick_count(), 0);
+        state.tick_heartbeat_throttled().unwrap();
+        assert_eq!(cp.tick_count(), 1, "first call must tick");
+
+        // Immediate second call falls inside the 5 s window.
+        state.tick_heartbeat_throttled().unwrap();
+        assert_eq!(
+            cp.tick_count(),
+            1,
+            "second call within 5s must be throttled, not tick again"
+        );
+    }
+
+    /// When persistence reports the run cancelled, the helper sets
+    /// `state.cancellation` and returns `Err(Cancelled)`.
+    #[test]
+    fn tick_heartbeat_throttled_propagates_external_cancel() {
+        let cp = Arc::new(CountingPersistence::new());
+        cp.set_cancelled(true);
+        let state = make_state_with_counting_persistence(Arc::clone(&cp), "run-1".into());
+
+        assert!(!state.cancellation.is_cancelled());
+        let result = state.tick_heartbeat_throttled();
+        assert!(
+            matches!(result, Err(EngineError::Cancelled(_))),
+            "expected Err(Cancelled), got {result:?}"
+        );
+        assert!(
+            state.cancellation.is_cancelled(),
+            "helper must set state.cancellation on external cancel"
         );
     }
 }

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -1268,58 +1268,10 @@ mod tests {
         cp: std::sync::Arc<CountingPersistence>,
         run_id: String,
     ) -> ExecutionState {
-        use crate::cancellation::CancellationToken;
-        use crate::traits::script_env_provider::NoOpScriptEnvProvider;
-        use crate::types::WorkflowExecConfig;
-
-        ExecutionState {
-            persistence: cp as Arc<dyn crate::traits::persistence::WorkflowPersistence>,
-            action_registry: Arc::new(crate::traits::action_executor::ActionRegistry::new(
-                HashMap::new(),
-                None,
-            )),
-            script_env_provider: Arc::new(NoOpScriptEnvProvider),
-            workflow_run_id: run_id,
-            workflow_name: "wf".into(),
-            worktree_ctx: WorktreeContext {
-                worktree_id: None,
-                working_dir: String::new(),
-                repo_path: String::new(),
-                ticket_id: None,
-                repo_id: None,
-                extra_plugin_dirs: vec![],
-            },
-            model: None,
-            exec_config: WorkflowExecConfig::default(),
-            inputs: HashMap::new(),
-            parent_run_id: String::new(),
-            depth: 0,
-            target_label: None,
-            step_results: HashMap::new(),
-            contexts: vec![],
-            position: 0,
-            all_succeeded: true,
-            total_cost: 0.0,
-            total_turns: 0,
-            total_duration_ms: 0,
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-            total_cache_read_input_tokens: 0,
-            total_cache_creation_input_tokens: 0,
-            last_gate_feedback: None,
-            block_output: None,
-            block_with: vec![],
-            resume_ctx: None,
-            default_bot_name: None,
-            triggered_by_hook: false,
-            schema_resolver: None,
-            child_runner: None,
-            last_heartbeat_at: ExecutionState::new_heartbeat(),
-            registry: Arc::new(crate::traits::item_provider::ItemProviderRegistry::new()),
-            event_sinks: Arc::from(vec![]),
-            cancellation: CancellationToken::new(),
-            current_execution_id: Arc::new(std::sync::Mutex::new(None)),
-        }
+        crate::test_helpers::make_test_execution_state(
+            cp as Arc<dyn crate::traits::persistence::WorkflowPersistence>,
+            run_id,
+        )
     }
 
     /// First call must tick (initial state has last_heartbeat_at = 0, far enough

--- a/runkon-flow/src/executors/foreach.rs
+++ b/runkon-flow/src/executors/foreach.rs
@@ -334,6 +334,11 @@ pub fn execute_foreach(
     let pool = threadpool::ThreadPool::new(max_slots);
 
     loop {
+        // Heartbeat tick + external cancel poll. Best-effort — the cancel
+        // signal lands on `state.cancellation`, and the controlled drain at the
+        // `is_cancelled()` check below picks it up. #2731.
+        let _ = state.tick_heartbeat_throttled();
+
         // 1. When threads are in-flight, block briefly on the first result to yield
         //    the CPU instead of spinning. Then drain any additional ready results.
         let mut completed: Vec<(String, bool)> = Vec::new();
@@ -961,5 +966,178 @@ mod tests {
         );
         assert_eq!(ctx.parent_workflow_ctx.inputs, parent_inputs);
         assert_eq!(ctx.parent_workflow_ctx.workflow_run_id, "parent-run");
+    }
+
+    /// Regression for #2731: the foreach wait loop must keep `tick_heartbeat`
+    /// firing while children are running. Foreach already had a 50 ms
+    /// `recv_timeout`, but it didn't ping the heartbeat — so a long-running
+    /// child meant `last_heartbeat` went stale and the watchdog reaped the run.
+    #[test]
+    fn foreach_wait_loop_ticks_heartbeat_during_long_children() {
+        use std::sync::{Arc, Mutex};
+        use std::time::Duration;
+
+        use crate::cancellation::CancellationToken;
+        use crate::dsl::{ForEachNode, OnChildFail, OnCycle};
+        use crate::engine::{
+            ChildWorkflowContext, ChildWorkflowInput, ChildWorkflowRunner, ExecutionState,
+            WorktreeContext,
+        };
+        use crate::engine_error::Result;
+        use crate::traits::action_executor::ActionRegistry;
+        use crate::traits::item_provider::{
+            FanOutItem, ItemProvider, ItemProviderRegistry, ProviderContext,
+        };
+        use crate::traits::persistence::{NewRun, WorkflowPersistence};
+        use crate::traits::script_env_provider::NoOpScriptEnvProvider;
+        use crate::types::{WorkflowExecConfig, WorkflowResult};
+
+        struct OneItemProvider;
+        impl ItemProvider for OneItemProvider {
+            fn name(&self) -> &str {
+                "test_items"
+            }
+            fn items(
+                &self,
+                _ctx: &ProviderContext,
+                _scope: Option<&crate::dsl::ForeachScope>,
+                _filter: &HashMap<String, String>,
+                _existing_set: &HashSet<String>,
+            ) -> Result<Vec<FanOutItem>> {
+                Ok(vec![FanOutItem {
+                    item_type: "test".into(),
+                    item_id: "item-1".into(),
+                    item_ref: "ref-1".into(),
+                }])
+            }
+        }
+
+        struct SleepingChildRunner;
+        impl ChildWorkflowRunner for SleepingChildRunner {
+            fn execute_child(
+                &self,
+                _: &str,
+                _: &ChildWorkflowContext,
+                _: ChildWorkflowInput,
+            ) -> Result<WorkflowResult> {
+                std::thread::sleep(Duration::from_millis(800));
+                Ok(WorkflowResult {
+                    workflow_run_id: "child-run".into(),
+                    worktree_id: None,
+                    workflow_name: "child-wf".into(),
+                    all_succeeded: true,
+                    total_cost: 0.0,
+                    total_turns: 0,
+                    total_duration_ms: 0,
+                    total_input_tokens: 0,
+                    total_output_tokens: 0,
+                    total_cache_read_input_tokens: 0,
+                    total_cache_creation_input_tokens: 0,
+                })
+            }
+            fn resume_child(
+                &self,
+                _: &str,
+                _: Option<&str>,
+                _: &ChildWorkflowContext,
+            ) -> Result<WorkflowResult> {
+                unimplemented!()
+            }
+            fn find_resumable_child(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<Option<crate::types::WorkflowRun>> {
+                Ok(None)
+            }
+        }
+
+        let cp = Arc::new(crate::test_helpers::CountingPersistence::new());
+        let run_id = cp
+            .create_run(NewRun {
+                workflow_name: "wf".to_string(),
+                worktree_id: None,
+                ticket_id: None,
+                repo_id: None,
+                parent_run_id: String::new(),
+                dry_run: false,
+                trigger: "manual".to_string(),
+                definition_snapshot: None,
+                parent_workflow_run_id: None,
+                target_label: None,
+            })
+            .unwrap()
+            .id;
+        let cp_for_state: Arc<dyn WorkflowPersistence> = Arc::clone(&cp) as _;
+
+        let mut registry = ItemProviderRegistry::new();
+        registry.register(OneItemProvider);
+
+        let mut state = ExecutionState {
+            persistence: cp_for_state,
+            action_registry: Arc::new(ActionRegistry::new(HashMap::new(), None)),
+            script_env_provider: Arc::new(NoOpScriptEnvProvider),
+            workflow_run_id: run_id,
+            workflow_name: "wf".into(),
+            worktree_ctx: WorktreeContext {
+                worktree_id: None,
+                working_dir: String::new(),
+                repo_path: String::new(),
+                ticket_id: None,
+                repo_id: None,
+                extra_plugin_dirs: vec![],
+            },
+            model: None,
+            exec_config: WorkflowExecConfig::default(),
+            inputs: HashMap::new(),
+            parent_run_id: String::new(),
+            depth: 0,
+            target_label: None,
+            step_results: HashMap::new(),
+            contexts: vec![],
+            position: 0,
+            all_succeeded: true,
+            total_cost: 0.0,
+            total_turns: 0,
+            total_duration_ms: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_read_input_tokens: 0,
+            total_cache_creation_input_tokens: 0,
+            last_gate_feedback: None,
+            block_output: None,
+            block_with: vec![],
+            resume_ctx: None,
+            default_bot_name: None,
+            triggered_by_hook: false,
+            schema_resolver: None,
+            child_runner: Some(Arc::new(SleepingChildRunner)),
+            last_heartbeat_at: ExecutionState::new_heartbeat(),
+            registry: Arc::new(registry),
+            event_sinks: Arc::from(vec![]),
+            cancellation: CancellationToken::new(),
+            current_execution_id: Arc::new(Mutex::new(None)),
+        };
+
+        let node = ForEachNode {
+            name: "foreach-test".into(),
+            over: "test_items".into(),
+            scope: None,
+            filter: HashMap::new(),
+            ordered: false,
+            on_cycle: OnCycle::Fail,
+            max_parallel: 1,
+            workflow: "child-wf".into(),
+            inputs: HashMap::new(),
+            on_child_fail: OnChildFail::Continue,
+        };
+
+        super::execute_foreach(&mut state, &node, 0).unwrap();
+
+        assert!(
+            cp.tick_count() >= 1,
+            "expected ≥1 heartbeat tick during foreach wait loop, got {}",
+            cp.tick_count()
+        );
     }
 }

--- a/runkon-flow/src/executors/foreach.rs
+++ b/runkon-flow/src/executors/foreach.rs
@@ -974,23 +974,17 @@ mod tests {
     /// child meant `last_heartbeat` went stale and the watchdog reaped the run.
     #[test]
     fn foreach_wait_loop_ticks_heartbeat_during_long_children() {
-        use std::sync::{Arc, Mutex};
+        use std::sync::Arc;
         use std::time::Duration;
 
-        use crate::cancellation::CancellationToken;
         use crate::dsl::{ForEachNode, OnChildFail, OnCycle};
-        use crate::engine::{
-            ChildWorkflowContext, ChildWorkflowInput, ChildWorkflowRunner, ExecutionState,
-            WorktreeContext,
-        };
+        use crate::engine::{ChildWorkflowContext, ChildWorkflowInput, ChildWorkflowRunner};
         use crate::engine_error::Result;
-        use crate::traits::action_executor::ActionRegistry;
         use crate::traits::item_provider::{
             FanOutItem, ItemProvider, ItemProviderRegistry, ProviderContext,
         };
         use crate::traits::persistence::{NewRun, WorkflowPersistence};
-        use crate::traits::script_env_provider::NoOpScriptEnvProvider;
-        use crate::types::{WorkflowExecConfig, WorkflowResult};
+        use crate::types::WorkflowResult;
 
         struct OneItemProvider;
         impl ItemProvider for OneItemProvider {
@@ -1073,51 +1067,9 @@ mod tests {
         let mut registry = ItemProviderRegistry::new();
         registry.register(OneItemProvider);
 
-        let mut state = ExecutionState {
-            persistence: cp_for_state,
-            action_registry: Arc::new(ActionRegistry::new(HashMap::new(), None)),
-            script_env_provider: Arc::new(NoOpScriptEnvProvider),
-            workflow_run_id: run_id,
-            workflow_name: "wf".into(),
-            worktree_ctx: WorktreeContext {
-                worktree_id: None,
-                working_dir: String::new(),
-                repo_path: String::new(),
-                ticket_id: None,
-                repo_id: None,
-                extra_plugin_dirs: vec![],
-            },
-            model: None,
-            exec_config: WorkflowExecConfig::default(),
-            inputs: HashMap::new(),
-            parent_run_id: String::new(),
-            depth: 0,
-            target_label: None,
-            step_results: HashMap::new(),
-            contexts: vec![],
-            position: 0,
-            all_succeeded: true,
-            total_cost: 0.0,
-            total_turns: 0,
-            total_duration_ms: 0,
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-            total_cache_read_input_tokens: 0,
-            total_cache_creation_input_tokens: 0,
-            last_gate_feedback: None,
-            block_output: None,
-            block_with: vec![],
-            resume_ctx: None,
-            default_bot_name: None,
-            triggered_by_hook: false,
-            schema_resolver: None,
-            child_runner: Some(Arc::new(SleepingChildRunner)),
-            last_heartbeat_at: ExecutionState::new_heartbeat(),
-            registry: Arc::new(registry),
-            event_sinks: Arc::from(vec![]),
-            cancellation: CancellationToken::new(),
-            current_execution_id: Arc::new(Mutex::new(None)),
-        };
+        let mut state = crate::test_helpers::make_test_execution_state(cp_for_state, run_id);
+        state.child_runner = Some(Arc::new(SleepingChildRunner));
+        state.registry = Arc::new(registry);
 
         let node = ForEachNode {
             name: "foreach-test".into(),

--- a/runkon-flow/src/executors/parallel.rs
+++ b/runkon-flow/src/executors/parallel.rs
@@ -861,51 +861,8 @@ mod tests {
             .id;
         let cp_for_state: Arc<dyn WorkflowPersistence> = Arc::clone(&cp) as _;
 
-        let mut state = ExecutionState {
-            persistence: cp_for_state,
-            action_registry: Arc::new(registry),
-            script_env_provider: Arc::new(NoOpScriptEnvProvider),
-            workflow_run_id: run_id,
-            workflow_name: "wf".into(),
-            worktree_ctx: WorktreeContext {
-                worktree_id: None,
-                working_dir: String::new(),
-                repo_path: String::new(),
-                ticket_id: None,
-                repo_id: None,
-                extra_plugin_dirs: vec![],
-            },
-            model: None,
-            exec_config: WorkflowExecConfig::default(),
-            inputs: HashMap::new(),
-            parent_run_id: String::new(),
-            depth: 0,
-            target_label: None,
-            step_results: HashMap::new(),
-            contexts: vec![],
-            position: 0,
-            all_succeeded: true,
-            total_cost: 0.0,
-            total_turns: 0,
-            total_duration_ms: 0,
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-            total_cache_read_input_tokens: 0,
-            total_cache_creation_input_tokens: 0,
-            last_gate_feedback: None,
-            block_output: None,
-            block_with: vec![],
-            resume_ctx: None,
-            default_bot_name: None,
-            triggered_by_hook: false,
-            schema_resolver: None,
-            child_runner: None,
-            last_heartbeat_at: ExecutionState::new_heartbeat(),
-            registry: Arc::new(ItemProviderRegistry::new()),
-            event_sinks: Arc::from(vec![]),
-            cancellation: crate::cancellation::CancellationToken::new(),
-            current_execution_id: Arc::new(std::sync::Mutex::new(None)),
-        };
+        let mut state = crate::test_helpers::make_test_execution_state(cp_for_state, run_id);
+        state.action_registry = Arc::new(registry);
 
         let node = ParallelNode {
             fail_fast: false,

--- a/runkon-flow/src/executors/parallel.rs
+++ b/runkon-flow/src/executors/parallel.rs
@@ -249,18 +249,36 @@ pub fn execute_parallel(
     drop(completion_tx);
 
     // Collect results as threads complete, triggering fail_fast cancellation as needed.
+    // The timeout-based recv lets us tick the heartbeat and poll for cross-process
+    // cancellation while waiting on long-running agents — without it the engine
+    // sits silent here for the full duration of the slowest branch and the
+    // watchdog reaper races us after >60 s. #2731.
     let mut results: Vec<ParallelCallResult> = Vec::new();
-    for (step_id, agent_name, agent_step_key, result) in completion_rx {
-        let failed = result.is_err();
-        results.push(ParallelCallResult {
-            agent_name,
-            step_id,
-            agent_step_key,
-            result,
-            attempt: 0,
-        });
-        if failed && node.fail_fast {
-            scope_token.cancel(CancellationReason::FailFast);
+    loop {
+        match completion_rx.recv_timeout(std::time::Duration::from_millis(500)) {
+            Ok((step_id, agent_name, agent_step_key, result)) => {
+                let failed = result.is_err();
+                results.push(ParallelCallResult {
+                    agent_name,
+                    step_id,
+                    agent_step_key,
+                    result,
+                    attempt: 0,
+                });
+                if failed && node.fail_fast {
+                    scope_token.cancel(CancellationReason::FailFast);
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                // Tick heartbeat + check for external cancel. Best-effort: on
+                // external cancel, propagate to scope_token so worker threads
+                // see it via their pre-dispatch check; keep draining the rest
+                // of the channel so in-flight workers' results land in `results`.
+                if state.tick_heartbeat_throttled().is_err() {
+                    scope_token.cancel(CancellationReason::UserRequested(None));
+                }
+            }
         }
     }
 
@@ -788,6 +806,129 @@ mod tests {
         assert!(
             !state.all_succeeded,
             "all_succeeded should be false when fail_fast fires"
+        );
+    }
+
+    /// Regression for #2731: the parallel wait loop must keep `tick_heartbeat`
+    /// firing while children are running. Prior to the fix, the wait loop was
+    /// `for ... in completion_rx { ... }` — blocking on the receiver for the
+    /// whole duration of the slowest branch — so `last_heartbeat` went stale
+    /// and the watchdog reaper claimed the run after >60 s, double-running it.
+    #[test]
+    fn parallel_wait_loop_ticks_heartbeat_during_long_branches() {
+        struct SleepingExecutor;
+        impl ActionExecutor for SleepingExecutor {
+            fn name(&self) -> &str {
+                "sleeping_exec"
+            }
+            fn execute(
+                &self,
+                _ectx: &crate::traits::action_executor::ExecutionContext,
+                _params: &ActionParams,
+            ) -> std::result::Result<ActionOutput, EngineError> {
+                // Long enough to trigger several recv_timeout (500 ms) iterations
+                // in the wait loop so the heartbeat tick has a chance to fire.
+                std::thread::sleep(std::time::Duration::from_millis(1300));
+                Ok(ActionOutput {
+                    cost_usd: Some(0.0),
+                    ..Default::default()
+                })
+            }
+        }
+
+        let mut named: HashMap<String, Box<dyn ActionExecutor>> = HashMap::new();
+        named.insert(
+            "sleeping_exec".to_string(),
+            Box::new(SleepingExecutor) as Box<dyn ActionExecutor>,
+        );
+        let registry = crate::traits::action_executor::ActionRegistry::new(named, None);
+
+        let cp = Arc::new(crate::test_helpers::CountingPersistence::new());
+        let run_id = cp
+            .create_run(crate::traits::persistence::NewRun {
+                workflow_name: "wf".to_string(),
+                worktree_id: None,
+                ticket_id: None,
+                repo_id: None,
+                parent_run_id: String::new(),
+                dry_run: false,
+                trigger: "manual".to_string(),
+                definition_snapshot: None,
+                parent_workflow_run_id: None,
+                target_label: None,
+            })
+            .unwrap()
+            .id;
+        let cp_for_state: Arc<dyn WorkflowPersistence> = Arc::clone(&cp) as _;
+
+        let mut state = ExecutionState {
+            persistence: cp_for_state,
+            action_registry: Arc::new(registry),
+            script_env_provider: Arc::new(NoOpScriptEnvProvider),
+            workflow_run_id: run_id,
+            workflow_name: "wf".into(),
+            worktree_ctx: WorktreeContext {
+                worktree_id: None,
+                working_dir: String::new(),
+                repo_path: String::new(),
+                ticket_id: None,
+                repo_id: None,
+                extra_plugin_dirs: vec![],
+            },
+            model: None,
+            exec_config: WorkflowExecConfig::default(),
+            inputs: HashMap::new(),
+            parent_run_id: String::new(),
+            depth: 0,
+            target_label: None,
+            step_results: HashMap::new(),
+            contexts: vec![],
+            position: 0,
+            all_succeeded: true,
+            total_cost: 0.0,
+            total_turns: 0,
+            total_duration_ms: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_read_input_tokens: 0,
+            total_cache_creation_input_tokens: 0,
+            last_gate_feedback: None,
+            block_output: None,
+            block_with: vec![],
+            resume_ctx: None,
+            default_bot_name: None,
+            triggered_by_hook: false,
+            schema_resolver: None,
+            child_runner: None,
+            last_heartbeat_at: ExecutionState::new_heartbeat(),
+            registry: Arc::new(ItemProviderRegistry::new()),
+            event_sinks: Arc::from(vec![]),
+            cancellation: crate::cancellation::CancellationToken::new(),
+            current_execution_id: Arc::new(std::sync::Mutex::new(None)),
+        };
+
+        let node = ParallelNode {
+            fail_fast: false,
+            min_success: None,
+            calls: vec![AgentRef::Name("sleeping_exec".to_string())],
+            output: None,
+            call_outputs: HashMap::new(),
+            with: vec![],
+            call_with: HashMap::new(),
+            call_if: HashMap::new(),
+        };
+
+        execute_parallel(&mut state, &node, 0).unwrap();
+
+        // last_heartbeat_at starts at 0 → first recv_timeout iteration's
+        // tick_heartbeat_throttled() fires immediately. With a 1300 ms sleep
+        // and 500 ms recv_timeout, expect at least one Timeout iteration → ≥1 tick.
+        assert!(
+            cp.tick_count() >= 1,
+            "expected ≥1 heartbeat tick during parallel wait loop, got {}; \
+             without #2731 fix this would be 0 because the receiver blocks \
+             for the whole duration of the slowest branch.",
+            cp.tick_count()
         );
     }
 }

--- a/runkon-flow/src/test_helpers.rs
+++ b/runkon-flow/src/test_helpers.rs
@@ -97,3 +97,170 @@ pub fn call_node(agent: &str) -> WorkflowNode {
         timeout: None,
     })
 }
+
+/// `WorkflowPersistence` decorator that delegates to `InMemoryWorkflowPersistence`
+/// and counts every call to `tick_heartbeat`. Also lets tests force
+/// `is_run_cancelled` to return true at will.
+///
+/// Built for the regression coverage in #2731: wait loops in `parallel` and
+/// `foreach` must keep `tick_heartbeat` firing while children are running so
+/// the watchdog reaper does not race the engine.
+pub struct CountingPersistence {
+    inner: crate::persistence_memory::InMemoryWorkflowPersistence,
+    tick_count: std::sync::atomic::AtomicUsize,
+    cancelled: std::sync::atomic::AtomicBool,
+}
+
+impl Default for CountingPersistence {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CountingPersistence {
+    pub fn new() -> Self {
+        Self {
+            inner: crate::persistence_memory::InMemoryWorkflowPersistence::new(),
+            tick_count: std::sync::atomic::AtomicUsize::new(0),
+            cancelled: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+    pub fn tick_count(&self) -> usize {
+        self.tick_count.load(std::sync::atomic::Ordering::Relaxed)
+    }
+    pub fn set_cancelled(&self, v: bool) {
+        self.cancelled
+            .store(v, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+impl crate::traits::persistence::WorkflowPersistence for CountingPersistence {
+    fn is_run_cancelled(&self, run_id: &str) -> Result<bool, crate::engine_error::EngineError> {
+        if self.cancelled.load(std::sync::atomic::Ordering::Relaxed) {
+            return Ok(true);
+        }
+        self.inner.is_run_cancelled(run_id)
+    }
+    fn tick_heartbeat(&self, run_id: &str) -> Result<(), crate::engine_error::EngineError> {
+        self.tick_count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.inner.tick_heartbeat(run_id)
+    }
+    fn create_run(
+        &self,
+        r: crate::traits::persistence::NewRun,
+    ) -> Result<crate::types::WorkflowRun, crate::engine_error::EngineError> {
+        self.inner.create_run(r)
+    }
+    fn get_run(
+        &self,
+        id: &str,
+    ) -> Result<Option<crate::types::WorkflowRun>, crate::engine_error::EngineError> {
+        self.inner.get_run(id)
+    }
+    fn list_active_runs(
+        &self,
+        s: &[crate::status::WorkflowRunStatus],
+    ) -> Result<Vec<crate::types::WorkflowRun>, crate::engine_error::EngineError> {
+        self.inner.list_active_runs(s)
+    }
+    fn update_run_status(
+        &self,
+        id: &str,
+        s: crate::status::WorkflowRunStatus,
+        result_summary: Option<&str>,
+        err: Option<&str>,
+    ) -> Result<(), crate::engine_error::EngineError> {
+        self.inner.update_run_status(id, s, result_summary, err)
+    }
+    fn insert_step(
+        &self,
+        s: crate::traits::persistence::NewStep,
+    ) -> Result<String, crate::engine_error::EngineError> {
+        self.inner.insert_step(s)
+    }
+    fn update_step(
+        &self,
+        id: &str,
+        u: crate::traits::persistence::StepUpdate,
+    ) -> Result<(), crate::engine_error::EngineError> {
+        self.inner.update_step(id, u)
+    }
+    fn get_steps(
+        &self,
+        run_id: &str,
+    ) -> Result<Vec<crate::types::WorkflowRunStep>, crate::engine_error::EngineError> {
+        self.inner.get_steps(run_id)
+    }
+    fn insert_fan_out_item(
+        &self,
+        step_run_id: &str,
+        item_type: &str,
+        item_id: &str,
+        item_ref: &str,
+    ) -> Result<String, crate::engine_error::EngineError> {
+        self.inner
+            .insert_fan_out_item(step_run_id, item_type, item_id, item_ref)
+    }
+    fn update_fan_out_item(
+        &self,
+        id: &str,
+        u: crate::traits::persistence::FanOutItemUpdate,
+    ) -> Result<(), crate::engine_error::EngineError> {
+        self.inner.update_fan_out_item(id, u)
+    }
+    fn get_fan_out_items(
+        &self,
+        step_run_id: &str,
+        f: Option<crate::traits::persistence::FanOutItemStatus>,
+    ) -> Result<Vec<crate::types::FanOutItemRow>, crate::engine_error::EngineError> {
+        self.inner.get_fan_out_items(step_run_id, f)
+    }
+    fn get_gate_approval(
+        &self,
+        step_id: &str,
+    ) -> Result<crate::traits::persistence::GateApprovalState, crate::engine_error::EngineError>
+    {
+        self.inner.get_gate_approval(step_id)
+    }
+    fn approve_gate(
+        &self,
+        step_id: &str,
+        approved_by: &str,
+        feedback: Option<&str>,
+        selections: Option<&[String]>,
+    ) -> Result<(), crate::engine_error::EngineError> {
+        self.inner
+            .approve_gate(step_id, approved_by, feedback, selections)
+    }
+    fn reject_gate(
+        &self,
+        step_id: &str,
+        rejected_by: &str,
+        feedback: Option<&str>,
+    ) -> Result<(), crate::engine_error::EngineError> {
+        self.inner.reject_gate(step_id, rejected_by, feedback)
+    }
+    fn persist_metrics(
+        &self,
+        run_id: &str,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_input_tokens: i64,
+        cache_creation_input_tokens: i64,
+        cost_usd: f64,
+        num_turns: i64,
+        duration_ms: i64,
+    ) -> Result<(), crate::engine_error::EngineError> {
+        self.inner.persist_metrics(
+            run_id,
+            input_tokens,
+            output_tokens,
+            cache_read_input_tokens,
+            cache_creation_input_tokens,
+            cost_usd,
+            num_turns,
+            duration_ms,
+        )
+    }
+}

--- a/runkon-flow/src/test_helpers.rs
+++ b/runkon-flow/src/test_helpers.rs
@@ -98,6 +98,69 @@ pub fn call_node(agent: &str) -> WorkflowNode {
     })
 }
 
+/// Build a minimal `ExecutionState` for tests — empty-ish defaults across all
+/// the fields tests don't usually care about. Caller passes the persistence and
+/// a `workflow_run_id` (the two fields nearly every test customizes); other
+/// fields can be overridden after construction since `ExecutionState`'s fields
+/// are `pub`.
+pub fn make_test_execution_state(
+    persistence: Arc<dyn crate::traits::persistence::WorkflowPersistence>,
+    workflow_run_id: String,
+) -> crate::engine::ExecutionState {
+    use crate::cancellation::CancellationToken;
+    use crate::engine::{ExecutionState, WorktreeContext};
+    use crate::traits::action_executor::ActionRegistry;
+    use crate::traits::item_provider::ItemProviderRegistry;
+    use crate::traits::script_env_provider::NoOpScriptEnvProvider;
+    use crate::types::WorkflowExecConfig;
+
+    ExecutionState {
+        persistence,
+        action_registry: Arc::new(ActionRegistry::new(HashMap::new(), None)),
+        script_env_provider: Arc::new(NoOpScriptEnvProvider),
+        workflow_run_id,
+        workflow_name: "wf".into(),
+        worktree_ctx: WorktreeContext {
+            worktree_id: None,
+            working_dir: String::new(),
+            repo_path: String::new(),
+            ticket_id: None,
+            repo_id: None,
+            extra_plugin_dirs: vec![],
+        },
+        model: None,
+        exec_config: WorkflowExecConfig::default(),
+        inputs: HashMap::new(),
+        parent_run_id: String::new(),
+        depth: 0,
+        target_label: None,
+        step_results: HashMap::new(),
+        contexts: vec![],
+        position: 0,
+        all_succeeded: true,
+        total_cost: 0.0,
+        total_turns: 0,
+        total_duration_ms: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cache_read_input_tokens: 0,
+        total_cache_creation_input_tokens: 0,
+        last_gate_feedback: None,
+        block_output: None,
+        block_with: vec![],
+        resume_ctx: None,
+        default_bot_name: None,
+        triggered_by_hook: false,
+        schema_resolver: None,
+        child_runner: None,
+        last_heartbeat_at: ExecutionState::new_heartbeat(),
+        registry: Arc::new(ItemProviderRegistry::new()),
+        event_sinks: Arc::from(vec![]),
+        cancellation: CancellationToken::new(),
+        current_execution_id: Arc::new(Mutex::new(None)),
+    }
+}
+
 /// `WorkflowPersistence` decorator that delegates to `InMemoryWorkflowPersistence`
 /// and counts every call to `tick_heartbeat`. Also lets tests force
 /// `is_run_cancelled` to return true at will.


### PR DESCRIPTION
## Bug

The watchdog reaper (`claim_heartbeat_stuck_runs`) races the engine after >60 s when a parallel block or foreach fan-out has no in-flight steps but children are still running. The query:

\`\`\`sql
WHERE status = 'running'
  AND parent_workflow_run_id IS NULL
  AND NOT EXISTS (... wrs.status IN ('running','pending','waiting') )
  AND (now - last_heartbeat) > 60
\`\`\`

…matches whenever the last step row settled but the run hasn't finished. `last_heartbeat` only got updated at step boundaries, so a multi-minute parallel block with the children's step rows already `completed` looked stale. The reaper claimed the run, spawned a resume, and ran the rest of the workflow alongside the original engine — duplicate step rows, duplicate agent runs (= duplicate Claude cost), and duplicate side effects (e.g. PR reviews posted twice on workflow run \`01KQDYX89400WDGH7B5704V2EV\`).

## Fix

Extract the throttled heartbeat-and-cancel block from `execute_nodes` into `ExecutionState::tick_heartbeat_throttled()` and call it from both wait loops.

**foreach.rs:** existing 50 ms `recv_timeout` loop gets `let _ = state.tick_heartbeat_throttled();` at the top. The helper sets `state.cancellation` on external cancel; the existing `is_cancelled()` check at line 472 drives the controlled drain — no early-return needed.

**parallel.rs:** convert `for ... in completion_rx` → `loop { recv_timeout(500 ms) }`:
- On `Ok` → process result, mirror fail_fast as before
- On `Timeout` → tick; on external cancel, propagate to `scope_token` (same shape as fail_fast) and keep draining
- On `Disconnected` → break

Helper preserves the engine main loop's exact early-return-on-cancel semantics via `?` propagation. Throttle (5 s) and TTL (60 s) keep ample margin against the watchdog threshold even on slow machines.

## Tests

- **Helper unit tests** (`engine.rs::tests`): first call ticks, immediate second call is throttled; external cancel sets `state.cancellation` and returns `Err(Cancelled)`.
- **parallel integration test**: `SleepingExecutor` sleeps 1300 ms, asserts ≥1 tick during the wait. **Bidirectional verification** — disabling the helper call in parallel.rs causes the test to fail.
- **foreach integration test**: `SleepingChildRunner` sleeps 800 ms, asserts ≥1 tick during the wait. Same bidirectional check.
- New `CountingPersistence` helper in `test_helpers.rs` — wraps `InMemoryWorkflowPersistence` and counts `tick_heartbeat` calls.

## Test plan

- [x] `cargo test -p runkon-flow --features test-utils` → 233 lib + 38 integ. (3 new tests; 0 regressions)
- [x] `cargo test -p conductor-core --lib` → 1928 passed
- [x] `cargo clippy --all-targets -F test-utils -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean

Closes #2731. Complementary to #2732 (lease-based ownership, the long-term structural fix that closes the entire race class — heartbeat refresh stays the right thing for the engine to do regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)