### PR TITLE
refactor(workflow): convert definitions.rs to free functions (#2590, PR 1/5)

### DIFF
--- a/conductor-cli/src/handlers/workflow.rs
+++ b/conductor-cli/src/handlers/workflow.rs
@@ -96,7 +96,7 @@ pub fn handle_workflow(
             };
 
             // Try new .wf files first, fall back to legacy .md
-            let (wf_defs, wf_warnings) = WorkflowManager::list_defs(&wt_path, &repo_path)?;
+            let (wf_defs, wf_warnings) = conductor_core::workflow::list_defs(&wt_path, &repo_path)?;
             for w in &wf_warnings {
                 eprintln!("warning: Failed to parse {}: {}", w.file, w.message);
             }
@@ -201,8 +201,11 @@ pub fn handle_workflow(
                 let repo_mgr = RepoManager::new(conn, config);
                 let r = repo_mgr.get_by_slug(&repo_slug)?;
 
-                let workflow =
-                    WorkflowManager::load_def_by_name(&r.local_path, &r.local_path, &name)?;
+                let workflow = conductor_core::workflow::load_def_by_name(
+                    &r.local_path,
+                    &r.local_path,
+                    &name,
+                )?;
 
                 if !workflow.targets.contains(&"repo".to_string()) {
                     eprintln!(
@@ -253,8 +256,11 @@ pub fn handle_workflow(
                     .entry("workflow_run_id".to_string())
                     .or_insert_with(|| run_id.clone());
 
-                let workflow =
-                    WorkflowManager::load_def_by_name(&ctx.working_dir, &ctx.repo_path, &name)?;
+                let workflow = conductor_core::workflow::load_def_by_name(
+                    &ctx.working_dir,
+                    &ctx.repo_path,
+                    &name,
+                )?;
 
                 conductor_core::workflow::apply_workflow_input_defaults(&workflow, &mut input_map)?;
 
@@ -294,8 +300,11 @@ pub fn handle_workflow(
                 let repo_mgr = RepoManager::new(conn, config);
                 let repo = repo_mgr.get_by_id(&ticket.repo_id)?;
 
-                let workflow =
-                    WorkflowManager::load_def_by_name(&repo.local_path, &repo.local_path, &name)?;
+                let workflow = conductor_core::workflow::load_def_by_name(
+                    &repo.local_path,
+                    &repo.local_path,
+                    &name,
+                )?;
 
                 conductor_core::workflow::apply_workflow_input_defaults(&workflow, &mut input_map)?;
 
@@ -343,7 +352,8 @@ pub fn handle_workflow(
                 let wt_mgr = WorktreeManager::new(conn, config);
                 let wt = wt_mgr.get_by_slug(&r.id, &worktree_slug)?;
 
-                let workflow = WorkflowManager::load_def_by_name(&wt.path, &r.local_path, &name)?;
+                let workflow =
+                    conductor_core::workflow::load_def_by_name(&wt.path, &r.local_path, &name)?;
 
                 // Validate required inputs and apply defaults
                 conductor_core::workflow::apply_workflow_input_defaults(&workflow, &mut input_map)?;
@@ -581,7 +591,7 @@ pub fn handle_workflow(
             let mut parse_errors: Vec<String> = Vec::new();
 
             if all {
-                let (defs, warnings) = WorkflowManager::list_defs(&wt_path, &repo_path)?;
+                let (defs, warnings) = conductor_core::workflow::list_defs(&wt_path, &repo_path)?;
                 for w in &warnings {
                     parse_errors.push(format!("{}: {}", w.file, w.message));
                 }
@@ -595,7 +605,7 @@ pub fn handle_workflow(
                 let wf_name = name
                     .as_deref()
                     .expect("name must be Some when --all is not set");
-                workflows = vec![WorkflowManager::load_def_by_name(
+                workflows = vec![conductor_core::workflow::load_def_by_name(
                     &wt_path, &repo_path, wf_name,
                 )?];
             };

--- a/conductor-cli/src/mcp/resources.rs
+++ b/conductor-cli/src/mcp/resources.rs
@@ -298,7 +298,8 @@ pub(super) fn read_resource_by_uri(db_path: &Path, uri: &str) -> anyhow::Result<
     if let Some(repo_slug) = uri.strip_prefix("conductor://workflows/") {
         let repo_mgr = RepoManager::new(&conn, &config);
         let repo = repo_mgr.get_by_slug(repo_slug)?;
-        let (defs, warnings) = WorkflowManager::list_defs(&repo.local_path, &repo.local_path)?;
+        let (defs, warnings) =
+            conductor_core::workflow::list_defs(&repo.local_path, &repo.local_path)?;
         let mut out = String::new();
         for w in &warnings {
             out.push_str(&format!(

--- a/conductor-cli/src/mcp/tools/workflows.rs
+++ b/conductor-cli/src/mcp/tools/workflows.rs
@@ -35,7 +35,6 @@ pub(super) fn tool_list_workflows(
     args: &serde_json::Map<String, Value>,
 ) -> CallToolResult {
     use conductor_core::repo::RepoManager;
-    use conductor_core::workflow::WorkflowManager;
 
     let repo_slug = require_arg!(args, "repo");
     let (conn, config) = match open_db_and_config(db_path) {
@@ -51,7 +50,7 @@ pub(super) fn tool_list_workflows(
         Ok(p) => p,
         Err(e) => return e,
     };
-    let (defs, warnings) = match WorkflowManager::list_defs(&wt_path, &repo.local_path) {
+    let (defs, warnings) = match conductor_core::workflow::list_defs(&wt_path, &repo.local_path) {
         Ok(v) => v,
         Err(e) => return tool_err(e),
     };
@@ -77,7 +76,6 @@ pub(super) fn tool_validate_workflow(
     args: &serde_json::Map<String, Value>,
 ) -> CallToolResult {
     use conductor_core::repo::RepoManager;
-    use conductor_core::workflow::WorkflowManager;
 
     let repo_slug = require_arg!(args, "repo");
     let workflow_name = require_arg!(args, "workflow");
@@ -97,15 +95,17 @@ pub(super) fn tool_validate_workflow(
     };
     let repo_path = repo.local_path.clone();
 
-    let workflow = match WorkflowManager::load_def_by_name(&wt_path, &repo_path, workflow_name) {
-        Ok(w) => w,
-        Err(e) => return tool_err(e),
-    };
+    let workflow =
+        match conductor_core::workflow::load_def_by_name(&wt_path, &repo_path, workflow_name) {
+            Ok(w) => w,
+            Err(e) => return tool_err(e),
+        };
 
     let known_bots: std::collections::HashSet<String> =
         config.github.apps.keys().cloned().collect();
 
-    let entry = WorkflowManager::validate_single(&wt_path, &repo_path, &workflow, &known_bots);
+    let entry =
+        conductor_core::workflow::validate_single(&wt_path, &repo_path, &workflow, &known_bots);
 
     format_validation_result(workflow_name, &entry)
 }
@@ -162,7 +162,6 @@ pub(super) fn tool_run_workflow(
     use conductor_core::repo::RepoManager;
     use conductor_core::workflow::{
         execute_workflow_standalone, RunIdSlot, WorkflowExecConfig, WorkflowExecStandalone,
-        WorkflowManager,
     };
     use conductor_core::worktree::WorktreeManager;
     use std::sync::{Arc, Mutex};
@@ -223,7 +222,7 @@ pub(super) fn tool_run_workflow(
     };
 
     // Load the workflow definition
-    let workflow = match WorkflowManager::load_def_by_name(
+    let workflow = match conductor_core::workflow::load_def_by_name(
         &repo.local_path,
         &repo.local_path,
         workflow_name,

--- a/conductor-core/src/workflow/manager/definitions.rs
+++ b/conductor-core/src/workflow/manager/definitions.rs
@@ -3,12 +3,10 @@ use std::collections::HashSet;
 use crate::error::Result;
 use runkon_flow::dsl as workflow_dsl;
 
-use super::WorkflowManager;
-
 /// Represents a workflow that failed to parse or failed post-parse validation.
 ///
-/// Used by [`WorkflowManager::list_defs_with_validation`] to communicate
-/// invalid workflows with semantic field names.
+/// Used by [`list_defs_with_validation`] to communicate invalid workflows with
+/// semantic field names.
 #[derive(Clone, Debug)]
 pub struct InvalidWorkflowEntry {
     /// The workflow name (or filename stem for parse failures).
@@ -17,155 +15,153 @@ pub struct InvalidWorkflowEntry {
     pub error: String,
 }
 
-impl WorkflowManager<'_> {
-    /// Load workflow definitions from the filesystem for a worktree.
-    ///
-    /// Returns `(defs, warnings)` — warnings contain one entry per `.wf` file
-    /// that failed to parse. Successfully-parsed definitions are always returned
-    /// even when some files are broken.
-    pub fn list_defs(
-        worktree_path: &str,
-        repo_path: &str,
-    ) -> Result<(
-        Vec<runkon_flow::dsl::WorkflowDef>,
-        Vec<runkon_flow::dsl::WorkflowWarning>,
-    )> {
-        workflow_dsl::load_workflow_defs(worktree_path, repo_path)
-            .map_err(crate::error::ConductorError::Workflow)
-    }
+/// Load workflow definitions from the filesystem for a worktree.
+///
+/// Returns `(defs, warnings)` — warnings contain one entry per `.wf` file
+/// that failed to parse. Successfully-parsed definitions are always returned
+/// even when some files are broken.
+pub fn list_defs(
+    worktree_path: &str,
+    repo_path: &str,
+) -> Result<(
+    Vec<runkon_flow::dsl::WorkflowDef>,
+    Vec<runkon_flow::dsl::WorkflowWarning>,
+)> {
+    workflow_dsl::load_workflow_defs(worktree_path, repo_path)
+        .map_err(crate::error::ConductorError::Workflow)
+}
 
-    /// Load a single workflow definition by name.
-    pub fn load_def_by_name(
-        worktree_path: &str,
-        repo_path: &str,
-        name: &str,
-    ) -> Result<runkon_flow::dsl::WorkflowDef> {
-        workflow_dsl::load_workflow_by_name(worktree_path, repo_path, name)
-            .map_err(crate::error::ConductorError::Workflow)
-    }
+/// Load a single workflow definition by name.
+pub fn load_def_by_name(
+    worktree_path: &str,
+    repo_path: &str,
+    name: &str,
+) -> Result<runkon_flow::dsl::WorkflowDef> {
+    workflow_dsl::load_workflow_by_name(worktree_path, repo_path, name)
+        .map_err(crate::error::ConductorError::Workflow)
+}
 
-    /// Validate a single workflow definition using the full batch validation
-    /// pipeline (agents, snippets, schemas, cycles, semantics, scripts, bot names).
-    ///
-    /// This is a convenience wrapper around [`validate_workflows_batch`] for callers
-    /// that already have a loaded `WorkflowDef` — e.g. the MCP tool.
-    pub fn validate_single(
-        wt_path: &str,
-        repo_path: &str,
-        workflow: &runkon_flow::dsl::WorkflowDef,
-        known_bots: &HashSet<String>,
-    ) -> crate::workflow::batch_validate::WorkflowValidationEntry {
-        let wt = wt_path.to_string();
-        let rp = repo_path.to_string();
-        let loader = |name: &str| -> std::result::Result<runkon_flow::dsl::WorkflowDef, String> {
-            workflow_dsl::load_workflow_by_name(&wt, &rp, name).map_err(|e| e.to_string())
-        };
-        let result = crate::workflow::batch_validate::validate_workflows_batch(
-            std::slice::from_ref(workflow),
-            &[],
-            wt_path,
-            repo_path,
-            known_bots,
-            &loader,
-        );
-        // validate_workflows_batch produces exactly one entry per input workflow,
-        // so with a single-item slice this always yields one element.
-        // Use unwrap_or_else to avoid a bare expect() in library code.
-        result.entries.into_iter().next().unwrap_or_else(|| {
-            crate::workflow::batch_validate::WorkflowValidationEntry {
-                name: workflow.name.clone(),
-                errors: vec![runkon_flow::dsl::ValidationError {
-                    message: "internal error: batch validation returned no entries".to_string(),
-                    hint: None,
-                }],
-                warnings: vec![],
+/// Validate a single workflow definition using the full batch validation
+/// pipeline (agents, snippets, schemas, cycles, semantics, scripts, bot names).
+///
+/// This is a convenience wrapper around [`validate_workflows_batch`] for callers
+/// that already have a loaded `WorkflowDef` — e.g. the MCP tool.
+pub fn validate_single(
+    wt_path: &str,
+    repo_path: &str,
+    workflow: &runkon_flow::dsl::WorkflowDef,
+    known_bots: &HashSet<String>,
+) -> crate::workflow::batch_validate::WorkflowValidationEntry {
+    let wt = wt_path.to_string();
+    let rp = repo_path.to_string();
+    let loader = |name: &str| -> std::result::Result<runkon_flow::dsl::WorkflowDef, String> {
+        workflow_dsl::load_workflow_by_name(&wt, &rp, name).map_err(|e| e.to_string())
+    };
+    let result = crate::workflow::batch_validate::validate_workflows_batch(
+        std::slice::from_ref(workflow),
+        &[],
+        wt_path,
+        repo_path,
+        known_bots,
+        &loader,
+    );
+    // validate_workflows_batch produces exactly one entry per input workflow,
+    // so with a single-item slice this always yields one element.
+    // Use unwrap_or_else to avoid a bare expect() in library code.
+    result.entries.into_iter().next().unwrap_or_else(|| {
+        crate::workflow::batch_validate::WorkflowValidationEntry {
+            name: workflow.name.clone(),
+            errors: vec![runkon_flow::dsl::ValidationError {
+                message: "internal error: batch validation returned no entries".to_string(),
+                hint: None,
+            }],
+            warnings: vec![],
+        }
+    })
+}
+
+/// Load workflow definitions and run full validation (parse + post-parse).
+///
+/// Returns `(valid_defs, invalid_entries)` where:
+/// - `valid_defs` are successfully-parsed and validated definitions
+/// - `invalid_entries` are invalid workflows with their error messages
+///
+/// Invalid entries include both parse failures (from `WorkflowWarning`) and
+/// validation errors from the batch validation pipeline.
+///
+/// This is the authoritative method for loading and validating workflows
+/// for UI display — it handles both parse and post-parse validation in one call.
+pub fn list_defs_with_validation(
+    wt_path: &str,
+    repo_path: &str,
+    known_bots: &HashSet<String>,
+) -> Result<(
+    Vec<runkon_flow::dsl::WorkflowDef>,
+    Vec<InvalidWorkflowEntry>,
+)> {
+    let (defs, warnings) = list_defs(wt_path, repo_path)?;
+
+    // Convert parse failures to invalid entries.
+    let mut invalid_entries: Vec<InvalidWorkflowEntry> = warnings
+        .iter()
+        .map(|w| {
+            let name = std::path::Path::new(&w.file)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or(&w.file)
+                .to_string();
+            InvalidWorkflowEntry {
+                name,
+                error: w.message.clone(),
             }
         })
-    }
+        .collect();
 
-    /// Load workflow definitions and run full validation (parse + post-parse).
-    ///
-    /// Returns `(valid_defs, invalid_entries)` where:
-    /// - `valid_defs` are successfully-parsed and validated definitions
-    /// - `invalid_entries` are invalid workflows with their error messages
-    ///
-    /// Invalid entries include both parse failures (from `WorkflowWarning`) and
-    /// validation errors from the batch validation pipeline.
-    ///
-    /// This is the authoritative method for loading and validating workflows
-    /// for UI display — it handles both parse and post-parse validation in one call.
-    pub fn list_defs_with_validation(
-        wt_path: &str,
-        repo_path: &str,
-        known_bots: &HashSet<String>,
-    ) -> Result<(
-        Vec<runkon_flow::dsl::WorkflowDef>,
-        Vec<InvalidWorkflowEntry>,
-    )> {
-        let (defs, warnings) = Self::list_defs(wt_path, repo_path)?;
+    // Run post-parse validation on successfully-parsed defs.
+    let wt = wt_path.to_string();
+    let rp = repo_path.to_string();
+    let loader = |name: &str| -> std::result::Result<runkon_flow::dsl::WorkflowDef, String> {
+        workflow_dsl::load_workflow_by_name(&wt, &rp, name).map_err(|e| e.to_string())
+    };
 
-        // Convert parse failures to invalid entries.
-        let mut invalid_entries: Vec<InvalidWorkflowEntry> = warnings
-            .iter()
-            .map(|w| {
-                let name = std::path::Path::new(&w.file)
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or(&w.file)
-                    .to_string();
-                InvalidWorkflowEntry {
-                    name,
-                    error: w.message.clone(),
-                }
-            })
-            .collect();
+    let validation = crate::workflow::batch_validate::validate_workflows_batch(
+        &defs,
+        &[],
+        wt_path,
+        repo_path,
+        known_bots,
+        &loader,
+    );
 
-        // Run post-parse validation on successfully-parsed defs.
-        let wt = wt_path.to_string();
-        let rp = repo_path.to_string();
-        let loader = |name: &str| -> std::result::Result<runkon_flow::dsl::WorkflowDef, String> {
-            workflow_dsl::load_workflow_by_name(&wt, &rp, name).map_err(|e| e.to_string())
-        };
-
-        let validation = crate::workflow::batch_validate::validate_workflows_batch(
-            &defs,
-            &[],
-            wt_path,
-            repo_path,
-            known_bots,
-            &loader,
-        );
-
-        // Add validation errors to invalid_entries.
-        for entry in &validation.entries {
-            if !entry.errors.is_empty() {
-                let msg = entry
-                    .errors
-                    .iter()
-                    .map(|v| v.message.as_str())
-                    .collect::<Vec<_>>()
-                    .join("; ");
-                invalid_entries.push(InvalidWorkflowEntry {
-                    name: entry.name.clone(),
-                    error: msg,
-                });
-            }
+    // Add validation errors to invalid_entries.
+    for entry in &validation.entries {
+        if !entry.errors.is_empty() {
+            let msg = entry
+                .errors
+                .iter()
+                .map(|v| v.message.as_str())
+                .collect::<Vec<_>>()
+                .join("; ");
+            invalid_entries.push(InvalidWorkflowEntry {
+                name: entry.name.clone(),
+                error: msg,
+            });
         }
-
-        // Build a set of invalid workflow names for efficient O(N) lookup.
-        let invalid_names: HashSet<String> = validation
-            .entries
-            .iter()
-            .filter(|e| !e.errors.is_empty())
-            .map(|e| e.name.clone())
-            .collect();
-
-        // Filter out defs that failed validation.
-        let valid_defs: Vec<_> = defs
-            .into_iter()
-            .filter(|d| !invalid_names.contains(&d.name))
-            .collect();
-
-        Ok((valid_defs, invalid_entries))
     }
+
+    // Build a set of invalid workflow names for efficient O(N) lookup.
+    let invalid_names: HashSet<String> = validation
+        .entries
+        .iter()
+        .filter(|e| !e.errors.is_empty())
+        .map(|e| e.name.clone())
+        .collect();
+
+    // Filter out defs that failed validation.
+    let valid_defs: Vec<_> = defs
+        .into_iter()
+        .filter(|d| !invalid_names.contains(&d.name))
+        .collect();
+
+    Ok((valid_defs, invalid_entries))
 }

--- a/conductor-core/src/workflow/manager/definitions.rs
+++ b/conductor-core/src/workflow/manager/definitions.rs
@@ -3,6 +3,20 @@ use std::collections::HashSet;
 use crate::error::Result;
 use runkon_flow::dsl as workflow_dsl;
 
+/// Build a workflow-by-name loader closure for batch validation.
+///
+/// Captures owned copies of `wt_path` / `repo_path` so the returned closure can
+/// outlive the borrows. Used by both `validate_single` and
+/// `list_defs_with_validation` to drive `validate_workflows_batch`.
+fn make_workflow_loader(
+    wt_path: &str,
+    repo_path: &str,
+) -> impl Fn(&str) -> std::result::Result<runkon_flow::dsl::WorkflowDef, String> {
+    let wt = wt_path.to_string();
+    let rp = repo_path.to_string();
+    move |name: &str| workflow_dsl::load_workflow_by_name(&wt, &rp, name).map_err(|e| e.to_string())
+}
+
 /// Represents a workflow that failed to parse or failed post-parse validation.
 ///
 /// Used by [`list_defs_with_validation`] to communicate invalid workflows with
@@ -52,11 +66,7 @@ pub fn validate_single(
     workflow: &runkon_flow::dsl::WorkflowDef,
     known_bots: &HashSet<String>,
 ) -> crate::workflow::batch_validate::WorkflowValidationEntry {
-    let wt = wt_path.to_string();
-    let rp = repo_path.to_string();
-    let loader = |name: &str| -> std::result::Result<runkon_flow::dsl::WorkflowDef, String> {
-        workflow_dsl::load_workflow_by_name(&wt, &rp, name).map_err(|e| e.to_string())
-    };
+    let loader = make_workflow_loader(wt_path, repo_path);
     let result = crate::workflow::batch_validate::validate_workflows_batch(
         std::slice::from_ref(workflow),
         &[],
@@ -118,11 +128,7 @@ pub fn list_defs_with_validation(
         .collect();
 
     // Run post-parse validation on successfully-parsed defs.
-    let wt = wt_path.to_string();
-    let rp = repo_path.to_string();
-    let loader = |name: &str| -> std::result::Result<runkon_flow::dsl::WorkflowDef, String> {
-        workflow_dsl::load_workflow_by_name(&wt, &rp, name).map_err(|e| e.to_string())
-    };
+    let loader = make_workflow_loader(wt_path, repo_path);
 
     let validation = crate::workflow::batch_validate::validate_workflows_batch(
         &defs,

--- a/conductor-core/src/workflow/manager/mod.rs
+++ b/conductor-core/src/workflow/manager/mod.rs
@@ -1,4 +1,4 @@
-mod definitions;
+pub(crate) mod definitions;
 mod fan_out;
 mod helpers;
 mod lifecycle;

--- a/conductor-core/src/workflow/manager/tests.rs
+++ b/conductor-core/src/workflow/manager/tests.rs
@@ -1148,7 +1148,7 @@ fn test_validate_single_returns_entry_for_valid_workflow() {
     let known_bots = std::collections::HashSet::new();
     let path = tmp.path().to_str().unwrap();
 
-    let entry = WorkflowManager::validate_single(path, path, &wf, &known_bots);
+    let entry = crate::workflow::validate_single(path, path, &wf, &known_bots);
 
     assert_eq!(entry.name, "good-wf");
     assert!(
@@ -1181,7 +1181,7 @@ fn test_validate_single_surfaces_warnings_for_unknown_bot() {
     let known_bots = std::collections::HashSet::new();
     let path = tmp.path().to_str().unwrap();
 
-    let entry = WorkflowManager::validate_single(path, path, &wf, &known_bots);
+    let entry = crate::workflow::validate_single(path, path, &wf, &known_bots);
 
     assert_eq!(entry.name, "bot-wf");
     assert!(
@@ -1217,7 +1217,7 @@ fn test_validate_single_reports_errors_for_missing_agent() {
     let known_bots = std::collections::HashSet::new();
     let path = tmp.path().to_str().unwrap();
 
-    let entry = WorkflowManager::validate_single(path, path, &wf, &known_bots);
+    let entry = crate::workflow::validate_single(path, path, &wf, &known_bots);
 
     assert_eq!(entry.name, "bad-wf");
     assert!(
@@ -4016,7 +4016,7 @@ fn test_list_defs_with_validation_parse_failures_are_captured() {
     std::fs::write(wf_dir.join("bad.wf"), "this is invalid !!!").unwrap();
 
     let wt_path_str = tmp.path().to_str().unwrap();
-    let (_defs, invalid) = WorkflowManager::list_defs_with_validation(
+    let (_defs, invalid) = crate::workflow::list_defs_with_validation(
         wt_path_str,
         "/nonexistent",
         &std::collections::HashSet::new(),
@@ -4047,7 +4047,7 @@ fn test_list_defs_with_validation_filename_stem_extraction() {
     // Just a parse failure with a specific filename
     std::fs::write(wf_dir.join("my-workflow.wf"), "invalid syntax here !!!").unwrap();
 
-    let (defs, invalid) = WorkflowManager::list_defs_with_validation(
+    let (defs, invalid) = crate::workflow::list_defs_with_validation(
         tmp.path().to_str().unwrap(),
         "/nonexistent",
         &std::collections::HashSet::new(),
@@ -4068,7 +4068,7 @@ fn test_list_defs_with_validation_empty_directory() {
     let wf_dir = tmp.path().join(".conductor").join("workflows");
     std::fs::create_dir_all(&wf_dir).unwrap();
 
-    let (defs, invalid) = WorkflowManager::list_defs_with_validation(
+    let (defs, invalid) = crate::workflow::list_defs_with_validation(
         tmp.path().to_str().unwrap(),
         "/nonexistent",
         &std::collections::HashSet::new(),
@@ -4095,7 +4095,7 @@ fn test_list_defs_with_validation_happy_path() {
     )
     .unwrap();
 
-    let (defs, invalid) = WorkflowManager::list_defs_with_validation(
+    let (defs, invalid) = crate::workflow::list_defs_with_validation(
         tmp.path().to_str().unwrap(),
         "/nonexistent",
         &std::collections::HashSet::new(),
@@ -4145,7 +4145,7 @@ fn test_list_defs_with_validation_propagates_io_error() {
     // Remove all permissions so fs::read_dir fails.
     std::fs::set_permissions(&wf_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
 
-    let result = WorkflowManager::list_defs_with_validation(
+    let result = crate::workflow::list_defs_with_validation(
         tmp.path().to_str().unwrap(),
         "/nonexistent",
         &std::collections::HashSet::new(),

--- a/conductor-core/src/workflow/mod.rs
+++ b/conductor-core/src/workflow/mod.rs
@@ -54,6 +54,9 @@ pub use coordinator::{
     validate_resume_preconditions,
 };
 pub use estimation::{Confidence, Estimate, LiveEstimate, StepEstimates};
+pub use manager::definitions::{
+    list_defs, list_defs_with_validation, load_def_by_name, validate_single,
+};
 pub use manager::recovery::{ReapedStaleRun, StaleWorkflowRun};
 pub use manager::{InvalidWorkflowEntry, StepMetrics, WorkflowManager};
 pub use output::{parse_flow_output, FlowOutput};

--- a/conductor-core/src/workflow_ephemeral.rs
+++ b/conductor-core/src/workflow_ephemeral.rs
@@ -17,7 +17,7 @@ use crate::config::Config;
 use crate::error::{ConductorError, Result};
 use crate::workflow::{
     apply_workflow_input_defaults, execute_workflow_standalone, WorkflowExecConfig,
-    WorkflowExecStandalone, WorkflowManager, WorkflowResult,
+    WorkflowExecStandalone, WorkflowResult,
 };
 
 /// A parsed GitHub PR reference.
@@ -207,7 +207,7 @@ pub fn run_workflow_on_pr(
     })?;
 
     // Load the workflow definition from the cloned repo
-    let workflow = WorkflowManager::load_def_by_name(clone_path_str, clone_path_str, workflow_name)
+    let workflow = crate::workflow::load_def_by_name(clone_path_str, clone_path_str, workflow_name)
         .map_err(|e| {
             ConductorError::Workflow(format!(
                 "Workflow '{}' not found in cloned PR repo: {e}",

--- a/conductor-core/src/workflow_template/instantiate.rs
+++ b/conductor-core/src/workflow_template/instantiate.rs
@@ -1,5 +1,3 @@
-use crate::workflow::WorkflowManager;
-
 use super::types::WorkflowTemplate;
 
 /// Normalize a template name into a filesystem-safe slug.
@@ -9,10 +7,10 @@ pub fn template_slug(name: &str) -> String {
 
 /// Collect existing workflow definition names for a given working directory.
 ///
-/// Errors from `WorkflowManager::list_defs` are logged as warnings and treated
+/// Errors from `workflow::list_defs` are logged as warnings and treated
 /// as an empty list so callers always get a usable result.
 pub fn collect_existing_workflow_names(working_dir: &str, repo_path: &str) -> Vec<String> {
-    match WorkflowManager::list_defs(working_dir, repo_path) {
+    match crate::workflow::list_defs(working_dir, repo_path) {
         Ok((defs, _)) => defs.into_iter().map(|d| d.name).collect(),
         Err(e) => {
             tracing::warn!("Failed to list workflow definitions: {e}");
@@ -298,7 +296,7 @@ mod tests {
 
     #[test]
     fn test_collect_existing_workflow_names_invalid_dir_returns_empty() {
-        // An invalid working_dir causes WorkflowManager::list_defs to error.
+        // An invalid working_dir causes workflow::list_defs to error.
         // collect_existing_workflow_names should return an empty Vec, not panic.
         let result = collect_existing_workflow_names("/nonexistent/path/xyz", "/nonexistent/repo");
         assert!(result.is_empty());

--- a/conductor-tui/src/app/agent_execution.rs
+++ b/conductor-tui/src/app/agent_execution.rs
@@ -485,8 +485,8 @@ impl App {
         let wt_path = worktree_path.clone();
         let rp = repo_path.clone();
         std::thread::spawn(move || {
-            use conductor_core::workflow::{WorkflowManager, WorkflowTrigger};
-            let manual_defs: Vec<_> = match WorkflowManager::list_defs(&wt_path, &rp) {
+            use conductor_core::workflow::WorkflowTrigger;
+            let manual_defs: Vec<_> = match conductor_core::workflow::list_defs(&wt_path, &rp) {
                 Ok((defs, _warnings)) => defs
                     .into_iter()
                     .filter(|d| d.trigger == WorkflowTrigger::Manual)

--- a/conductor-tui/src/app/workflow_management.rs
+++ b/conductor-tui/src/app/workflow_management.rs
@@ -150,13 +150,14 @@ impl App {
                 if let Some(ref tx) = self.bg_tx {
                     let tx = tx.clone();
                     std::thread::spawn(move || {
-                        let (defs, warnings) = match WorkflowManager::list_defs(&wt_path, &rp) {
-                            Ok(result) => result,
-                            Err(e) => {
-                                tracing::warn!("Failed to load workflow definitions: {e}");
-                                (vec![], vec![])
-                            }
-                        };
+                        let (defs, warnings) =
+                            match conductor_core::workflow::list_defs(&wt_path, &rp) {
+                                Ok(result) => result,
+                                Err(e) => {
+                                    tracing::warn!("Failed to load workflow definitions: {e}");
+                                    (vec![], vec![])
+                                }
+                            };
                         let _ = tx.send(Action::WorkflowDefsReloaded { defs, warnings });
                     });
                 }
@@ -519,7 +520,7 @@ impl App {
 
                 for wt_path in &worktree_paths {
                     let (defs, _warnings) =
-                        conductor_core::workflow::WorkflowManager::list_defs(wt_path, &repo_path)?;
+                        conductor_core::workflow::list_defs(wt_path, &repo_path)?;
                     for def in defs {
                         if seen.insert(def.name.clone()) {
                             all_defs.push(def);
@@ -529,8 +530,7 @@ impl App {
 
                 // Fallback: no worktrees provided (or none had defs) → repo-only load.
                 if all_defs.is_empty() {
-                    let (defs, _warnings) =
-                        conductor_core::workflow::WorkflowManager::list_defs("", &repo_path)?;
+                    let (defs, _warnings) = conductor_core::workflow::list_defs("", &repo_path)?;
                     all_defs = defs;
                 }
 

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -1024,7 +1024,8 @@ fn poll_workflow_data(
     } else if let Some(wt_path) = worktree_path {
         // Worktree-scoped: load defs from this worktree's filesystem path.
         let (mut defs, warnings) =
-            WorkflowManager::list_defs(wt_path, repo_path.unwrap_or("")).unwrap_or_default();
+            conductor_core::workflow::list_defs(wt_path, repo_path.unwrap_or(""))
+                .unwrap_or_default();
         defs.sort_by(|a, b| {
             let ka = (
                 if a.group.is_none() { 1u8 } else { 0u8 },
@@ -1059,7 +1060,7 @@ fn poll_workflow_data(
                     continue;
                 }
                 let (mut wt_defs, warnings) =
-                    WorkflowManager::list_defs(&wt.path, &rp).unwrap_or_default();
+                    conductor_core::workflow::list_defs(&wt.path, &rp).unwrap_or_default();
                 all_warnings.extend(warnings);
                 wt_defs.retain(|d| seen.insert(d.name.clone()));
                 all_defs.extend(wt_defs);
@@ -1067,7 +1068,7 @@ fn poll_workflow_data(
             // Fallback: no active worktrees → load from repo root
             if all_defs.is_empty() && !rp.is_empty() {
                 let (repo_defs, warnings) =
-                    WorkflowManager::list_defs(&rp, &rp).unwrap_or_default();
+                    conductor_core::workflow::list_defs(&rp, &rp).unwrap_or_default();
                 all_warnings.extend(warnings);
                 all_defs.extend(repo_defs);
             }
@@ -1110,7 +1111,7 @@ fn poll_workflow_data(
                     .map(|(s, p)| (s.as_str(), p.as_str()))
                     .unwrap_or(("?", ""));
                 let (mut wt_defs, warnings) =
-                    WorkflowManager::list_defs(&wt.path, rp).unwrap_or_default();
+                    conductor_core::workflow::list_defs(&wt.path, rp).unwrap_or_default();
                 all_warnings.extend(warnings);
                 // Deduplicate by (repo_id, workflow_name): each worktree has its own
                 // filesystem copy of .conductor/workflows/, so source_path differs per
@@ -1129,7 +1130,7 @@ fn poll_workflow_data(
                     continue;
                 }
                 let (mut repo_defs, warnings) =
-                    WorkflowManager::list_defs(repo_path, repo_path).unwrap_or_default();
+                    conductor_core::workflow::list_defs(repo_path, repo_path).unwrap_or_default();
                 all_warnings.extend(warnings);
                 repo_defs.retain(|d| seen.insert((repo_id.clone(), d.name.clone())));
                 for d in repo_defs {

--- a/conductor-web/src/routes/workflows.rs
+++ b/conductor-web/src/routes/workflows.rs
@@ -280,7 +280,7 @@ fn build_workflow_summaries(
     known_bots: &std::collections::HashSet<String>,
 ) -> Result<Vec<WorkflowDefSummary>, ApiError> {
     let (defs, invalid_entries) =
-        WorkflowManager::list_defs_with_validation(wt_path, repo_path, known_bots)
+        conductor_core::workflow::list_defs_with_validation(wt_path, repo_path, known_bots)
             .map_err(ApiError::Core)?;
 
     let mut summaries: Vec<WorkflowDefSummary> = Vec::new();
@@ -411,7 +411,7 @@ pub async fn get_workflow_def(
     let repo = RepoManager::new(&db, &config).get_by_id(&wt.repo_id)?;
 
     let (defs, _warnings) =
-        WorkflowManager::list_defs(&wt.path, &repo.local_path).map_err(ApiError::Core)?;
+        conductor_core::workflow::list_defs(&wt.path, &repo.local_path).map_err(ApiError::Core)?;
 
     let def = defs
         .into_iter()
@@ -456,7 +456,8 @@ pub async fn run_workflow(
         let repo = repo_mgr.get_by_id(&wt.repo_id)?;
 
         // Validate workflow exists and load definition
-        let def = WorkflowManager::load_def_by_name(&wt.path, &repo.local_path, &req.name)?;
+        let def =
+            conductor_core::workflow::load_def_by_name(&wt.path, &repo.local_path, &req.name)?;
 
         // Reject if a top-level workflow run is already active on this worktree
         let wf_mgr = WorkflowManager::new(&db);
@@ -726,7 +727,8 @@ pub async fn post_workflow_run(
             };
 
         // Validate workflow exists (def is reused by the spawn below — no double load)
-        let def = WorkflowManager::load_def_by_name(&wt_path, &repo.local_path, &req.workflow)?;
+        let def =
+            conductor_core::workflow::load_def_by_name(&wt_path, &repo.local_path, &req.workflow)?;
         let model = req
             .model
             .clone()


### PR DESCRIPTION
## Summary

First step in the WorkflowManager free-function migration (#2590). The four definition loaders — `list_defs`, `load_def_by_name`, `validate_single`, `list_defs_with_validation` — were already associated functions on `WorkflowManager` (no `&self`), used the struct purely as a namespace, and never touched the database. They now live as plain module-level free functions in `conductor-core/src/workflow/manager/definitions.rs` and are re-exported from `conductor_core::workflow`.

All 38 call sites across `conductor-cli`, `conductor-tui`, `conductor-web`, and `conductor-core` (including tests) are updated to call the free function form. Unused `WorkflowManager` imports introduced by the migration are removed.

## Migration roadmap

This is the warm-up PR in the 5-PR sequence that decomposes the WorkflowManager god object:

1. ✅ **`definitions.rs`** — this PR
2. `queries.rs` — read-only DB queries (~2,228 lines)
3. `steps.rs` + `fan_out.rs` — step + fan-out writes
4. `lifecycle.rs` — create/cancel/update
5. `recovery.rs` — reap/detect/claim (~1,964 lines)
6. (Final cleanup) — delete `WorkflowManager` struct + `mod.rs` wrapper

See #2590 for the full plan and rationale.

## Test plan

- [x] `cargo build` — passes for `conductor-core`, `conductor-cli`, `conductor-tui`
- [x] `cargo clippy -p conductor-core -p conductor-cli -p conductor-tui -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test -p conductor-core` — 1963 tests pass, 0 failures
- [x] `cargo test -p conductor-cli -p conductor-tui` — 963 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)