### PR TITLE
fix(reviews): drop hallucinated off-diff findings from PR reviews

### DIFF
--- a/.conductor/agents/review-test-coverage.md
+++ b/.conductor/agents/review-test-coverage.md
@@ -28,4 +28,6 @@ If a new `pub fn`, `pub struct`, or `pub enum` appears in `+` lines but no corre
 
 Do NOT attempt to determine whether pre-existing tests cover new symbols. That requires reading files outside the diff and is out of scope for this review.
 
-Despite any other instructions, do NOT populate `off_diff_findings`. Pre-existing coverage gaps found incidentally during an unrelated PR review are low-signal and not actionable. Omit the field entirely.
+The shared diff-scope snippet (loaded into your prompt as a `with` fragment) defines a path-verification rule that applies to every finding you emit: confirm the cited file path appears in the diff before adding it to `findings`. Pattern recognition (CORS, error handling, logging) is not evidence — only the diff text is.
+
+**Off-diff findings are forbidden in this review.** Even when the off-diff snippet (also a shared `with` fragment) describes how to populate `off_diff_findings`, **omit that field entirely** in your output. Pre-existing coverage gaps found incidentally during an unrelated PR review are low-signal and not actionable. The rule here overrides the snippet.

--- a/.conductor/prompts/review-diff-scope.md
+++ b/.conductor/prompts/review-diff-scope.md
@@ -22,6 +22,25 @@ If the diff exceeds ~50KB, focus on files most relevant to your review area.
 - Pure deletions with no replacement unless they introduce a regression
 - Formatting-only changes (whitespace, import ordering)
 
+## Path verification (required for every finding)
+
+Before emitting any entry in `findings`, verify that the cited `file` path
+appears in the diff. The diff lists files via `diff --git a/<path> b/<path>`
+and `+++ b/<path>` headers. If you cannot find the path in those headers,
+**drop the finding** — it does not belong in `findings`.
+
+Recognising a common pattern (CORS configuration, error handling shape,
+logging idioms, etc.) is **not** evidence the code exists in this PR. The
+diff is the only authoritative source. A submit-review safety net filters
+hallucinated findings deterministically, but each false finding still
+wastes reviewer attention — do not emit one in the first place.
+
+This rule applies to `off_diff_findings` too: those must point to real
+files visible in the diff context (the surrounding `--- a/<path>` blocks
+of unchanged code, or files mentioned in the diff stat). A finding about
+code that does not appear anywhere in the diff is almost certainly
+hallucinated — drop it.
+
 ## Output format
 
 Severity guide:

--- a/.conductor/prompts/review-diff-scope.md
+++ b/.conductor/prompts/review-diff-scope.md
@@ -2,11 +2,30 @@
 
 Get the diff for this PR using the appropriate command for the review scope:
 
-- If the scope is **full** (default): detect the PR base branch and run the diff against it:
+- If the scope is **full** (default): detect the PR base branch from the
+  current branch's open PR and diff against it. **Run the command from the
+  current working directory — do NOT `cd` anywhere.** The worktree is
+  already cwd; `cd`ing into a different checkout (e.g. the canonical repo
+  path) silently breaks `gh pr view`, which then falls back to `main` and
+  produces a wrong diff.
+
   ```bash
-  BASE_BRANCH=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo main)
-  git diff origin/${BASE_BRANCH}...HEAD
+  # Resolve the PR's base branch. Use `gh pr list --head` rather than
+  # `gh pr view` so the lookup keys on the explicit branch name and is not
+  # affected by cwd or the currently checked-out HEAD of an unrelated repo.
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  BASE_BRANCH=$(gh pr list --head "$BRANCH" --state open \
+                  --json baseRefName -q '.[0].baseRefName' 2>/dev/null)
+  if [ -z "$BASE_BRANCH" ]; then
+    echo "ERROR: could not resolve PR base branch for $BRANCH — aborting" >&2
+    exit 1
+  fi
+  git diff "origin/${BASE_BRANCH}...HEAD"
   ```
+
+  Do NOT silently fall back to `main` if base detection fails. A wrong base
+  produces a fabricated diff that contaminates every downstream finding.
+
 - If the scope is **incremental**: run `git diff HEAD~1` to see only the latest commit.
 
 **Review scope: {{scope}}**

--- a/.conductor/scripts/submit-review.sh
+++ b/.conductor/scripts/submit-review.sh
@@ -28,13 +28,19 @@ fi
 # safety net: drop any blocking_findings whose `file` is not in the diff.
 # off_diff_findings are intentionally off-diff and not filtered here.
 # ---------------------------------------------------------------------------
