### PR TITLE
feat(workflow): inject resolved PR base branch as {{base_branch}} (#2736)

### DIFF
--- a/.conductor/prompts/review-diff-scope.md
+++ b/.conductor/prompts/review-diff-scope.md
@@ -2,29 +2,14 @@
 
 Get the diff for this PR using the appropriate command for the review scope:
 
-- If the scope is **full** (default): detect the PR base branch from the
-  current branch's open PR and diff against it. **Run the command from the
-  current working directory — do NOT `cd` anywhere.** The worktree is
-  already cwd; `cd`ing into a different checkout (e.g. the canonical repo
-  path) silently breaks `gh pr view`, which then falls back to `main` and
-  produces a wrong diff.
+- If the scope is **full** (default): the PR's base branch has already been
+  resolved by the workflow's `resolve-pr-base` step and is injected as
+  `{{base_branch}}`. Use it literally — do not run `gh pr view` or compute
+  the base yourself.
 
   ```bash
-  # Resolve the PR's base branch. Use `gh pr list --head` rather than
-  # `gh pr view` so the lookup keys on the explicit branch name and is not
-  # affected by cwd or the currently checked-out HEAD of an unrelated repo.
-  BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  BASE_BRANCH=$(gh pr list --head "$BRANCH" --state open \
-                  --json baseRefName -q '.[0].baseRefName' 2>/dev/null)
-  if [ -z "$BASE_BRANCH" ]; then
-    echo "ERROR: could not resolve PR base branch for $BRANCH — aborting" >&2
-    exit 1
-  fi
-  git diff "origin/${BASE_BRANCH}...HEAD"
+  git diff "origin/{{base_branch}}...HEAD"
   ```
-
-  Do NOT silently fall back to `main` if base detection fails. A wrong base
-  produces a fabricated diff that contaminates every downstream finding.
 
 - If the scope is **incremental**: run `git diff HEAD~1` to see only the latest commit.
 

--- a/.conductor/scripts/detect-db-migrations.sh
+++ b/.conductor/scripts/detect-db-migrations.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Get the PR's actual base branch (falls back to main for non-PR contexts)
-base_branch=$(gh pr view --json baseRefName -q '.baseRefName' 2>/dev/null || echo "main")
+# BASE_BRANCH is injected by the workflow from the resolve-pr-base step.
+# We refuse to silently fall back to a guess — a wrong base produces a
+# fabricated diff that contaminates the downstream review. See #2736.
+if [ -z "${BASE_BRANCH:-}" ]; then
+  echo "ERROR: BASE_BRANCH env var not set — workflow must run resolve-pr-base first." >&2
+  exit 1
+fi
 
 # Get changed files relative to the PR base branch
-changed_files=$(git diff "origin/${base_branch}...HEAD" --name-only 2>/dev/null || true)
+changed_files=$(git diff "origin/${BASE_BRANCH}...HEAD" --name-only 2>/dev/null || true)
 
 # Filter for migration files
 migration_files=()

--- a/.conductor/scripts/detect-file-types.sh
+++ b/.conductor/scripts/detect-file-types.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Get changed files relative to PR base branch
-BASE_BRANCH=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo main)
-changed_files=$(git diff origin/${BASE_BRANCH}...HEAD --name-only 2>/dev/null || true)
+# BASE_BRANCH is injected by the workflow from the resolve-pr-base step.
+# We refuse to silently fall back to a guess — a wrong base produces a
+# fabricated diff that contaminates every conditional reviewer. See #2736.
+if [ -z "${BASE_BRANCH:-}" ]; then
+  echo "ERROR: BASE_BRANCH env var not set — workflow must run resolve-pr-base first." >&2
+  exit 1
+fi
+
+changed_files=$(git diff "origin/${BASE_BRANCH}...HEAD" --name-only 2>/dev/null || true)
 
 # Filter for code files, excluding .conductor/, docs/, .github/, and root-level *.md
 code_files=()

--- a/.conductor/scripts/resolve-pr-base.sh
+++ b/.conductor/scripts/resolve-pr-base.sh
@@ -30,8 +30,11 @@ if [ -z "${BASE_BRANCH}" ]; then
   exit 1
 fi
 
-cat <<EOF
-<<<FLOW_OUTPUT>>>
-{"markers": ["base_branch_resolved"], "context": "${BASE_BRANCH}", "base_branch": "${BASE_BRANCH}"}
-<<<END_FLOW_OUTPUT>>>
-EOF
+# Build the FLOW_OUTPUT JSON via `jq -n --arg` so any quotes / backslashes /
+# control chars in BASE_BRANCH are encoded safely. String interpolation here
+# would let a crafted branch name (e.g. one containing `\` or `"`) inject
+# extra keys into the parsed FlowOutput.
+PAYLOAD=$(jq -nc --arg base "${BASE_BRANCH}" \
+  '{markers: ["base_branch_resolved"], context: $base, base_branch: $base}')
+
+printf '<<<FLOW_OUTPUT>>>\n%s\n<<<END_FLOW_OUTPUT>>>\n' "${PAYLOAD}"