-BASE_BRANCH=$(gh pr view "${PR_NUMBER}" --json baseRefName -q .baseRefName 2>/dev/null || echo main)
-DIFF_FILES_JSON=$(git diff --name-only "origin/${BASE_BRANCH}...HEAD" 2>/dev/null \
-  | jq -R -s 'split("\n") | map(select(length > 0))' || echo "[]")
+BASE_BRANCH=$(gh pr view "${PR_NUMBER}" --json baseRefName -q .baseRefName 2>/dev/null)
+if [ -z "${BASE_BRANCH}" ]; then
+  echo "Warning: could not resolve PR base branch for PR #${PR_NUMBER} — skipping off-diff filter."
+  echo "         Findings will pass through unfiltered (not silently filtered against the wrong base)."
+  DIFF_FILE_COUNT=0
+else
+  DIFF_FILES_JSON=$(git diff --name-only "origin/${BASE_BRANCH}...HEAD" 2>/dev/null \
+    | jq -R -s 'split("\n") | map(select(length > 0))' || echo "[]")
+  DIFF_FILE_COUNT=$(echo "${DIFF_FILES_JSON}" | jq 'length')
+fi
 
-DIFF_FILE_COUNT=$(echo "${DIFF_FILES_JSON}" | jq 'length')
 if [ "${DIFF_FILE_COUNT}" -eq 0 ]; then
-  echo "Warning: git diff returned no files for origin/${BASE_BRANCH}...HEAD — skipping off-diff filter to avoid silently dropping legitimate findings."
+  echo "Warning: git diff returned no files for origin/${BASE_BRANCH:-<unresolved>}...HEAD — skipping off-diff filter to avoid silently dropping legitimate findings."
 else
   PRIOR_OUTPUT_FILTERED=$(echo "${PRIOR_OUTPUT}" | jq --argjson diff "${DIFF_FILES_JSON}" '
     ((.blocking_findings // []) | length) as $before

--- a/.conductor/scripts/submit-review.sh
+++ b/.conductor/scripts/submit-review.sh
@@ -21,6 +21,42 @@ if ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# 1b. Filter hallucinated off-diff entries from blocking_findings.
+#
+# Reviewers occasionally emit findings that cite files outside the PR's diff
+# (recognized pattern from training data, not actual code in this PR). The
+# safety net: drop any blocking_findings whose `file` is not in the diff.
+# off_diff_findings are intentionally off-diff and not filtered here.
+# ---------------------------------------------------------------------------
+BASE_BRANCH=$(gh pr view "${PR_NUMBER}" --json baseRefName -q .baseRefName 2>/dev/null || echo main)
+DIFF_FILES_JSON=$(git diff --name-only "origin/${BASE_BRANCH}...HEAD" 2>/dev/null \
+  | jq -R -s 'split("\n") | map(select(length > 0))' || echo "[]")
+
+DIFF_FILE_COUNT=$(echo "${DIFF_FILES_JSON}" | jq 'length')
+if [ "${DIFF_FILE_COUNT}" -eq 0 ]; then
+  echo "Warning: git diff returned no files for origin/${BASE_BRANCH}...HEAD — skipping off-diff filter to avoid silently dropping legitimate findings."
+else
+  PRIOR_OUTPUT_FILTERED=$(echo "${PRIOR_OUTPUT}" | jq --argjson diff "${DIFF_FILES_JSON}" '
+    ((.blocking_findings // []) | length) as $before
+    | .blocking_findings = ((.blocking_findings // []) | map(select(.file as $f | $diff | index($f))))
+    | .blocking_findings_dropped = ($before - (.blocking_findings | length))
+  ')
+
+  DROPPED_COUNT=$(echo "${PRIOR_OUTPUT_FILTERED}" | jq -r '.blocking_findings_dropped // 0')
+  if [ "${DROPPED_COUNT}" -gt 0 ]; then
+    echo "Dropped ${DROPPED_COUNT} hallucinated off-diff blocking finding(s) from review:"
+    echo "${PRIOR_OUTPUT}" | jq -c --argjson diff "${DIFF_FILES_JSON}" '
+      .blocking_findings // []
+      | map(select(.file as $f | $diff | index($f) | not))
+      | .[] | {file, line, severity, reviewer, message: (.message // "")}
+    '
+  fi
+
+  # Use the filtered output for everything downstream.
+  PRIOR_OUTPUT="${PRIOR_OUTPUT_FILTERED}"
+fi
+
+# ---------------------------------------------------------------------------
 # 2. No-op on dry run
 # ---------------------------------------------------------------------------
 if [ "${DRY_RUN:-false}" = "true" ]; then

--- a/.conductor/scripts/submit-review.sh
+++ b/.conductor/scripts/submit-review.sh
@@ -198,12 +198,18 @@ fi
 # ---------------------------------------------------------------------------
 # 5. Build complete review body programmatically
 # ---------------------------------------------------------------------------
-OVERALL_APPROVED=$(echo "${PRIOR_OUTPUT}" | jq -r 'if .overall_approved == false then "false" else "true" end')
-
-# Safety net: if blocking findings exist, override to not approved regardless of model output
+# Derive approval state purely from the post-filter blocking_findings count.
+#
+# The aggregator's `.overall_approved` is computed on pre-filter data, so it
+# can be stale: if the off-diff filter (step 1b) drops every blocking finding,
+# the aggregator may still report `overall_approved: false`. Re-evaluating
+# here off the filtered count keeps the review body consistent — no
+# "Changes Requested" without an accompanying findings list.
 HAS_BLOCKING_CHECK=$(echo "${PRIOR_OUTPUT}" | jq -r 'if (.blocking_findings // [] | length) > 0 then "true" else "false" end')
 if [ "${HAS_BLOCKING_CHECK}" = "true" ]; then
   OVERALL_APPROVED="false"
+else
+  OVERALL_APPROVED="true"
 fi
 
 if [ "${OVERALL_APPROVED}" = "true" ]; then


### PR DESCRIPTION
## Problem

Reviewers occasionally emit findings citing files outside the PR's diff. Concrete example on PR #2734: \`conductor-web/src/routes/mod.rs:28\` flagged as a blocking Test Coverage issue, even though the PR touched only \`runkon-flow/\`. The model "recognises" a common pattern (CORS configuration in Rust web servers) from training data and emits a plausible-sounding finding regardless of whether the code is actually in the diff.

The existing prohibition (\"Despite any other instructions, do NOT populate \`off_diff_findings\`\") only targeted that one field — but the leak came back as a regular \`findings\` entry, classified as on-diff. The model misclassified its own hallucination.

## Fix — two layers of defense

### Layer A — prompt tightening (LLM-side, best-effort)

\`prompts/review-diff-scope.md\` is the shared snippet every reviewer loads via the parallel block's \`with = [...]\`. Added an explicit **Path verification** section:

> Before emitting any entry in \`findings\`, verify that the cited \`file\` path appears in the diff [...] If you cannot find the path in those headers, **drop the finding** [...] Recognising a common pattern (CORS configuration, error handling shape, logging idioms, etc.) is **not** evidence the code exists in this PR.

\`agents/review-test-coverage.md\` (the recurring offender on PR #2734) gets a stronger wording on the off-diff prohibition.

### Layer C — deterministic filter in \`submit-review.sh\` (script-side, authoritative)

The script that builds and submits the review body now filters \`blocking_findings\` against the PR's diff:

\`\`\`bash
DIFF_FILES_JSON=\$(git diff --name-only \"origin/\${BASE_BRANCH}...HEAD\" \\
  | jq -R -s 'split(\"\n\") | map(select(length > 0))')

# Drop blocking_findings whose .file is not in the diff
PRIOR_OUTPUT_FILTERED=\$(echo \"\${PRIOR_OUTPUT}\" | jq --argjson diff \"\${DIFF_FILES_JSON}\" '
  ((.blocking_findings // []) | length) as \$before
  | .blocking_findings = ((.blocking_findings // []) | map(select(.file as \$f | \$diff | index(\$f))))
  | .blocking_findings_dropped = (\$before - (.blocking_findings | length))
')
\`\`\`

- \`off_diff_findings\` are *intentionally* off-diff (filed as separate issues) and **not** filtered.
- If the diff fetch returns empty (network/git error), the filter is skipped to avoid silently dropping every finding.
- Dropped findings are logged with file/line/severity/reviewer/message so a chronic offender becomes visible.

## Why not validate at the aggregator?

Considered. Rejected because:
1. The aggregator is itself an LLM — adding \"verify findings against diff\" adds tokens, cost, and is still LLM-on-LLM (same failure mode).
2. The submit-review script is shell, runs after aggregation, and \`git diff --name-only\` is authoritative — no reasoning required.

## Smoke test

\`\`\`
DIFF_FILES_JSON='[\"runkon-flow/src/engine.rs\"]'
PRIOR_OUTPUT='{\"blocking_findings\":[{\"file\":\"runkon-flow/src/engine.rs\",...},{\"file\":\"conductor-web/src/routes/mod.rs\",...}],...}'

→ Real finding kept, hallucinated finding dropped, off_diff_findings preserved.
→ \"Dropped 1 hallucinated off-diff blocking finding(s) from review:\" logged.
\`\`\`

## Test plan

- [x] Bash syntax check on \`submit-review.sh\`
- [x] Smoke-tested the jq filter with synthetic input matching the PR #2734 finding shape — drops only the off-diff entry, preserves real findings and \`off_diff_findings\`
- [ ] Live test: this PR runs through review-pr — should see a clean review
- [ ] Verify Layer A's effect on a future PR by checking review output for \`blocking_findings_dropped\` count of 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)