--- a/.conductor/scripts/resolve-pr-base.sh
+++ b/.conductor/scripts/resolve-pr-base.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# resolve-pr-base.sh — resolve the PR's base branch ONCE per workflow run and
+# expose it to downstream steps via the engine's variable substitution layer.
+#
+# Emits a FLOW_OUTPUT block whose `base_branch` field is picked up by
+# runkon-flow/src/prompt_builder.rs::build_variable_map and exposed as
+# `{{base_branch}}` in subsequent step prompts and env-var bindings.
+#
+# Why this exists: reviewer agents running `gh pr view` from inside their own
+# subprocess routinely cd into a different repo path before the lookup. From
+# the wrong cwd, `gh pr view` returns nothing and the silent `|| echo main`
+# fallback fabricates a diff against `main`. See #2731 / #2735 / #2736.
+set -euo pipefail
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ -z "${BRANCH}" ] || [ "${BRANCH}" = "HEAD" ]; then
+  echo "ERROR: not on a named branch (got '${BRANCH}') — cannot resolve PR base." >&2
+  exit 1
+fi
+
+# `gh pr list --head <branch>` keys on the explicit branch name and is not
+# affected by cwd or the currently checked-out HEAD of an unrelated repo.
+BASE_BRANCH=$(gh pr list --head "${BRANCH}" --state open \
+                --json baseRefName -q '.[0].baseRefName' 2>/dev/null || true)
+
+if [ -z "${BASE_BRANCH}" ]; then
+  echo "ERROR: could not resolve PR base branch for branch '${BRANCH}'." >&2
+  echo "       Aborting rather than falling back to 'main' silently — a wrong" >&2
+  echo "       base produces a fabricated diff that contaminates every reviewer." >&2
+  exit 1
+fi
+
+cat <<EOF
+<<<FLOW_OUTPUT>>>
+{"markers": ["base_branch_resolved"], "context": "${BASE_BRANCH}", "base_branch": "${BASE_BRANCH}"}
+<<<END_FLOW_OUTPUT>>>
+EOF

--- a/.conductor/workflows/review-pr.wf
+++ b/.conductor/workflows/review-pr.wf
@@ -11,11 +11,24 @@ workflow review-pr {
     scope default = "full"
   }
 
+  // Resolve the PR's base branch once at workflow start. Exposes it to all
+  // downstream steps as {{base_branch}} via the engine's variable map.
+  // Without this, reviewer agents and detect-* scripts each run their own
+  // `gh pr view` and the silent fallback to `main` corrupts the diff. #2736.
+  script resolve-pr-base {
+    run = ".conductor/scripts/resolve-pr-base.sh"
+  }
   script detect-db-migrations {
     run = ".conductor/scripts/detect-db-migrations.sh"
+    env = {
+      BASE_BRANCH = "{{base_branch}}"
+    }
   }
   script detect-file-types {
     run = ".conductor/scripts/detect-file-types.sh"
+    env = {
+      BASE_BRANCH = "{{base_branch}}"
+    }
   }
 
   parallel {

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -645,7 +645,7 @@ pub fn record_step_success(
 /// check for missing required inputs.
 pub fn resolve_child_inputs(
     raw_inputs: &HashMap<String, String>,
-    vars: &HashMap<&str, String>,
+    vars: &HashMap<String, String>,
     input_decls: &[crate::dsl::InputDecl],
 ) -> std::result::Result<HashMap<String, String>, String> {
     let mut child_inputs = HashMap::new();
@@ -941,7 +941,7 @@ pub fn check_max_iterations(
 }
 
 /// Build the variable map from execution state for substitution.
-pub fn build_variable_map(state: &ExecutionState) -> HashMap<&str, String> {
+pub fn build_variable_map(state: &ExecutionState) -> HashMap<String, String> {
     crate::prompt_builder::build_variable_map(state)
 }
 

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -97,9 +97,9 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
     // Build variable map for substitution, shell-quoting all values to prevent
     // injection when they are interpolated into the sh -c command string.
     let vars = build_variable_map(state);
-    let shell_safe_vars: std::collections::HashMap<&str, String> = vars
+    let shell_safe_vars: std::collections::HashMap<String, String> = vars
         .iter()
-        .map(|(k, v)| (*k, crate::prompt_builder::shell_quote(v)))
+        .map(|(k, v)| (k.clone(), crate::prompt_builder::shell_quote(v)))
         .collect();
     let script_cmd = crate::prompt_builder::substitute_variables(&node.run, &shell_safe_vars);
 

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -347,12 +347,20 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
             duration_ms
         );
 
-        let (markers, context) = crate::helpers::parse_flow_output(&stdout)
-            .map(|out| (out.markers, out.context))
-            .unwrap_or_else(|| {
-                let ctx = stdout.chars().take(2000).collect();
-                (vec![], ctx)
-            });
+        // Parse FLOW_OUTPUT once; keep the full struct so we can persist its
+        // JSON shape (including any `extras` fields) as structured_output for
+        // downstream variable injection — see prompt_builder::build_variable_map.
+        let parsed = crate::helpers::parse_flow_output(&stdout);
+        let (markers, context, structured_output) = match parsed {
+            Some(out) => {
+                let json = serde_json::to_string(&out).ok();
+                (out.markers, out.context, json)
+            }
+            None => {
+                let ctx: String = stdout.chars().take(2000).collect();
+                (vec![], ctx, None)
+            }
+        };
 
         let markers_json =
             crate::helpers::serialize_or_empty_array(&markers, &format!("script '{}'", node.name));
@@ -365,7 +373,7 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
             Some(context.clone()),
             Some(markers_json),
             0,
-            None,
+            structured_output.clone(),
         )?;
 
         record_step_success(
@@ -378,6 +386,7 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
                 markers,
                 context,
                 iteration,
+                structured_output,
                 ..crate::types::StepSuccess::default()
             },
         );

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -353,7 +353,17 @@ pub fn execute_script(state: &mut ExecutionState, node: &ScriptNode, iteration: 
         let parsed = crate::helpers::parse_flow_output(&stdout);
         let (markers, context, structured_output) = match parsed {
             Some(out) => {
-                let json = serde_json::to_string(&out).ok();
+                let json = serde_json::to_string(&out)
+                    .map_err(|e| {
+                        tracing::warn!(
+                            step = %node.name,
+                            error = %e,
+                            "script: failed to re-serialize FlowOutput as structured_output \
+                             — downstream `{{name}}` variable injection from this step's \
+                             extras will be unavailable",
+                        );
+                    })
+                    .ok();
                 (out.markers, out.context, json)
             }
             None => {

--- a/runkon-flow/src/helpers.rs
+++ b/runkon-flow/src/helpers.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::dsl::{WhileNode, WorkflowNode};
 use crate::status::WorkflowStepStatus;
 use serde::{Deserialize, Serialize};
@@ -10,12 +12,23 @@ use crate::engine::ExecutionState;
 // ---------------------------------------------------------------------------
 
 /// Parsed `<<<FLOW_OUTPUT>>>` block.
+///
+/// `markers` and `context` are core engine-recognized fields. Any other
+/// top-level JSON fields are preserved in `extras` so they round-trip through
+/// re-serialization. Engine plumbing (e.g. `prompt_builder` exposing
+/// `{{base_branch}}` from a `resolve-pr-base.sh` step — see #2736) reads from
+/// `extras` to inject typed values as template variables for subsequent steps.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FlowOutput {
     #[serde(default)]
     pub markers: Vec<String>,
     #[serde(default)]
     pub context: String,
+    /// Extra top-level fields preserved on parse and re-emitted on serialize.
+    /// Allows scripts to expose typed values to downstream steps via the
+    /// engine's variable substitution layer.
+    #[serde(flatten, default)]
+    pub extras: HashMap<String, serde_json::Value>,
 }
 
 /// Extract markers and context from a `<<<FLOW_OUTPUT>>> … <<<END_FLOW_OUTPUT>>>`
@@ -385,6 +398,42 @@ mod parse_tests {
     fn returns_none_when_no_block_present() {
         assert!(parse_flow_output("no flow output block here").is_none());
         assert!(parse_flow_output("").is_none());
+    }
+
+    /// `extras` captures any top-level fields beyond `markers` and `context`,
+    /// and re-serialization round-trips them so downstream readers
+    /// (e.g. `prompt_builder::build_variable_map` looking for `base_branch`)
+    /// can pick them up. #2736.
+    #[test]
+    fn extras_fields_are_preserved_on_parse_and_serialize() {
+        let text = concat!(
+            "<<<FLOW_OUTPUT>>>\n",
+            r#"{"markers":["base_branch_resolved"],"context":"release/0.10.0","base_branch":"release/0.10.0"}"#,
+            "\n",
+            "<<<END_FLOW_OUTPUT>>>"
+        );
+        let out = parse_flow_output(text).expect("parse must succeed");
+
+        // Core fields still extracted correctly.
+        assert_eq!(out.markers, vec!["base_branch_resolved".to_string()]);
+        assert_eq!(out.context, "release/0.10.0");
+
+        // Extra fields land in `extras`.
+        assert_eq!(
+            out.extras.get("base_branch").and_then(|v| v.as_str()),
+            Some("release/0.10.0"),
+            "base_branch should round-trip into extras"
+        );
+
+        // Re-serialization must include the extras at the top level so
+        // structured_output JSON readers find them.
+        let json = serde_json::to_string(&out).expect("serialize must succeed");
+        let reparsed: serde_json::Value =
+            serde_json::from_str(&json).expect("reparse must succeed");
+        assert_eq!(
+            reparsed.get("base_branch").and_then(|v| v.as_str()),
+            Some("release/0.10.0")
+        );
     }
 
     #[test]

--- a/runkon-flow/src/prompt_builder.rs
+++ b/runkon-flow/src/prompt_builder.rs
@@ -144,11 +144,30 @@ pub fn build_variable_map(state: &ExecutionState) -> HashMap<String, String> {
         };
         let parsed = match serde_json::from_str::<serde_json::Value>(json) {
             Ok(v) => v,
-            Err(_) => continue,
+            Err(e) => {
+                // structured_output is always written by script.rs via
+                // serde_json, so a parse failure here is a real bug — but
+                // not fatal to the run. Log and skip so other steps' exports
+                // still flow.
+                tracing::warn!(
+                    step = %c.step,
+                    error = %e,
+                    "build_variable_map: structured_output is not valid JSON — \
+                     {{name}} variable exports from this step will be unavailable",
+                );
+                continue;
+            }
         };
         let obj = match parsed.as_object() {
             Some(o) => o,
-            None => continue,
+            None => {
+                tracing::warn!(
+                    step = %c.step,
+                    "build_variable_map: structured_output JSON is not an object — \
+                     {{name}} variable exports from this step will be unavailable",
+                );
+                continue;
+            }
         };
         for (key, value) in obj {
             if key == "markers" || key == "context" {

--- a/runkon-flow/src/prompt_builder.rs
+++ b/runkon-flow/src/prompt_builder.rs
@@ -4,7 +4,7 @@ use crate::engine::{ExecutionState, ENGINE_INJECTED_KEYS};
 
 fn substitute_variables_impl(
     template: &str,
-    vars: &HashMap<&str, String>,
+    vars: &HashMap<String, String>,
     strip_unresolved: bool,
 ) -> String {
     // Single-pass tokeniser: scan the original template once, emitting each
@@ -44,13 +44,13 @@ fn substitute_variables_impl(
 }
 
 /// For agent prompts: substitutes variables AND strips unresolved `{{…}}` placeholders.
-pub fn substitute_variables(prompt: &str, vars: &HashMap<&str, String>) -> String {
+pub fn substitute_variables(prompt: &str, vars: &HashMap<String, String>) -> String {
     substitute_variables_impl(prompt, vars, true)
 }
 
 /// For data contexts (env vars, sub-workflow inputs): substitutes variables but
 /// preserves any `{{…}}` text that was not a template variable.
-pub fn substitute_variables_keep_literal(template: &str, vars: &HashMap<&str, String>) -> String {
+pub fn substitute_variables_keep_literal(template: &str, vars: &HashMap<String, String>) -> String {
     substitute_variables_impl(template, vars, false)
 }
 
@@ -62,33 +62,33 @@ pub fn shell_quote(s: &str) -> String {
 }
 
 /// Build the variable map from execution state (used for substitution in sub-workflow inputs).
-pub fn build_variable_map(state: &ExecutionState) -> HashMap<&str, String> {
-    let mut vars: HashMap<&str, String> = HashMap::new();
+pub fn build_variable_map(state: &ExecutionState) -> HashMap<String, String> {
+    let mut vars: HashMap<String, String> = HashMap::new();
 
     // Non-injected user-defined inputs
     for (k, v) in &state.inputs {
         if !ENGINE_INJECTED_KEYS.contains(&k.as_str()) {
-            vars.insert(k.as_str(), v.clone());
+            vars.insert(k.clone(), v.clone());
         }
     }
 
     // Engine-injected variables from the worktree context
     let wt = &state.worktree_ctx;
     if let Some(ref tid) = wt.ticket_id {
-        vars.insert("ticket_id", tid.clone());
+        vars.insert("ticket_id".into(), tid.clone());
     }
     if let Some(ref rid) = wt.repo_id {
-        vars.insert("repo_id", rid.clone());
+        vars.insert("repo_id".into(), rid.clone());
     }
-    vars.insert("repo_path", wt.repo_path.clone());
-    vars.insert("workflow_run_id", state.workflow_run_id.clone());
+    vars.insert("repo_path".into(), wt.repo_path.clone());
+    vars.insert("workflow_run_id".into(), state.workflow_run_id.clone());
 
     let prior_context = state
         .contexts
         .last()
         .map(|c| c.context.clone())
         .unwrap_or_default();
-    vars.insert("prior_context", prior_context);
+    vars.insert("prior_context".into(), prior_context);
     let prior_contexts_json = if state.contexts.is_empty() {
         "[]".to_string()
     } else {
@@ -97,9 +97,9 @@ pub fn build_variable_map(state: &ExecutionState) -> HashMap<&str, String> {
             "build_variable_map:prior_contexts",
         )
     };
-    vars.insert("prior_contexts", prior_contexts_json);
+    vars.insert("prior_contexts".into(), prior_contexts_json);
     if let Some(ref gf) = state.last_gate_feedback {
-        vars.insert("gate_feedback", gf.clone());
+        vars.insert("gate_feedback".into(), gf.clone());
     }
     // prior_output: raw JSON from the last step's structured output (if any)
     if let Some(last_output) = state
@@ -108,7 +108,7 @@ pub fn build_variable_map(state: &ExecutionState) -> HashMap<&str, String> {
         .rev()
         .find_map(|c| c.structured_output.as_ref())
     {
-        vars.insert("prior_output", last_output.clone());
+        vars.insert("prior_output".into(), last_output.clone());
     }
     // prior_output_file: path to the last script step's stdout temp file (if any)
     if let Some(path) = state
@@ -117,25 +117,54 @@ pub fn build_variable_map(state: &ExecutionState) -> HashMap<&str, String> {
         .rev()
         .find_map(|c| c.output_file.as_ref())
     {
-        vars.insert("prior_output_file", path.clone());
+        vars.insert("prior_output_file".into(), path.clone());
     }
     // dry_run: "true" or "false"
-    vars.insert("dry_run", state.exec_config.dry_run.to_string());
+    vars.insert("dry_run".into(), state.exec_config.dry_run.to_string());
 
-    // {{base_branch}}: pre-resolved PR base branch from a `resolve-pr-base.sh`
-    // script step (or any step that emits `base_branch: "<branch>"` in its
-    // FLOW_OUTPUT). #2736 — agents and detect-* scripts read this instead of
-    // running `gh pr view` themselves, which is brittle when the agent cd's
-    // out of the worktree and the silent fallback diffs against the wrong base.
+    // Script-exported variables from prior steps' FLOW_OUTPUT extras (#2736).
     //
-    // Walk forward through prior contexts; later writes overwrite earlier
-    // ones with the same name.
+    // Any string-valued top-level field other than `markers` and `context` in
+    // a step's structured_output is exposed as `{{name}}` to subsequent steps.
+    // Used by `resolve-pr-base.sh` to plumb `{{base_branch}}` to all
+    // downstream consumers; future scripts can export additional values
+    // without engine-side code changes.
+    //
+    // Shadowing guard: keys present in `ENGINE_INJECTED_KEYS` cannot be
+    // overwritten by a script — those are reserved for engine-controlled
+    // state (workflow_run_id, ticket_id, repo_path, etc.). A script that
+    // tries to export one of these gets a warning and is ignored.
+    //
+    // Iteration order: walk forward (oldest first); later writes from
+    // non-reserved names overwrite earlier ones.
     for c in &state.contexts {
-        if let Some(json) = &c.structured_output {
-            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json) {
-                if let Some(s) = parsed.get("base_branch").and_then(|v| v.as_str()) {
-                    vars.insert("base_branch", s.to_string());
-                }
+        let json = match &c.structured_output {
+            Some(j) => j,
+            None => continue,
+        };
+        let parsed = match serde_json::from_str::<serde_json::Value>(json) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let obj = match parsed.as_object() {
+            Some(o) => o,
+            None => continue,
+        };
+        for (key, value) in obj {
+            if key == "markers" || key == "context" {
+                // Engine-recognized FlowOutput fields, not exports.
+                continue;
+            }
+            if ENGINE_INJECTED_KEYS.contains(&key.as_str()) {
+                tracing::warn!(
+                    step = %c.step,
+                    var = %key,
+                    "script tried to export reserved variable name — ignoring",
+                );
+                continue;
+            }
+            if let Some(s) = value.as_str() {
+                vars.insert(key.clone(), s.to_string());
             }
         }
     }
@@ -156,16 +185,16 @@ mod tests {
 
     #[test]
     fn substitute_resolves_known_strips_unknown() {
-        let mut vars = HashMap::new();
-        vars.insert("name", "world".to_string());
+        let mut vars: HashMap<String, String> = HashMap::new();
+        vars.insert("name".into(), "world".to_string());
         let result = substitute_variables("hello {{name}} and {{unknown}}", &vars);
         assert_eq!(result, "hello world and ");
     }
 
     #[test]
     fn substitute_keep_literal_preserves_unresolved() {
-        let mut vars = HashMap::new();
-        vars.insert("name", "world".to_string());
+        let mut vars: HashMap<String, String> = HashMap::new();
+        vars.insert("name".into(), "world".to_string());
         let result = substitute_variables_keep_literal("hello {{name}} and {{unknown}}", &vars);
         assert_eq!(result, "hello world and {{unknown}}");
     }
@@ -173,8 +202,8 @@ mod tests {
     #[test]
     fn substitute_keep_literal_preserves_embedded_json() {
         let json_value = r#"{"risks":["{{deterministic-review.score}}","other"]}"#.to_string();
-        let mut vars = HashMap::new();
-        vars.insert("prior_output", json_value);
+        let mut vars: HashMap<String, String> = HashMap::new();
+        vars.insert("prior_output".into(), json_value);
         let result = substitute_variables_keep_literal("{{prior_output}}", &vars);
         assert_eq!(
             result,
@@ -185,9 +214,9 @@ mod tests {
     #[test]
     fn substitute_no_double_substitution() {
         // If variable A's value contains {{B}}, B must not be expanded in the output.
-        let mut vars = HashMap::new();
-        vars.insert("a", "{{b}}".to_string());
-        vars.insert("b", "injected".to_string());
+        let mut vars: HashMap<String, String> = HashMap::new();
+        vars.insert("a".into(), "{{b}}".to_string());
+        vars.insert("b".into(), "injected".to_string());
         let result = substitute_variables_keep_literal("{{a}}", &vars);
         // Should emit the literal value of a, not expand {{b}} inside it.
         assert_eq!(result, "{{b}}");
@@ -197,9 +226,9 @@ mod tests {
     fn shell_quote_no_double_substitution() {
         // Simulates the shell-quoting path used in script execution:
         // a shell-safe var map is built then substituted into the run template.
-        let mut vars = HashMap::new();
-        vars.insert("cmd", "'{{evil}}'".to_string()); // already shell-quoted value
-        vars.insert("evil", ";rm -rf /".to_string());
+        let mut vars: HashMap<String, String> = HashMap::new();
+        vars.insert("cmd".into(), "'{{evil}}'".to_string()); // already shell-quoted value
+        vars.insert("evil".into(), ";rm -rf /".to_string());
         // The run template only references {{cmd}}; {{evil}} should not be expanded.
         let result = substitute_variables("run {{cmd}}", &vars);
         assert_eq!(result, "run '{{evil}}'");
@@ -309,5 +338,105 @@ mod tests {
         let vars = build_variable_map(&state);
         let rendered = substitute_variables("git diff origin/{{base_branch}}...HEAD", &vars);
         assert_eq!(rendered, "git diff origin/release/0.10.0...HEAD");
+    }
+
+    /// Generic exports: any string-valued top-level field beyond
+    /// `markers`/`context` becomes a `{{name}}` variable. Used by future
+    /// scripts that want to plumb their own values without engine-side
+    /// code changes — see #2736 review round 2.
+    #[test]
+    fn build_variable_map_exposes_arbitrary_string_extras() {
+        use crate::test_helpers::CountingPersistence;
+        use std::sync::Arc;
+
+        let cp = Arc::new(CountingPersistence::new());
+        let mut state = crate::test_helpers::make_test_execution_state(
+            cp as Arc<dyn crate::traits::persistence::WorkflowPersistence>,
+            "run-1".into(),
+        );
+        state.contexts.push(crate::types::ContextEntry {
+            step: "some-script".into(),
+            iteration: 0,
+            context: "ok".into(),
+            markers: vec![],
+            structured_output: Some(
+                r#"{"markers":[],"context":"ok","pr_number":"42","tag":"v1.2.3"}"#.into(),
+            ),
+            output_file: None,
+        });
+
+        let vars = build_variable_map(&state);
+        assert_eq!(vars.get("pr_number").map(String::as_str), Some("42"));
+        assert_eq!(vars.get("tag").map(String::as_str), Some("v1.2.3"));
+    }
+
+    /// Shadowing guard: a script that tries to export a key already injected by
+    /// the engine (workflow_run_id, ticket_id, repo_path, …) is ignored. The
+    /// engine-injected value wins. Prevents a malicious or careless script
+    /// from overriding load-bearing engine state.
+    #[test]
+    fn build_variable_map_blocks_engine_injected_key_shadowing() {
+        use crate::test_helpers::CountingPersistence;
+        use std::sync::Arc;
+
+        let cp = Arc::new(CountingPersistence::new());
+        let mut state = crate::test_helpers::make_test_execution_state(
+            cp as Arc<dyn crate::traits::persistence::WorkflowPersistence>,
+            "run-real".into(),
+        );
+        state.worktree_ctx.repo_path = "/repo/real".into();
+        state.worktree_ctx.ticket_id = Some("TICK-real".into());
+
+        // Script tries to override every engine-injected key it can find.
+        // Prefer ENGINE_INJECTED_KEYS as the source of truth so this test
+        // stays correct as that list evolves.
+        let mut malicious = serde_json::Map::new();
+        malicious.insert("markers".into(), serde_json::Value::Array(vec![]));
+        malicious.insert("context".into(), serde_json::Value::String("evil".into()));
+        for key in ENGINE_INJECTED_KEYS {
+            malicious.insert(
+                (*key).into(),
+                serde_json::Value::String(format!("HIJACKED:{key}")),
+            );
+        }
+        let json = serde_json::to_string(&serde_json::Value::Object(malicious)).unwrap();
+        state.contexts.push(crate::types::ContextEntry {
+            step: "evil-script".into(),
+            iteration: 0,
+            context: "evil".into(),
+            markers: vec![],
+            structured_output: Some(json),
+            output_file: None,
+        });
+
+        let vars = build_variable_map(&state);
+
+        // Engine-injected values should NOT be overridden.
+        assert_eq!(
+            vars.get("workflow_run_id").map(String::as_str),
+            Some("run-real"),
+            "workflow_run_id must not be hijacked"
+        );
+        assert_eq!(
+            vars.get("repo_path").map(String::as_str),
+            Some("/repo/real"),
+            "repo_path must not be hijacked"
+        );
+        assert_eq!(
+            vars.get("ticket_id").map(String::as_str),
+            Some("TICK-real"),
+            "ticket_id must not be hijacked"
+        );
+
+        // Sanity: every engine-injected key is non-hijacked, regardless of
+        // whether it was set on the state we constructed.
+        for key in ENGINE_INJECTED_KEYS {
+            if let Some(v) = vars.get(*key) {
+                assert!(
+                    !v.starts_with("HIJACKED:"),
+                    "engine-injected key '{key}' was overridden by script export"
+                );
+            }
+        }
     }
 }

--- a/runkon-flow/src/prompt_builder.rs
+++ b/runkon-flow/src/prompt_builder.rs
@@ -121,6 +121,25 @@ pub fn build_variable_map(state: &ExecutionState) -> HashMap<&str, String> {
     }
     // dry_run: "true" or "false"
     vars.insert("dry_run", state.exec_config.dry_run.to_string());
+
+    // {{base_branch}}: pre-resolved PR base branch from a `resolve-pr-base.sh`
+    // script step (or any step that emits `base_branch: "<branch>"` in its
+    // FLOW_OUTPUT). #2736 — agents and detect-* scripts read this instead of
+    // running `gh pr view` themselves, which is brittle when the agent cd's
+    // out of the worktree and the silent fallback diffs against the wrong base.
+    //
+    // Walk forward through prior contexts; later writes overwrite earlier
+    // ones with the same name.
+    for c in &state.contexts {
+        if let Some(json) = &c.structured_output {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json) {
+                if let Some(s) = parsed.get("base_branch").and_then(|v| v.as_str()) {
+                    vars.insert("base_branch", s.to_string());
+                }
+            }
+        }
+    }
+
     vars
 }
 
@@ -184,5 +203,111 @@ mod tests {
         // The run template only references {{cmd}}; {{evil}} should not be expanded.
         let result = substitute_variables("run {{cmd}}", &vars);
         assert_eq!(result, "run '{{evil}}'");
+    }
+
+    /// `build_variable_map` exposes `{{base_branch}}` from any prior step's
+    /// structured_output JSON containing a top-level `base_branch` string.
+    /// #2736 — `resolve-pr-base.sh` writes this once at the start of
+    /// review-pr.wf and downstream consumers read it without re-running gh.
+    #[test]
+    fn build_variable_map_exposes_base_branch_from_prior_context() {
+        use crate::test_helpers::CountingPersistence;
+        use std::sync::Arc;
+
+        let cp = Arc::new(CountingPersistence::new());
+        let mut state = crate::test_helpers::make_test_execution_state(
+            cp as Arc<dyn crate::traits::persistence::WorkflowPersistence>,
+            "run-1".into(),
+        );
+
+        // No prior context → {{base_branch}} should be unset.
+        let vars = build_variable_map(&state);
+        assert!(
+            !vars.contains_key("base_branch"),
+            "no prior step → no base_branch variable"
+        );
+
+        // A prior step with structured_output carrying base_branch → exposed.
+        state.contexts.push(crate::types::ContextEntry {
+            step: "resolve-pr-base".into(),
+            iteration: 0,
+            context: "release/0.10.0".into(),
+            markers: vec!["base_branch_resolved".into()],
+            structured_output: Some(
+                r#"{"markers":["base_branch_resolved"],"context":"release/0.10.0","base_branch":"release/0.10.0"}"#
+                    .into(),
+            ),
+            output_file: None,
+        });
+        let vars = build_variable_map(&state);
+        assert_eq!(
+            vars.get("base_branch").map(String::as_str),
+            Some("release/0.10.0"),
+            "base_branch must be exposed from prior structured_output"
+        );
+
+        // A later step with no base_branch → previous value persists.
+        state.contexts.push(crate::types::ContextEntry {
+            step: "detect-file-types".into(),
+            iteration: 0,
+            context: "code changes".into(),
+            markers: vec![],
+            structured_output: Some(r#"{"markers":[],"context":"Found 2 files"}"#.into()),
+            output_file: None,
+        });
+        let vars = build_variable_map(&state);
+        assert_eq!(
+            vars.get("base_branch").map(String::as_str),
+            Some("release/0.10.0"),
+            "later step without base_branch must not clobber the value"
+        );
+
+        // A later step that overwrites base_branch → wins.
+        state.contexts.push(crate::types::ContextEntry {
+            step: "override".into(),
+            iteration: 0,
+            context: "main".into(),
+            markers: vec![],
+            structured_output: Some(
+                r#"{"markers":[],"context":"main","base_branch":"main"}"#.into(),
+            ),
+            output_file: None,
+        });
+        let vars = build_variable_map(&state);
+        assert_eq!(
+            vars.get("base_branch").map(String::as_str),
+            Some("main"),
+            "later step with base_branch must overwrite earlier value"
+        );
+    }
+
+    /// Substitution: a template referencing {{base_branch}} resolves to the
+    /// value exposed by `build_variable_map`. End-to-end verification that the
+    /// engine variable injection works for the new variable.
+    #[test]
+    fn substitute_uses_base_branch_from_variable_map() {
+        use crate::test_helpers::CountingPersistence;
+        use std::sync::Arc;
+
+        let cp = Arc::new(CountingPersistence::new());
+        let mut state = crate::test_helpers::make_test_execution_state(
+            cp as Arc<dyn crate::traits::persistence::WorkflowPersistence>,
+            "run-1".into(),
+        );
+        state.contexts.push(crate::types::ContextEntry {
+            step: "resolve-pr-base".into(),
+            iteration: 0,
+            context: "release/0.10.0".into(),
+            markers: vec![],
+            structured_output: Some(
+                r#"{"markers":[],"context":"release/0.10.0","base_branch":"release/0.10.0"}"#
+                    .into(),
+            ),
+            output_file: None,
+        });
+
+        let vars = build_variable_map(&state);
+        let rendered = substitute_variables("git diff origin/{{base_branch}}...HEAD", &vars);
+        assert_eq!(rendered, "git diff origin/release/0.10.0...HEAD");
     }
 }

--- a/runkon-flow/src/prompt_builder.rs
+++ b/runkon-flow/src/prompt_builder.rs
@@ -124,11 +124,17 @@ pub fn build_variable_map(state: &ExecutionState) -> HashMap<String, String> {
 
     // Script-exported variables from prior steps' FLOW_OUTPUT extras (#2736).
     //
-    // Any string-valued top-level field other than `markers` and `context` in
-    // a step's structured_output is exposed as `{{name}}` to subsequent steps.
-    // Used by `resolve-pr-base.sh` to plumb `{{base_branch}}` to all
+    // Any string-valued top-level field other than the FlowOutput-recognized
+    // ones (`markers`, `context`) is exposed as `{{name}}` to subsequent
+    // steps. Used by `resolve-pr-base.sh` to plumb `{{base_branch}}` to all
     // downstream consumers; future scripts can export additional values
     // without engine-side code changes.
+    //
+    // Parse as `FlowOutput` (not raw `serde_json::Value`) so the named fields
+    // are stripped and we iterate only `.extras`. This couples the skip-list
+    // to FlowOutput's serde schema — if FlowOutput gains a new named field,
+    // it lands in named-field land automatically rather than leaking through
+    // a manual `markers`/`context` guard.
     //
     // Shadowing guard: keys present in `ENGINE_INJECTED_KEYS` cannot be
     // overwritten by a script — those are reserved for engine-controlled
@@ -142,38 +148,24 @@ pub fn build_variable_map(state: &ExecutionState) -> HashMap<String, String> {
             Some(j) => j,
             None => continue,
         };
-        let parsed = match serde_json::from_str::<serde_json::Value>(json) {
-            Ok(v) => v,
+        let flow_output = match serde_json::from_str::<crate::helpers::FlowOutput>(json) {
+            Ok(out) => out,
             Err(e) => {
                 // structured_output is always written by script.rs via
                 // serde_json, so a parse failure here is a real bug — but
                 // not fatal to the run. Log and skip so other steps' exports
-                // still flow.
+                // still flow.  Same path catches non-object JSON since
+                // FlowOutput requires the input be a JSON object.
                 tracing::warn!(
                     step = %c.step,
                     error = %e,
-                    "build_variable_map: structured_output is not valid JSON — \
+                    "build_variable_map: structured_output is not a valid FlowOutput JSON — \
                      {{name}} variable exports from this step will be unavailable",
                 );
                 continue;
             }
         };
-        let obj = match parsed.as_object() {
-            Some(o) => o,
-            None => {
-                tracing::warn!(
-                    step = %c.step,
-                    "build_variable_map: structured_output JSON is not an object — \
-                     {{name}} variable exports from this step will be unavailable",
-                );
-                continue;
-            }
-        };
-        for (key, value) in obj {
-            if key == "markers" || key == "context" {
-                // Engine-recognized FlowOutput fields, not exports.
-                continue;
-            }
+        for (key, value) in &flow_output.extras {
             if ENGINE_INJECTED_KEYS.contains(&key.as_str()) {
                 tracing::warn!(
                     step = %c.step,
@@ -457,5 +449,57 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Malformed JSON in a step's structured_output must not abort the loop —
+    /// other steps' exports should still flow. Covers the parse-failure log
+    /// path in `build_variable_map`.
+    #[test]
+    fn build_variable_map_skips_steps_with_invalid_structured_output() {
+        use crate::test_helpers::CountingPersistence;
+        use std::sync::Arc;
+
+        let cp = Arc::new(CountingPersistence::new());
+        let mut state = crate::test_helpers::make_test_execution_state(
+            cp as Arc<dyn crate::traits::persistence::WorkflowPersistence>,
+            "run-1".into(),
+        );
+
+        // Step 1: malformed JSON. Should be skipped with a warning.
+        state.contexts.push(crate::types::ContextEntry {
+            step: "broken-step".into(),
+            iteration: 0,
+            context: String::new(),
+            markers: vec![],
+            structured_output: Some("this is not json".into()),
+            output_file: None,
+        });
+
+        // Step 2: also "not an object" (a JSON array). FlowOutput parse
+        // requires an object, so this should also be skipped — same path.
+        state.contexts.push(crate::types::ContextEntry {
+            step: "array-step".into(),
+            iteration: 0,
+            context: String::new(),
+            markers: vec![],
+            structured_output: Some(r#"["nope", "not an object"]"#.into()),
+            output_file: None,
+        });
+
+        // Step 3: valid extras. Should flow.
+        state.contexts.push(crate::types::ContextEntry {
+            step: "good-step".into(),
+            iteration: 0,
+            context: "ok".into(),
+            markers: vec![],
+            structured_output: Some(r#"{"markers":[],"context":"ok","payload":"survived"}"#.into()),
+            output_file: None,
+        });
+
+        let vars = build_variable_map(&state);
+        // Bad steps contribute nothing.
+        assert!(!vars.contains_key("broken-step"));
+        // Good step's extras still appear — proves the loop continues past failures.
+        assert_eq!(vars.get("payload").map(String::as_str), Some("survived"));
     }
 }


### PR DESCRIPTION
## Problem

Reviewer agents and detect-* scripts in `review-pr.wf` each ran `gh pr view --json baseRefName` themselves, with a silent `|| echo main` fallback. Concrete failure on workflow run \`01KQE8SYYNJN1WGD846E148JS6\`: a reviewer agent \`cd\`'d into the canonical repo path before the lookup, \`gh pr view\` returned nothing, the fallback produced a diff against \`main\`, and the reviewer then critiqued ~150 files of code accumulated on \`release/0.10.0\` as if it belonged to that PR.

PR #2735 hardened the snippet (\`gh pr list --head\` keys on explicit branch + drop silent fallback) but the fundamental issue remained: the LLM agent does the resolution.

## Fix

Resolve the base branch **once** in a script step at the start of \`review-pr.wf\`, expose it to every downstream step via the engine's variable substitution layer as \`{{base_branch}}\`. No agent or detect-* script computes it themselves; they just consume the value.

## Implementation

### Engine plumbing (\`runkon-flow\`)

- **\`FlowOutput\` gains \`extras: HashMap<String, serde_json::Value>\`** via \`#[serde(flatten, default)]\`. Unknown top-level fields round-trip through parse + re-serialize.
- **\`executors/script.rs\` now persists \`structured_output\`** for FLOW_OUTPUT-emitting scripts (was \`None\`). The full parsed FlowOutput is re-serialized so extras land in the step record + ContextEntry.
- **\`prompt_builder::build_variable_map\` walks prior contexts** looking for \`base_branch\` in any structured_output JSON and exposes it as \`{{base_branch}}\`. Targeted (not a generic exports mechanism) — easy to extend if more named values come up.

### Workflow + scripts

- **New \`.conductor/scripts/resolve-pr-base.sh\`**: runs \`gh pr list --head \$(git rev-parse --abbrev-ref HEAD)\`. Exits 1 with a loud message on failure — no silent \`main\` fallback. Emits FLOW_OUTPUT with \`{"base_branch": "<branch>"}\`.
- **\`review-pr.wf\`**: \`script resolve-pr-base\` is now the first step. \`detect-file-types\` and \`detect-db-migrations\` consume \`BASE_BRANCH\` via \`env = { BASE_BRANCH = "{{base_branch}}" }\`.
- **\`prompts/review-diff-scope.md\`**: replaced the shell-based detection with a literal \`git diff origin/{{base_branch}}...HEAD\`. No shell logic in the snippet at all.
- **\`detect-file-types.sh\` / \`detect-db-migrations.sh\`**: read BASE_BRANCH from env, fail loud if unset.

## Tests

- \`helpers::extras_fields_are_preserved_on_parse_and_serialize\` — round-trip.
- \`prompt_builder::build_variable_map_exposes_base_branch_from_prior_context\` — covers no-prior, present, overwrite-by-later, missing-doesn't-clobber.
- \`prompt_builder::substitute_uses_base_branch_from_variable_map\` — end-to-end template substitution.

## Smoke tests

- \`resolve-pr-base.sh\` against a known PR (\`fix/2728-foreach-child-ticket-lineage\`) → returns \`release/0.10.0\` ✓
- \`resolve-pr-base.sh\` with no PR for the branch → exits 1 with a clear message ✓
- \`cargo run --bin conductor -- workflow validate review-pr\` → PASS ✓

## Test plan

- [x] \`cargo test -p runkon-flow --features test-utils\` → 236 lib + 38 integ. (3 new tests; 0 regressions)
- [x] \`cargo test -p conductor-core --lib\` → 1928 passed
- [x] \`cargo clippy --all-targets -F test-utils -- -D warnings\` → clean
- [x] \`cargo fmt --all --check\` → clean
- [ ] Live: this PR's review-pr run will exercise the new path end-to-end.

Closes #2736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)