### PR TITLE
refactor(workflow): convert queries.rs to free functions (#2590, PR 2/5)

### DIFF
--- a/conductor-cli/src/handlers/workflow.rs
+++ b/conductor-cli/src/handlers/workflow.rs
@@ -25,8 +25,7 @@ pub fn handle_workflow(
 
     match command {
         WorkflowCommands::Active => {
-            let wf_mgr = WorkflowManager::new(conn);
-            let runs = conductor_core::workflow::list_active_workflow_runs(wf_mgr.conn(), &[])?;
+            let runs = conductor_core::workflow::list_active_workflow_runs(conn, &[])?;
 
             if runs.is_empty() {
                 println!("No active workflow runs.");
@@ -248,9 +247,7 @@ pub fn handle_workflow(
                 })?;
             } else if let Some(run_id) = workflow_run {
                 // Workflow-run targeted run (e.g. postmortem workflows)
-                let wf_mgr = WorkflowManager::new(conn);
-                let ctx =
-                    conductor_core::workflow::resolve_run_context(wf_mgr.conn(), &run_id, config)?;
+                let ctx = conductor_core::workflow::resolve_run_context(conn, &run_id, config)?;
 
                 // Auto-inject the workflow_run_id input (user --input flags merge after)
                 input_map
@@ -429,8 +426,7 @@ pub fn handle_workflow(
             }
         }
         WorkflowCommands::RunShow { id } => {
-            let wf_mgr = WorkflowManager::new(conn);
-            match conductor_core::workflow::get_workflow_run(wf_mgr.conn(), &id)? {
+            match conductor_core::workflow::get_workflow_run(conn, &id)? {
                 Some(run) => {
                     println!("Workflow Run: {}", run.id);
                     println!("  Name:    {}", run.workflow_name);
@@ -459,8 +455,7 @@ pub fn handle_workflow(
                         println!("\n{summary}");
                     }
 
-                    let steps =
-                        conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), &run.id)?;
+                    let steps = conductor_core::workflow::get_workflow_steps(conn, &run.id)?;
                     if !steps.is_empty() {
                         println!("\nSteps:");
                         for step in &steps {
@@ -981,10 +976,10 @@ fn with_waiting_gate(
         &str,
     ) -> Result<()>,
 ) -> Result<()> {
-    let wf_mgr = WorkflowManager::new(conn);
-    match conductor_core::workflow::find_waiting_gate(wf_mgr.conn(), run_id)? {
+    match conductor_core::workflow::find_waiting_gate(conn, run_id)? {
         Some(step) => {
             let user = std::env::var("USER").unwrap_or_else(|_| "cli".to_string());
+            let wf_mgr = WorkflowManager::new(conn);
             action(&wf_mgr, &step, &user)
         }
         None => {

--- a/conductor-cli/src/handlers/workflow.rs
+++ b/conductor-cli/src/handlers/workflow.rs
@@ -26,7 +26,7 @@ pub fn handle_workflow(
     match command {
         WorkflowCommands::Active => {
             let wf_mgr = WorkflowManager::new(conn);
-            let runs = wf_mgr.list_active_workflow_runs(&[])?;
+            let runs = conductor_core::workflow::list_active_workflow_runs(wf_mgr.conn(), &[])?;
 
             if runs.is_empty() {
                 println!("No active workflow runs.");
@@ -249,7 +249,8 @@ pub fn handle_workflow(
             } else if let Some(run_id) = workflow_run {
                 // Workflow-run targeted run (e.g. postmortem workflows)
                 let wf_mgr = WorkflowManager::new(conn);
-                let ctx = wf_mgr.resolve_run_context(&run_id, config)?;
+                let ctx =
+                    conductor_core::workflow::resolve_run_context(wf_mgr.conn(), &run_id, config)?;
 
                 // Auto-inject the workflow_run_id input (user --input flags merge after)
                 input_map
@@ -429,7 +430,7 @@ pub fn handle_workflow(
         }
         WorkflowCommands::RunShow { id } => {
             let wf_mgr = WorkflowManager::new(conn);
-            match wf_mgr.get_workflow_run(&id)? {
+            match conductor_core::workflow::get_workflow_run(wf_mgr.conn(), &id)? {
                 Some(run) => {
                     println!("Workflow Run: {}", run.id);
                     println!("  Name:    {}", run.workflow_name);
@@ -458,7 +459,8 @@ pub fn handle_workflow(
                         println!("\n{summary}");
                     }
 
-                    let steps = wf_mgr.get_workflow_steps(&run.id)?;
+                    let steps =
+                        conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), &run.id)?;
                     if !steps.is_empty() {
                         println!("\nSteps:");
                         for step in &steps {
@@ -980,7 +982,7 @@ fn with_waiting_gate(
     ) -> Result<()>,
 ) -> Result<()> {
     let wf_mgr = WorkflowManager::new(conn);
-    match wf_mgr.find_waiting_gate(run_id)? {
+    match conductor_core::workflow::find_waiting_gate(wf_mgr.conn(), run_id)? {
         Some(step) => {
             let user = std::env::var("USER").unwrap_or_else(|_| "cli".to_string());
             action(&wf_mgr, &step, &user)

--- a/conductor-cli/src/mcp/resources.rs
+++ b/conductor-cli/src/mcp/resources.rs
@@ -91,7 +91,12 @@ pub(super) fn enumerate_resources(db_path: &Path) -> anyhow::Result<Vec<Resource
 
         // Per-repo workflow runs: query directly by repo_id to avoid the global
         // cap silently dropping older runs when many repos are registered.
-        let repo_runs = wf_mgr.list_workflow_runs_by_repo_id(&repo.id, 50, 0)?;
+        let repo_runs = conductor_core::workflow::list_workflow_runs_by_repo_id(
+            wf_mgr.conn(),
+            &repo.id,
+            50,
+            0,
+        )?;
         for run in &repo_runs {
             resources.push(make_resource(
                 format!("conductor://run/{}", run.id),
@@ -246,7 +251,12 @@ pub(super) fn read_resource_by_uri(db_path: &Path, uri: &str) -> anyhow::Result<
         let repo_mgr = RepoManager::new(&conn, &config);
         let repo = repo_mgr.get_by_slug(repo_slug)?;
         let wf_mgr = WorkflowManager::new(&conn);
-        let repo_runs = wf_mgr.list_workflow_runs_by_repo_id(&repo.id, 50, 0)?;
+        let repo_runs = conductor_core::workflow::list_workflow_runs_by_repo_id(
+            wf_mgr.conn(),
+            &repo.id,
+            50,
+            0,
+        )?;
         if repo_runs.is_empty() {
             return Ok(format!("No workflow runs for {repo_slug}."));
         }
@@ -282,10 +292,9 @@ pub(super) fn read_resource_by_uri(db_path: &Path, uri: &str) -> anyhow::Result<
 
     if let Some(run_id) = uri.strip_prefix("conductor://run/") {
         let wf_mgr = WorkflowManager::new(&conn);
-        let run = wf_mgr
-            .get_workflow_run(run_id)?
+        let run = conductor_core::workflow::get_workflow_run(wf_mgr.conn(), run_id)?
             .ok_or_else(|| anyhow::anyhow!("Workflow run {run_id} not found"))?;
-        let steps = wf_mgr.get_workflow_steps(run_id)?;
+        let steps = conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), run_id)?;
         let claude_dir = config.general.resolve_optional_claude_dir();
         return Ok(format_run_detail_with_log(
             &conn,

--- a/conductor-cli/src/mcp/resources.rs
+++ b/conductor-cli/src/mcp/resources.rs
@@ -14,7 +14,6 @@ use rmcp::model::Resource;
 pub(super) fn enumerate_resources(db_path: &Path) -> anyhow::Result<Vec<Resource>> {
     use conductor_core::repo::RepoManager;
     use conductor_core::tickets::TicketSyncer;
-    use conductor_core::workflow::WorkflowManager;
     use conductor_core::worktree::WorktreeManager;
 
     let (conn, config) = super::helpers::open_db_and_config(db_path)?;
@@ -37,9 +36,6 @@ pub(super) fn enumerate_resources(db_path: &Path) -> anyhow::Result<Vec<Resource
 
     let wt_mgr = WorktreeManager::new(&conn, &config);
     let all_worktrees = wt_mgr.list(None, false)?;
-
-    let wf_mgr = WorkflowManager::new(&conn);
-
     for repo in &repos {
         resources.push(make_resource(
             format!("conductor://repo/{}", repo.slug),
@@ -91,12 +87,8 @@ pub(super) fn enumerate_resources(db_path: &Path) -> anyhow::Result<Vec<Resource
 
         // Per-repo workflow runs: query directly by repo_id to avoid the global
         // cap silently dropping older runs when many repos are registered.
-        let repo_runs = conductor_core::workflow::list_workflow_runs_by_repo_id(
-            wf_mgr.conn(),
-            &repo.id,
-            50,
-            0,
-        )?;
+        let repo_runs =
+            conductor_core::workflow::list_workflow_runs_by_repo_id(&conn, &repo.id, 50, 0)?;
         for run in &repo_runs {
             resources.push(make_resource(
                 format!("conductor://run/{}", run.id),
@@ -116,7 +108,6 @@ pub(super) fn enumerate_resources(db_path: &Path) -> anyhow::Result<Vec<Resource
 pub(super) fn read_resource_by_uri(db_path: &Path, uri: &str) -> anyhow::Result<String> {
     use conductor_core::repo::RepoManager;
     use conductor_core::tickets::TicketSyncer;
-    use conductor_core::workflow::WorkflowManager;
     use conductor_core::worktree::WorktreeManager;
     use std::collections::HashMap;
 
@@ -250,13 +241,8 @@ pub(super) fn read_resource_by_uri(db_path: &Path, uri: &str) -> anyhow::Result<
     if let Some(repo_slug) = uri.strip_prefix("conductor://runs/") {
         let repo_mgr = RepoManager::new(&conn, &config);
         let repo = repo_mgr.get_by_slug(repo_slug)?;
-        let wf_mgr = WorkflowManager::new(&conn);
-        let repo_runs = conductor_core::workflow::list_workflow_runs_by_repo_id(
-            wf_mgr.conn(),
-            &repo.id,
-            50,
-            0,
-        )?;
+        let repo_runs =
+            conductor_core::workflow::list_workflow_runs_by_repo_id(&conn, &repo.id, 50, 0)?;
         if repo_runs.is_empty() {
             return Ok(format!("No workflow runs for {repo_slug}."));
         }
@@ -291,10 +277,9 @@ pub(super) fn read_resource_by_uri(db_path: &Path, uri: &str) -> anyhow::Result<
     }
 
     if let Some(run_id) = uri.strip_prefix("conductor://run/") {
-        let wf_mgr = WorkflowManager::new(&conn);
-        let run = conductor_core::workflow::get_workflow_run(wf_mgr.conn(), run_id)?
+        let run = conductor_core::workflow::get_workflow_run(&conn, run_id)?
             .ok_or_else(|| anyhow::anyhow!("Workflow run {run_id} not found"))?;
-        let steps = conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), run_id)?;
+        let steps = conductor_core::workflow::get_workflow_steps(&conn, run_id)?;
         let claude_dir = config.general.resolve_optional_claude_dir();
         return Ok(format_run_detail_with_log(
             &conn,

--- a/conductor-cli/src/mcp/tools/agents.rs
+++ b/conductor-cli/src/mcp/tools/agents.rs
@@ -11,7 +11,6 @@ pub(super) fn tool_list_agent_runs(
 ) -> CallToolResult {
     use conductor_core::agent::{AgentManager, AgentRunStatus};
     use conductor_core::repo::RepoManager;
-    use conductor_core::workflow::WorkflowManager;
     use conductor_core::worktree::WorktreeManager;
 
     let repo_slug = get_arg(args, "repo");
@@ -100,14 +99,11 @@ pub(super) fn tool_list_agent_runs(
 
     // Batch-load workflow run IDs for all agent run IDs
     let run_ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
-    let wf_mgr = WorkflowManager::new(&conn);
-    let workflow_id_map = match conductor_core::workflow::get_workflow_run_ids_for_agent_runs(
-        wf_mgr.conn(),
-        &run_ids,
-    ) {
-        Ok(m) => m,
-        Err(e) => return tool_err(e),
-    };
+    let workflow_id_map =
+        match conductor_core::workflow::get_workflow_run_ids_for_agent_runs(&conn, &run_ids) {
+            Ok(m) => m,
+            Err(e) => return tool_err(e),
+        };
 
     // Batch-load pending feedback for all waiting runs (avoids N+1 queries)
     let waiting_run_ids: Vec<&str> = runs

--- a/conductor-cli/src/mcp/tools/agents.rs
+++ b/conductor-cli/src/mcp/tools/agents.rs
@@ -101,7 +101,10 @@ pub(super) fn tool_list_agent_runs(
     // Batch-load workflow run IDs for all agent run IDs
     let run_ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
     let wf_mgr = WorkflowManager::new(&conn);
-    let workflow_id_map = match wf_mgr.get_workflow_run_ids_for_agent_runs(&run_ids) {
+    let workflow_id_map = match conductor_core::workflow::get_workflow_run_ids_for_agent_runs(
+        wf_mgr.conn(),
+        &run_ids,
+    ) {
         Ok(m) => m,
         Err(e) => return tool_err(e),
     };

--- a/conductor-cli/src/mcp/tools/gates.rs
+++ b/conductor-cli/src/mcp/tools/gates.rs
@@ -29,7 +29,7 @@ pub(super) fn tool_approve_gate(
         Err(e) => return tool_err(e),
     };
     let wf_mgr = WorkflowManager::new(&conn);
-    let step = match conductor_core::workflow::find_waiting_gate(wf_mgr.conn(), run_id) {
+    let step = match conductor_core::workflow::find_waiting_gate(&conn, run_id) {
         Ok(Some(s)) => s,
         Ok(None) => return tool_err(format!("No waiting gate found for run {run_id}")),
         Err(e) => return tool_err(e),
@@ -63,7 +63,7 @@ pub(super) fn tool_reject_gate(
     };
     let wf_mgr = WorkflowManager::new(&conn);
     let feedback = get_arg(args, "feedback");
-    let step = match conductor_core::workflow::find_waiting_gate(wf_mgr.conn(), run_id) {
+    let step = match conductor_core::workflow::find_waiting_gate(&conn, run_id) {
         Ok(Some(s)) => s,
         Ok(None) => return tool_err(format!("No waiting gate found for run {run_id}")),
         Err(e) => return tool_err(e),
@@ -245,9 +245,8 @@ mod tests {
         use conductor_core::db::open_database;
         use conductor_core::workflow::WorkflowManager;
         let conn = open_database(&db).expect("open db");
-        let mgr = WorkflowManager::new(&conn);
         let steps =
-            conductor_core::workflow::get_workflow_steps(mgr.conn(), &run_id).expect("get steps");
+            conductor_core::workflow::get_workflow_steps(&conn, &run_id).expect("get steps");
         assert_eq!(steps[0].gate_feedback.as_deref(), Some("LGTM"));
         assert_eq!(steps[0].gate_approved_by.as_deref(), Some("mcp"));
     }
@@ -270,9 +269,8 @@ mod tests {
         use conductor_core::db::open_database;
         use conductor_core::workflow::WorkflowManager;
         let conn = open_database(&db).expect("open db");
-        let mgr = WorkflowManager::new(&conn);
         let steps =
-            conductor_core::workflow::get_workflow_steps(mgr.conn(), &run_id).expect("get steps");
+            conductor_core::workflow::get_workflow_steps(&conn, &run_id).expect("get steps");
         assert_eq!(steps[0].gate_feedback.as_deref(), Some("Needs more work"));
         assert_eq!(steps[0].gate_approved_by.as_deref(), Some("mcp"));
     }

--- a/conductor-cli/src/mcp/tools/gates.rs
+++ b/conductor-cli/src/mcp/tools/gates.rs
@@ -29,7 +29,7 @@ pub(super) fn tool_approve_gate(
         Err(e) => return tool_err(e),
     };
     let wf_mgr = WorkflowManager::new(&conn);
-    let step = match wf_mgr.find_waiting_gate(run_id) {
+    let step = match conductor_core::workflow::find_waiting_gate(wf_mgr.conn(), run_id) {
         Ok(Some(s)) => s,
         Ok(None) => return tool_err(format!("No waiting gate found for run {run_id}")),
         Err(e) => return tool_err(e),
@@ -63,7 +63,7 @@ pub(super) fn tool_reject_gate(
     };
     let wf_mgr = WorkflowManager::new(&conn);
     let feedback = get_arg(args, "feedback");
-    let step = match wf_mgr.find_waiting_gate(run_id) {
+    let step = match conductor_core::workflow::find_waiting_gate(wf_mgr.conn(), run_id) {
         Ok(Some(s)) => s,
         Ok(None) => return tool_err(format!("No waiting gate found for run {run_id}")),
         Err(e) => return tool_err(e),
@@ -246,7 +246,8 @@ mod tests {
         use conductor_core::workflow::WorkflowManager;
         let conn = open_database(&db).expect("open db");
         let mgr = WorkflowManager::new(&conn);
-        let steps = mgr.get_workflow_steps(&run_id).expect("get steps");
+        let steps =
+            conductor_core::workflow::get_workflow_steps(mgr.conn(), &run_id).expect("get steps");
         assert_eq!(steps[0].gate_feedback.as_deref(), Some("LGTM"));
         assert_eq!(steps[0].gate_approved_by.as_deref(), Some("mcp"));
     }
@@ -270,7 +271,8 @@ mod tests {
         use conductor_core::workflow::WorkflowManager;
         let conn = open_database(&db).expect("open db");
         let mgr = WorkflowManager::new(&conn);
-        let steps = mgr.get_workflow_steps(&run_id).expect("get steps");
+        let steps =
+            conductor_core::workflow::get_workflow_steps(mgr.conn(), &run_id).expect("get steps");
         assert_eq!(steps[0].gate_feedback.as_deref(), Some("Needs more work"));
         assert_eq!(steps[0].gate_approved_by.as_deref(), Some("mcp"));
     }

--- a/conductor-cli/src/mcp/tools/repos.rs
+++ b/conductor-cli/src/mcp/tools/repos.rs
@@ -8,7 +8,6 @@ use crate::mcp::helpers::{get_arg, open_db_and_config, tool_err, tool_ok};
 pub(super) fn tool_list_repos(db_path: &Path) -> CallToolResult {
     use conductor_core::agent::AgentManager;
     use conductor_core::repo::RepoManager;
-    use conductor_core::workflow::WorkflowManager;
 
     let (conn, config) = match open_db_and_config(db_path) {
         Ok(v) => v,
@@ -25,7 +24,7 @@ pub(super) fn tool_list_repos(db_path: &Path) -> CallToolResult {
         Ok(m) => m,
         Err(e) => return tool_err(e),
     };
-    let workflow_counts = match WorkflowManager::new(&conn).active_run_counts_by_repo() {
+    let workflow_counts = match conductor_core::workflow::active_run_counts_by_repo(&conn) {
         Ok(m) => m,
         Err(e) => return tool_err(e),
     };

--- a/conductor-cli/src/mcp/tools/runs.rs
+++ b/conductor-cli/src/mcp/tools/runs.rs
@@ -13,7 +13,7 @@ pub(super) fn tool_list_runs(
     args: &serde_json::Map<String, Value>,
 ) -> CallToolResult {
     use conductor_core::repo::RepoManager;
-    use conductor_core::workflow::{WorkflowManager, WorkflowRunStatus};
+    use conductor_core::workflow::WorkflowRunStatus;
     use conductor_core::worktree::WorktreeManager;
 
     let repo_slug = get_arg(args, "repo");
@@ -44,7 +44,6 @@ pub(super) fn tool_list_runs(
         Ok(v) => v,
         Err(e) => return tool_err(e),
     };
-    let wf_mgr = WorkflowManager::new(&conn);
 
     if let Some(slug) = repo_slug {
         // Per-repo path (existing behaviour)
@@ -61,22 +60,14 @@ pub(super) fn tool_list_runs(
                 Err(e) => return tool_err(e),
             };
             match conductor_core::workflow::list_workflow_runs_filtered_paginated(
-                wf_mgr.conn(),
-                &wt.id,
-                status,
-                limit,
-                offset,
+                &conn, &wt.id, status, limit, offset,
             ) {
                 Ok(r) => r,
                 Err(e) => return tool_err(e),
             }
         } else {
             match conductor_core::workflow::list_workflow_runs_by_repo_id_filtered(
-                wf_mgr.conn(),
-                &repo.id,
-                limit,
-                offset,
-                status,
+                &conn, &repo.id, limit, offset, status,
             ) {
                 Ok(r) => r,
                 Err(e) => return tool_err(e),
@@ -123,10 +114,7 @@ pub(super) fn tool_list_runs(
             repos.into_iter().map(|r| (r.id, r.slug)).collect();
 
         let runs = match conductor_core::workflow::list_all_workflow_runs_filtered_paginated(
-            wf_mgr.conn(),
-            status,
-            limit,
-            offset,
+            &conn, status, limit, offset,
         ) {
             Ok(r) => r,
             Err(e) => return tool_err(e),
@@ -154,20 +142,17 @@ pub(super) fn tool_get_run(
     db_path: &Path,
     args: &serde_json::Map<String, Value>,
 ) -> CallToolResult {
-    use conductor_core::workflow::WorkflowManager;
-
     let run_id = require_arg!(args, "run_id");
     let (conn, config) = match open_db_and_config(db_path) {
         Ok(v) => v,
         Err(e) => return tool_err(e),
     };
-    let wf_mgr = WorkflowManager::new(&conn);
-    let run = match conductor_core::workflow::get_workflow_run(wf_mgr.conn(), run_id) {
+    let run = match conductor_core::workflow::get_workflow_run(&conn, run_id) {
         Ok(Some(r)) => r,
         Ok(None) => return tool_err(format!("Workflow run {run_id} not found")),
         Err(e) => return tool_err(e),
     };
-    let steps = match conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), run_id) {
+    let steps = match conductor_core::workflow::get_workflow_steps(&conn, run_id) {
         Ok(s) => s,
         Err(e) => return tool_err(e),
     };
@@ -184,15 +169,13 @@ pub(super) fn tool_cancel_run(
     db_path: &Path,
     args: &serde_json::Map<String, Value>,
 ) -> CallToolResult {
-    use conductor_core::workflow::WorkflowManager;
-
     let run_id = require_arg!(args, "run_id");
     let (conn, _config) = match open_db_and_config(db_path) {
         Ok(v) => v,
         Err(e) => return tool_err(e),
     };
-    let wf_mgr = WorkflowManager::new(&conn);
-    let run = match conductor_core::workflow::get_workflow_run(wf_mgr.conn(), run_id) {
+    let wf_mgr = conductor_core::workflow::WorkflowManager::new(&conn);
+    let run = match conductor_core::workflow::get_workflow_run(&conn, run_id) {
         Ok(Some(r)) => r,
         Ok(None) => return tool_err(format!("Workflow run not found: {run_id}")),
         Err(e) => return tool_err(e),
@@ -211,8 +194,7 @@ pub(super) fn tool_resume_run(
     args: &serde_json::Map<String, Value>,
 ) -> CallToolResult {
     use conductor_core::workflow::{
-        resume_workflow_standalone, validate_resume_preconditions, WorkflowManager,
-        WorkflowResumeStandalone,
+        resume_workflow_standalone, validate_resume_preconditions, WorkflowResumeStandalone,
     };
     use std::sync::{Arc, Mutex};
 
@@ -224,8 +206,7 @@ pub(super) fn tool_resume_run(
         Ok(v) => v,
         Err(e) => return tool_err(e),
     };
-    let wf_mgr = WorkflowManager::new(&conn);
-    let run = match conductor_core::workflow::get_workflow_run(wf_mgr.conn(), run_id) {
+    let run = match conductor_core::workflow::get_workflow_run(&conn, run_id) {
         Ok(Some(r)) => r,
         Ok(None) => return tool_err(format!("Workflow run not found: {run_id}")),
         Err(e) => return tool_err(e),
@@ -290,7 +271,6 @@ pub(super) fn tool_get_step_log(
     args: &serde_json::Map<String, Value>,
 ) -> CallToolResult {
     use conductor_core::agent::AgentManager;
-    use conductor_core::workflow::WorkflowManager;
 
     let run_id = require_arg!(args, "run_id");
     let step_name = require_arg!(args, "step_name");
@@ -299,18 +279,15 @@ pub(super) fn tool_get_step_log(
         Ok(v) => v,
         Err(e) => return tool_err(e),
     };
-
-    let wf_mgr = WorkflowManager::new(&conn);
-
     // Verify the workflow run exists.
-    match conductor_core::workflow::get_workflow_run(wf_mgr.conn(), run_id) {
+    match conductor_core::workflow::get_workflow_run(&conn, run_id) {
         Ok(Some(_)) => {}
         Ok(None) => return tool_err(format!("Workflow run {run_id} not found")),
         Err(e) => return tool_err(e),
     }
 
     // Find all steps for this run and pick the last matching step_name.
-    let steps = match conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), run_id) {
+    let steps = match conductor_core::workflow::get_workflow_steps(&conn, run_id) {
         Ok(s) => s,
         Err(e) => return tool_err(e),
     };
@@ -388,14 +365,13 @@ mod tests {
     ) -> String {
         use conductor_core::agent::AgentManager;
         use conductor_core::db::open_database;
-        use conductor_core::workflow::WorkflowManager;
 
         let conn = open_database(db_path).expect("open db");
         let agent_mgr = AgentManager::new(&conn);
         let parent = agent_mgr
             .create_run(None, "workflow", None)
             .expect("create agent run");
-        let mgr = WorkflowManager::new(&conn);
+        let mgr = conductor_core::workflow::WorkflowManager::new(&conn);
         let run = mgr
             .create_workflow_run("test-wf", None, &parent.id, false, "manual", None)
             .expect("create workflow run");
@@ -422,14 +398,13 @@ mod tests {
     fn make_run_with_step(db_path: &std::path::Path, step_name: &str) -> (String, String) {
         use conductor_core::agent::AgentManager;
         use conductor_core::db::open_database;
-        use conductor_core::workflow::WorkflowManager;
 
         let conn = open_database(db_path).expect("open db");
         let agent_mgr = AgentManager::new(&conn);
         let parent = agent_mgr
             .create_run(None, "workflow", None)
             .expect("create parent run");
-        let mgr = WorkflowManager::new(&conn);
+        let mgr = conductor_core::workflow::WorkflowManager::new(&conn);
         let run = mgr
             .create_workflow_run("test-wf", None, &parent.id, false, "manual", None)
             .expect("create workflow run");
@@ -491,7 +466,6 @@ mod tests {
     fn test_dispatch_list_runs_cross_repo() {
         use conductor_core::agent::AgentManager;
         use conductor_core::db::open_database;
-        use conductor_core::workflow::WorkflowManager;
 
         let (_f, db) = make_test_db();
         {
@@ -523,8 +497,7 @@ mod tests {
             let agent_mgr = AgentManager::new(&conn);
             let p1 = agent_mgr.create_run(Some("w1"), "wf-a", None).unwrap();
             let p2 = agent_mgr.create_run(Some("w2"), "wf-b", None).unwrap();
-
-            let wf_mgr = WorkflowManager::new(&conn);
+            let wf_mgr = conductor_core::workflow::WorkflowManager::new(&conn);
             wf_mgr
                 .create_workflow_run_with_targets(
                     "flow-a",
@@ -591,13 +564,12 @@ mod tests {
     #[test]
     fn test_list_workflow_runs_by_repo_id_empty() {
         use conductor_core::db::open_database;
-        use conductor_core::workflow::WorkflowManager;
 
         let (_f, db) = make_test_db();
         let conn = open_database(&db).expect("open db");
-        let mgr = WorkflowManager::new(&conn);
+        let mgr = conductor_core::workflow::WorkflowManager::new(&conn);
         let runs = conductor_core::workflow::list_workflow_runs_by_repo_id(
-            mgr.conn(),
+            &conn,
             "nonexistent-repo-id",
             50,
             0,
@@ -612,7 +584,6 @@ mod tests {
         use conductor_core::config::Config;
         use conductor_core::db::open_database;
         use conductor_core::repo::RepoManager;
-        use conductor_core::workflow::WorkflowManager;
 
         let (_f, db) = make_test_db();
         let conn = open_database(&db).expect("open db");
@@ -626,7 +597,7 @@ mod tests {
             .expect("register repo-b");
 
         let agent_mgr = AgentManager::new(&conn);
-        let mgr = WorkflowManager::new(&conn);
+        let mgr = conductor_core::workflow::WorkflowManager::new(&conn);
 
         let parent = agent_mgr
             .create_run(None, "workflow", None)
@@ -663,10 +634,10 @@ mod tests {
             .expect("create run B");
 
         let runs_a =
-            conductor_core::workflow::list_workflow_runs_by_repo_id(mgr.conn(), &repo_a.id, 50, 0)
+            conductor_core::workflow::list_workflow_runs_by_repo_id(&conn, &repo_a.id, 50, 0)
                 .expect("query A");
         let runs_b =
-            conductor_core::workflow::list_workflow_runs_by_repo_id(mgr.conn(), &repo_b.id, 50, 0)
+            conductor_core::workflow::list_workflow_runs_by_repo_id(&conn, &repo_b.id, 50, 0)
                 .expect("query B");
 
         assert_eq!(runs_a.len(), 1, "expected 1 run for repo-a");
@@ -738,7 +709,7 @@ mod tests {
     #[test]
     fn test_dispatch_cancel_run_running() {
         use conductor_core::db::open_database;
-        use conductor_core::workflow::{WorkflowManager, WorkflowRunStatus};
+        use conductor_core::workflow::WorkflowRunStatus;
         let (_f, db) = make_test_db();
         let run_id = make_workflow_run_with_status(&db, WorkflowRunStatus::Running);
         let args = args_with("run_id", &run_id);
@@ -761,8 +732,8 @@ mod tests {
 
         // Verify the run status was updated in the DB.
         let conn = open_database(&db).expect("open db");
-        let mgr = WorkflowManager::new(&conn);
-        let run = conductor_core::workflow::get_workflow_run(mgr.conn(), &run_id)
+        let mgr = conductor_core::workflow::WorkflowManager::new(&conn);
+        let run = conductor_core::workflow::get_workflow_run(&conn, &run_id)
             .expect("query")
             .expect("run exists");
         assert_eq!(run.status, WorkflowRunStatus::Cancelled);
@@ -875,7 +846,6 @@ mod tests {
         use conductor_core::config::Config;
         use conductor_core::db::open_database;
         use conductor_core::repo::RepoManager;
-        use conductor_core::workflow::WorkflowManager;
 
         let (_f, db) = make_test_db();
         let conn = open_database(&db).expect("open db");
@@ -911,7 +881,7 @@ mod tests {
         let parent = agent_mgr
             .create_run(None, "workflow", None)
             .expect("create agent run");
-        WorkflowManager::new(&conn)
+        conductor_core::workflow::WorkflowManager::new(&conn)
             .create_workflow_run_with_targets(
                 "my-wf",
                 Some(wt_id),
@@ -1039,7 +1009,7 @@ mod tests {
         // Step has a child_run_id but no log file exists on disk.
         use conductor_core::agent::AgentManager;
         use conductor_core::db::open_database;
-        use conductor_core::workflow::{WorkflowManager, WorkflowStepStatus};
+        use conductor_core::workflow::WorkflowStepStatus;
 
         let (_f, db) = make_test_db();
         let (run_id, step_id) = make_run_with_step(&db, "build");
@@ -1059,7 +1029,7 @@ mod tests {
             rusqlite::params![nonexistent_str, child_run.id],
         )
         .expect("set log_file");
-        let mgr = WorkflowManager::new(&conn);
+        let mgr = conductor_core::workflow::WorkflowManager::new(&conn);
         mgr.update_step_status(
             &step_id,
             WorkflowStepStatus::Completed,
@@ -1099,7 +1069,7 @@ mod tests {
     fn test_dispatch_get_step_log_success() {
         // Happy path: step has child_run linked to an agent run with a log file.
         use conductor_core::db::open_database;
-        use conductor_core::workflow::{WorkflowManager, WorkflowStepStatus};
+        use conductor_core::workflow::WorkflowStepStatus;
         use std::io::Write as _;
 
         let (_f, db) = make_test_db();
@@ -1117,7 +1087,7 @@ mod tests {
         let conn = open_database(&db).expect("open db");
         let child_run_id = create_run_with_log(&conn, &log_path);
 
-        let mgr = WorkflowManager::new(&conn);
+        let mgr = conductor_core::workflow::WorkflowManager::new(&conn);
         mgr.update_step_status(
             &step_id,
             WorkflowStepStatus::Completed,
@@ -1157,7 +1127,7 @@ mod tests {
     #[test]
     fn test_dispatch_get_step_log_multi_iteration_returns_last() {
         use conductor_core::db::open_database;
-        use conductor_core::workflow::{WorkflowManager, WorkflowStepStatus};
+        use conductor_core::workflow::WorkflowStepStatus;
         use std::io::Write as _;
 
         let (_f, db) = make_test_db();
@@ -1179,7 +1149,7 @@ mod tests {
         let conn = open_database(&db).expect("open db");
         let child0_id = create_run_with_log(&conn, &path0);
 
-        let mgr = WorkflowManager::new(&conn);
+        let mgr = conductor_core::workflow::WorkflowManager::new(&conn);
         mgr.update_step_status(
             &step0_id,
             WorkflowStepStatus::Completed,
@@ -1238,7 +1208,7 @@ mod tests {
     #[test]
     fn test_dispatch_get_step_log_multi_step_name_isolation() {
         use conductor_core::db::open_database;
-        use conductor_core::workflow::{WorkflowManager, WorkflowStepStatus};
+        use conductor_core::workflow::WorkflowStepStatus;
         use std::io::Write as _;
 
         let (_f, db) = make_test_db();
@@ -1263,7 +1233,7 @@ mod tests {
         let path_test1 = log_test1.path().to_str().unwrap().to_string();
 
         let conn = open_database(&db).expect("open db");
-        let mgr = WorkflowManager::new(&conn);
+        let mgr = conductor_core::workflow::WorkflowManager::new(&conn);
 
         // Link build step to its agent run.
         let child_build_id = create_run_with_log(&conn, &path_build);

--- a/conductor-cli/src/mcp/tools/runs.rs
+++ b/conductor-cli/src/mcp/tools/runs.rs
@@ -60,12 +60,24 @@ pub(super) fn tool_list_runs(
                 Ok(w) => w,
                 Err(e) => return tool_err(e),
             };
-            match wf_mgr.list_workflow_runs_filtered_paginated(&wt.id, status, limit, offset) {
+            match conductor_core::workflow::list_workflow_runs_filtered_paginated(
+                wf_mgr.conn(),
+                &wt.id,
+                status,
+                limit,
+                offset,
+            ) {
                 Ok(r) => r,
                 Err(e) => return tool_err(e),
             }
         } else {
-            match wf_mgr.list_workflow_runs_by_repo_id_filtered(&repo.id, limit, offset, status) {
+            match conductor_core::workflow::list_workflow_runs_by_repo_id_filtered(
+                wf_mgr.conn(),
+                &repo.id,
+                limit,
+                offset,
+                status,
+            ) {
                 Ok(r) => r,
                 Err(e) => return tool_err(e),
             }
@@ -110,7 +122,12 @@ pub(super) fn tool_list_runs(
         let repo_map: std::collections::HashMap<String, String> =
             repos.into_iter().map(|r| (r.id, r.slug)).collect();
 
-        let runs = match wf_mgr.list_all_workflow_runs_filtered_paginated(status, limit, offset) {
+        let runs = match conductor_core::workflow::list_all_workflow_runs_filtered_paginated(
+            wf_mgr.conn(),
+            status,
+            limit,
+            offset,
+        ) {
             Ok(r) => r,
             Err(e) => return tool_err(e),
         };
@@ -145,12 +162,12 @@ pub(super) fn tool_get_run(
         Err(e) => return tool_err(e),
     };
     let wf_mgr = WorkflowManager::new(&conn);
-    let run = match wf_mgr.get_workflow_run(run_id) {
+    let run = match conductor_core::workflow::get_workflow_run(wf_mgr.conn(), run_id) {
         Ok(Some(r)) => r,
         Ok(None) => return tool_err(format!("Workflow run {run_id} not found")),
         Err(e) => return tool_err(e),
     };
-    let steps = match wf_mgr.get_workflow_steps(run_id) {
+    let steps = match conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), run_id) {
         Ok(s) => s,
         Err(e) => return tool_err(e),
     };
@@ -175,7 +192,7 @@ pub(super) fn tool_cancel_run(
         Err(e) => return tool_err(e),
     };
     let wf_mgr = WorkflowManager::new(&conn);
-    let run = match wf_mgr.get_workflow_run(run_id) {
+    let run = match conductor_core::workflow::get_workflow_run(wf_mgr.conn(), run_id) {
         Ok(Some(r)) => r,
         Ok(None) => return tool_err(format!("Workflow run not found: {run_id}")),
         Err(e) => return tool_err(e),
@@ -208,7 +225,7 @@ pub(super) fn tool_resume_run(
         Err(e) => return tool_err(e),
     };
     let wf_mgr = WorkflowManager::new(&conn);
-    let run = match wf_mgr.get_workflow_run(run_id) {
+    let run = match conductor_core::workflow::get_workflow_run(wf_mgr.conn(), run_id) {
         Ok(Some(r)) => r,
         Ok(None) => return tool_err(format!("Workflow run not found: {run_id}")),
         Err(e) => return tool_err(e),
@@ -286,14 +303,14 @@ pub(super) fn tool_get_step_log(
     let wf_mgr = WorkflowManager::new(&conn);
 
     // Verify the workflow run exists.
-    match wf_mgr.get_workflow_run(run_id) {
+    match conductor_core::workflow::get_workflow_run(wf_mgr.conn(), run_id) {
         Ok(Some(_)) => {}
         Ok(None) => return tool_err(format!("Workflow run {run_id} not found")),
         Err(e) => return tool_err(e),
     }
 
     // Find all steps for this run and pick the last matching step_name.
-    let steps = match wf_mgr.get_workflow_steps(run_id) {
+    let steps = match conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), run_id) {
         Ok(s) => s,
         Err(e) => return tool_err(e),
     };
@@ -579,9 +596,13 @@ mod tests {
         let (_f, db) = make_test_db();
         let conn = open_database(&db).expect("open db");
         let mgr = WorkflowManager::new(&conn);
-        let runs = mgr
-            .list_workflow_runs_by_repo_id("nonexistent-repo-id", 50, 0)
-            .expect("query should succeed");
+        let runs = conductor_core::workflow::list_workflow_runs_by_repo_id(
+            mgr.conn(),
+            "nonexistent-repo-id",
+            50,
+            0,
+        )
+        .expect("query should succeed");
         assert!(runs.is_empty(), "expected no runs for unknown repo");
     }
 
@@ -641,12 +662,12 @@ mod tests {
             )
             .expect("create run B");
 
-        let runs_a = mgr
-            .list_workflow_runs_by_repo_id(&repo_a.id, 50, 0)
-            .expect("query A");
-        let runs_b = mgr
-            .list_workflow_runs_by_repo_id(&repo_b.id, 50, 0)
-            .expect("query B");
+        let runs_a =
+            conductor_core::workflow::list_workflow_runs_by_repo_id(mgr.conn(), &repo_a.id, 50, 0)
+                .expect("query A");
+        let runs_b =
+            conductor_core::workflow::list_workflow_runs_by_repo_id(mgr.conn(), &repo_b.id, 50, 0)
+                .expect("query B");
 
         assert_eq!(runs_a.len(), 1, "expected 1 run for repo-a");
         assert_eq!(runs_a[0].workflow_name, "wf-a");
@@ -741,8 +762,7 @@ mod tests {
         // Verify the run status was updated in the DB.
         let conn = open_database(&db).expect("open db");
         let mgr = WorkflowManager::new(&conn);
-        let run = mgr
-            .get_workflow_run(&run_id)
+        let run = conductor_core::workflow::get_workflow_run(mgr.conn(), &run_id)
             .expect("query")
             .expect("run exists");
         assert_eq!(run.status, WorkflowRunStatus::Cancelled);

--- a/conductor-cli/src/mcp/tools/worktrees.rs
+++ b/conductor-cli/src/mcp/tools/worktrees.rs
@@ -65,7 +65,6 @@ pub(super) fn tool_get_worktree(
     use conductor_core::github::get_pr_detail;
     use conductor_core::repo::RepoManager;
     use conductor_core::tickets::TicketSyncer;
-    use conductor_core::workflow::WorkflowManager;
     use conductor_core::worktree::WorktreeManager;
 
     let repo_slug = require_arg!(args, "repo");
@@ -137,8 +136,7 @@ pub(super) fn tool_get_worktree(
     }
 
     // Latest workflow run
-    let wf_mgr = WorkflowManager::new(&conn);
-    match conductor_core::workflow::list_workflow_runs(wf_mgr.conn(), &wt.id) {
+    match conductor_core::workflow::list_workflow_runs(&conn, &wt.id) {
         Ok(runs) => {
             if let Some(run) = runs.first() {
                 out.push_str(&format!(

--- a/conductor-cli/src/mcp/tools/worktrees.rs
+++ b/conductor-cli/src/mcp/tools/worktrees.rs
@@ -138,7 +138,7 @@ pub(super) fn tool_get_worktree(
 
     // Latest workflow run
     let wf_mgr = WorkflowManager::new(&conn);
-    match wf_mgr.list_workflow_runs(&wt.id) {
+    match conductor_core::workflow::list_workflow_runs(wf_mgr.conn(), &wt.id) {
         Ok(runs) => {
             if let Some(run) = runs.first() {
                 out.push_str(&format!(

--- a/conductor-core/src/test_helpers.rs
+++ b/conductor-core/src/test_helpers.rs
@@ -163,8 +163,8 @@ pub fn make_agent_parent_id(conn: &Connection) -> String {
 ///
 /// Suitable for tests that need a fan-out step to attach items to (e.g. dependency edge tests).
 pub fn make_foreach_step(conn: &Connection) -> String {
-    let parent_id = make_agent_parent_id(conn);
     let wf_mgr = crate::workflow::manager::WorkflowManager::new(conn);
+    let parent_id = make_agent_parent_id(conn);
     let run = wf_mgr
         .create_workflow_run("test-wf", Some("w1"), &parent_id, false, "manual", None)
         .unwrap();

--- a/conductor-core/src/workflow/coordinator.rs
+++ b/conductor-core/src/workflow/coordinator.rs
@@ -206,19 +206,20 @@ fn lock_shared(
 /// Extracted to a standalone function so it can be tested in isolation against an
 /// in-memory database without setting up a full engine.
 pub(crate) fn guard_active_run(
-    wf_mgr: &WorkflowManager<'_>,
+    conn: &rusqlite::Connection,
     worktree_id: &str,
     force: bool,
 ) -> Result<()> {
     if let Some(active) =
-        crate::workflow::manager::queries::get_active_run_for_worktree(wf_mgr.conn, worktree_id)?
+        crate::workflow::manager::queries::get_active_run_for_worktree(conn, worktree_id)?
     {
         if force {
             tracing::info!(
                 "Force override: cancelling active run {} to start new run",
                 active.id
             );
-            wf_mgr.cancel_run(&active.id, "force override: new run requested")?;
+            WorkflowManager::new(conn)
+                .cancel_run(&active.id, "force override: new run requested")?;
         } else {
             return Err(ConductorError::WorkflowRunAlreadyActive {
                 name: active.workflow_name,
@@ -451,7 +452,7 @@ pub fn execute_workflow_standalone(params: &WorkflowExecStandalone) -> Result<Wo
         // concurrently with their parent and must not trigger this check.
         if params.depth == 0 {
             if let Some(ref wt_id) = params.worktree_id {
-                guard_active_run(&wf_mgr, wt_id, params.force)?;
+                guard_active_run(conn, wt_id, params.force)?;
             }
         }
 
@@ -1416,7 +1417,7 @@ mod tests {
         let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let wf_name = "my-workflow";
         make_running_workflow_run(&conn, "w1", wf_name);
-        let err = guard_active_run(&wf_mgr, "w1", false).unwrap_err();
+        let err = guard_active_run(&conn, "w1", false).unwrap_err();
         assert!(
             matches!(err, crate::error::ConductorError::WorkflowRunAlreadyActive { ref name } if name == wf_name),
             "expected WorkflowRunAlreadyActive, got: {err}"
@@ -1428,7 +1429,7 @@ mod tests {
         let conn = setup_guard_db();
         let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         // No workflow runs exist — guard should pass.
-        guard_active_run(&wf_mgr, "w1", false).expect("no active run should return Ok");
+        guard_active_run(&conn, "w1", false).expect("no active run should return Ok");
     }
 
     #[test]
@@ -1436,7 +1437,7 @@ mod tests {
         let conn = setup_guard_db();
         let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let run_id = make_running_workflow_run(&conn, "w1", "my-wf");
-        guard_active_run(&wf_mgr, "w1", true).expect("force should cancel and return Ok");
+        guard_active_run(&conn, "w1", true).expect("force should cancel and return Ok");
 
         // The previously active run must now be cancelled.
         let row: String = conn
@@ -1468,7 +1469,7 @@ mod tests {
         .unwrap();
 
         // Completed run is not "active" — guard should pass.
-        guard_active_run(&wf_mgr, "w1", false).expect("completed run should not block new run");
+        guard_active_run(&conn, "w1", false).expect("completed run should not block new run");
     }
 
     // -------------------------------------------------------------------------

--- a/conductor-core/src/workflow/coordinator.rs
+++ b/conductor-core/src/workflow/coordinator.rs
@@ -211,7 +211,7 @@ pub(crate) fn guard_active_run(
     force: bool,
 ) -> Result<()> {
     if let Some(active) =
-        crate::workflow::manager::queries::get_active_run_for_worktree(wf_mgr.conn(), worktree_id)?
+        crate::workflow::manager::queries::get_active_run_for_worktree(wf_mgr.conn, worktree_id)?
     {
         if force {
             tracing::info!(
@@ -1397,7 +1397,7 @@ mod tests {
     ) -> String {
         let agent_mgr = crate::agent::AgentManager::new(conn);
         let parent = agent_mgr.create_run(Some(wt_id), "workflow", None).unwrap();
-        let wf_mgr = WorkflowManager::new(conn);
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(conn);
         let run = wf_mgr
             .create_workflow_run(wf_name, Some(wt_id), &parent.id, false, "manual", None)
             .unwrap();
@@ -1413,10 +1413,9 @@ mod tests {
     #[test]
     fn guard_active_run_returns_already_active_when_run_exists() {
         let conn = setup_guard_db();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let wf_name = "my-workflow";
         make_running_workflow_run(&conn, "w1", wf_name);
-
-        let wf_mgr = WorkflowManager::new(&conn);
         let err = guard_active_run(&wf_mgr, "w1", false).unwrap_err();
         assert!(
             matches!(err, crate::error::ConductorError::WorkflowRunAlreadyActive { ref name } if name == wf_name),
@@ -1427,7 +1426,7 @@ mod tests {
     #[test]
     fn guard_active_run_ok_when_no_active_run() {
         let conn = setup_guard_db();
-        let wf_mgr = WorkflowManager::new(&conn);
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         // No workflow runs exist — guard should pass.
         guard_active_run(&wf_mgr, "w1", false).expect("no active run should return Ok");
     }
@@ -1435,9 +1434,8 @@ mod tests {
     #[test]
     fn guard_active_run_force_cancels_active_run() {
         let conn = setup_guard_db();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let run_id = make_running_workflow_run(&conn, "w1", "my-wf");
-
-        let wf_mgr = WorkflowManager::new(&conn);
         guard_active_run(&wf_mgr, "w1", true).expect("force should cancel and return Ok");
 
         // The previously active run must now be cancelled.
@@ -1457,9 +1455,9 @@ mod tests {
     #[test]
     fn guard_active_run_ok_when_only_completed_runs_exist() {
         let conn = setup_guard_db();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let agent_mgr = crate::agent::AgentManager::new(&conn);
         let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-        let wf_mgr = WorkflowManager::new(&conn);
         let run = wf_mgr
             .create_workflow_run("wf", Some("w1"), &parent.id, false, "manual", None)
             .unwrap();
@@ -1595,6 +1593,7 @@ mod tests {
         let db_file = tempfile::NamedTempFile::new().unwrap();
         {
             let conn = crate::db::open_database(db_file.path()).unwrap();
+            let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
             crate::test_helpers::insert_test_repo(&conn, "r1", "test-repo", "/tmp/repo");
             crate::test_helpers::insert_test_worktree(&conn, "w1", "r1", "feat-test", "/tmp");
         }
@@ -1650,12 +1649,12 @@ mod tests {
         let db_file = NamedTempFile::new().unwrap();
         let run_id = {
             let conn = crate::db::open_database(db_file.path()).unwrap();
+            let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
             crate::test_helpers::insert_test_repo(&conn, "r1", "test-repo", "/tmp/repo");
             crate::test_helpers::insert_test_worktree(&conn, "w1", "r1", "feat-test", "/tmp");
             let parent = crate::agent::AgentManager::new(&conn)
                 .create_run(Some("w1"), "workflow", None)
                 .unwrap();
-            let wf_mgr = WorkflowManager::new(&conn);
             let run = wf_mgr
                 .create_workflow_run("test-wf", Some("w1"), &parent.id, false, "manual", None)
                 .unwrap();
@@ -1687,11 +1686,11 @@ mod tests {
         let db_file = NamedTempFile::new().unwrap();
         let run_id = {
             let conn = crate::db::open_database(db_file.path()).unwrap();
+            let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
             // Ephemeral runs have no worktree/repo/ticket — only an agent parent.
             let parent = crate::agent::AgentManager::new(&conn)
                 .create_run(None, "workflow", None)
                 .unwrap();
-            let wf_mgr = WorkflowManager::new(&conn);
             let run = wf_mgr
                 .create_workflow_run_with_targets(
                     "test-wf", None, // worktree_id
@@ -1763,6 +1762,7 @@ mod tests {
         );
 
         let conn = crate::db::open_database(db_file.path()).unwrap();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let status: String = conn
             .query_row("SELECT status FROM workflow_runs LIMIT 1", [], |r| r.get(0))
             .expect("workflow run must be persisted in the database");
@@ -1789,6 +1789,7 @@ mod tests {
         execute_workflow_standalone(&params).expect("empty workflow should succeed");
 
         let conn = crate::db::open_database(db_file.path()).unwrap();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let inputs_json: String = conn
             .query_row("SELECT inputs FROM workflow_runs LIMIT 1", [], |r| r.get(0))
             .expect("workflow run must be persisted");
@@ -1826,11 +1827,11 @@ mod tests {
         conn: &rusqlite::Connection,
         snapshot_json: Option<&str>,
     ) -> String {
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(conn);
         crate::test_helpers::insert_test_repo(conn, "r1", "test-repo", "/tmp");
         let parent = crate::agent::AgentManager::new(conn)
             .create_run(None, "workflow", None)
             .unwrap();
-        let wf_mgr = WorkflowManager::new(conn);
         let run = wf_mgr
             .create_workflow_run_with_targets(
                 "test-wf",
@@ -1872,6 +1873,7 @@ mod tests {
         let db_file = tempfile::NamedTempFile::new().unwrap();
         let run_id = {
             let conn = crate::db::open_database(db_file.path()).unwrap();
+            let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
             insert_failed_run_with_repo(&conn, None) // no definition_snapshot
         };
 
@@ -1892,6 +1894,7 @@ mod tests {
         let snapshot = serde_json::to_string(&make_wf(vec![])).unwrap();
         let run_id = {
             let conn = crate::db::open_database(db_file.path()).unwrap();
+            let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
             insert_failed_run_with_repo(&conn, Some(&snapshot))
         };
 
@@ -1910,6 +1913,7 @@ mod tests {
         let snapshot = serde_json::to_string(&make_wf(vec![])).unwrap();
         let run_id = {
             let conn = crate::db::open_database(db_file.path()).unwrap();
+            let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
             insert_failed_run_with_repo(&conn, Some(&snapshot))
         };
 
@@ -1935,6 +1939,7 @@ mod tests {
         let snapshot = serde_json::to_string(&make_wf(vec![])).unwrap();
         let run_id = {
             let conn = crate::db::open_database(db_file.path()).unwrap();
+            let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
             insert_failed_run_with_repo(&conn, Some(&snapshot))
         };
 
@@ -1947,6 +1952,7 @@ mod tests {
         );
 
         let conn = crate::db::open_database(db_file.path()).unwrap();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let status: String = conn
             .query_row(
                 "SELECT status FROM workflow_runs WHERE id = ?1",
@@ -1969,13 +1975,13 @@ mod tests {
         let snapshot = serde_json::to_string(&make_wf(vec![])).unwrap();
         let run_id = {
             let conn = crate::db::open_database(db_file.path()).unwrap();
+            let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
             // insert_test_repo / insert_test_worktree use "/tmp" paths that exist.
             crate::test_helpers::insert_test_repo(&conn, "r1", "test-repo", "/tmp");
             crate::test_helpers::insert_test_worktree(&conn, "w1", "r1", "feat-test", "/tmp");
             let parent = crate::agent::AgentManager::new(&conn)
                 .create_run(Some("w1"), "workflow", None)
                 .unwrap();
-            let wf_mgr = WorkflowManager::new(&conn);
             let run = wf_mgr
                 .create_workflow_run(
                     "test-wf",
@@ -2012,6 +2018,7 @@ mod tests {
         let snapshot = serde_json::to_string(&make_wf(vec![])).unwrap();
         let run_id = {
             let conn = crate::db::open_database(db_file.path()).unwrap();
+            let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
             insert_failed_run_with_repo(&conn, Some(&snapshot))
         };
 

--- a/conductor-core/src/workflow/coordinator.rs
+++ b/conductor-core/src/workflow/coordinator.rs
@@ -210,7 +210,9 @@ pub(crate) fn guard_active_run(
     worktree_id: &str,
     force: bool,
 ) -> Result<()> {
-    if let Some(active) = wf_mgr.get_active_run_for_worktree(worktree_id)? {
+    if let Some(active) =
+        crate::workflow::manager::queries::get_active_run_for_worktree(wf_mgr.conn(), worktree_id)?
+    {
         if force {
             tracing::info!(
                 "Force override: cancelling active run {} to start new run",
@@ -855,21 +857,21 @@ pub fn resume_workflow(input: &WorkflowResumeInput<'_>) -> Result<WorkflowResult
         let wt_mgr = WorktreeManager::new(conn, config);
 
         // Load and validate the workflow run
-        let wf_run = wf_mgr
-            .get_workflow_run(input.workflow_run_id)?
-            .ok_or_else(|| {
-                ConductorError::Workflow(format!(
-                    "Workflow run not found: {}",
-                    input.workflow_run_id
-                ))
-            })?;
+        let wf_run =
+            crate::workflow::manager::queries::get_workflow_run(conn, input.workflow_run_id)?
+                .ok_or_else(|| {
+                    ConductorError::Workflow(format!(
+                        "Workflow run not found: {}",
+                        input.workflow_run_id
+                    ))
+                })?;
 
         validate_resume_preconditions(&wf_run.status, input.restart, input.from_step)?;
 
         // Load steps for --from-step validation and skip-count logging.
         // Note: FlowEngine::resume() issues a second get_steps() query after all
         // DB resets complete, so it reads the accurate post-reset state.
-        let all_steps = wf_mgr.get_workflow_steps(&wf_run.id)?;
+        let all_steps = crate::workflow::manager::queries::get_workflow_steps(conn, &wf_run.id)?;
 
         // Validate --from-step early (fail-fast before heavier worktree/snapshot operations)
         if let Some(from_step) = input.from_step {

--- a/conductor-core/src/workflow/item_provider/tickets.rs
+++ b/conductor-core/src/workflow/item_provider/tickets.rs
@@ -315,6 +315,7 @@ mod tests {
     #[test]
     fn test_tickets_dependencies_returns_edges_within_set() {
         let conn = test_helpers::setup_db();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let config = crate::config::Config::default();
         let syncer = TicketSyncer::new(&conn);
 
@@ -346,7 +347,6 @@ mod tests {
         let id2 = by_src["2"].to_string();
 
         let step_id = test_helpers::make_foreach_step(&conn);
-        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         wf_mgr
             .insert_fan_out_item(&step_id, "ticket", &id1, "1")
             .unwrap();

--- a/conductor-core/src/workflow/item_provider/workflow_runs.rs
+++ b/conductor-core/src/workflow/item_provider/workflow_runs.rs
@@ -29,8 +29,11 @@ impl ItemProvider for WorkflowRunsProvider {
                 .collect()
         };
 
-        let wf_mgr = crate::workflow::manager::WorkflowManager::new(ctx.conn);
-        let rows = wf_mgr.list_runs_by_status(&statuses, workflow_name_filter)?;
+        let rows = crate::workflow::manager::queries::list_runs_by_status(
+            ctx.conn,
+            &statuses,
+            workflow_name_filter,
+        )?;
 
         Ok(collect_fan_out_items(
             rows,

--- a/conductor-core/src/workflow/item_provider/workflow_runs.rs
+++ b/conductor-core/src/workflow/item_provider/workflow_runs.rs
@@ -57,12 +57,11 @@ mod tests {
     #[test]
     fn test_default_terminal_statuses_when_no_filter() {
         let conn = test_helpers::setup_db();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let config = Config::default();
 
         // Insert a completed run and a running run.
         let parent_id = test_helpers::make_agent_parent_id(&conn);
-        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
-
         let run1 = wf_mgr
             .create_workflow_run("wf-a", Some("w1"), &parent_id, false, "manual", None)
             .unwrap();
@@ -108,11 +107,10 @@ mod tests {
     #[test]
     fn test_status_filter_respected() {
         let conn = test_helpers::setup_db();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let config = Config::default();
 
         let parent_id = test_helpers::make_agent_parent_id(&conn);
-        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
-
         let run1 = wf_mgr
             .create_workflow_run("wf-fail", Some("w1"), &parent_id, false, "manual", None)
             .unwrap();
@@ -160,11 +158,10 @@ mod tests {
     #[test]
     fn test_workflow_name_filter_respected() {
         let conn = test_helpers::setup_db();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let config = Config::default();
 
         let parent_id = test_helpers::make_agent_parent_id(&conn);
-        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
-
         let run_a = wf_mgr
             .create_workflow_run("wf-alpha", Some("w1"), &parent_id, false, "manual", None)
             .unwrap();
@@ -205,11 +202,10 @@ mod tests {
     #[test]
     fn test_existing_set_deduplication() {
         let conn = test_helpers::setup_db();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let config = Config::default();
 
         let parent_id = test_helpers::make_agent_parent_id(&conn);
-        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
-
         let run1 = wf_mgr
             .create_workflow_run("wf-x", Some("w1"), &parent_id, false, "manual", None)
             .unwrap();

--- a/conductor-core/src/workflow/item_provider/worktrees.rs
+++ b/conductor-core/src/workflow/item_provider/worktrees.rs
@@ -356,6 +356,7 @@ mod tests {
     #[test]
     fn test_worktrees_dependencies_returns_edges_via_tickets() {
         let conn = test_helpers::setup_db();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let config = Config::default();
 
         // Insert tickets: t2 blocked by t1.
@@ -398,7 +399,6 @@ mod tests {
         ).unwrap();
 
         let step_id = test_helpers::make_foreach_step(&conn);
-        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         wf_mgr
             .insert_fan_out_item(&step_id, "worktree", "wt1", "wt1-slug")
             .unwrap();

--- a/conductor-core/src/workflow/manager/fan_out.rs
+++ b/conductor-core/src/workflow/manager/fan_out.rs
@@ -50,11 +50,11 @@ impl<'a> WorkflowManager<'a> {
         step_id: &str,
         status_filter: Option<&str>,
     ) -> Result<Vec<FanOutItemRow>> {
-        let step =
-            self.get_step_by_id(step_id)?
-                .ok_or_else(|| ConductorError::WorkflowStepNotFound {
-                    id: step_id.to_string(),
-                })?;
+        let step = super::queries::get_step_by_id(self.conn, step_id)?.ok_or_else(|| {
+            ConductorError::WorkflowStepNotFound {
+                id: step_id.to_string(),
+            }
+        })?;
         if step.workflow_run_id != run_id {
             return Err(ConductorError::WorkflowStepNotInRun {
                 step_id: step_id.to_string(),

--- a/conductor-core/src/workflow/manager/lifecycle.rs
+++ b/conductor-core/src/workflow/manager/lifecycle.rs
@@ -218,8 +218,7 @@ impl<'a> WorkflowManager<'a> {
     /// no-op).  Step and child-run cancellation failures are silently ignored
     /// (best-effort).
     pub fn cancel_run(&self, run_id: &str, reason: &str) -> Result<()> {
-        let run = self
-            .get_workflow_run(run_id)?
+        let run = super::queries::get_workflow_run(self.conn, run_id)?
             .ok_or_else(|| ConductorError::Workflow(format!("Workflow run not found: {run_id}")))?;
 
         if matches!(
@@ -240,7 +239,7 @@ impl<'a> WorkflowManager<'a> {
         }
 
         let agent_mgr = AgentManager::new(self.conn);
-        if let Ok(steps) = self.get_workflow_steps(run_id) {
+        if let Ok(steps) = super::queries::get_workflow_steps(self.conn, run_id) {
             for step in steps {
                 if matches!(
                     step.status,
@@ -283,7 +282,7 @@ impl<'a> WorkflowManager<'a> {
         }
 
         // Recursively cancel child workflow runs (sub-workflows spawned by call_workflow steps)
-        if let Ok(children) = self.list_child_workflow_runs(run_id) {
+        if let Ok(children) = super::queries::list_child_workflow_runs(self.conn, run_id) {
             for child in children {
                 if matches!(
                     child.status,
@@ -389,7 +388,7 @@ impl<'a> WorkflowManager<'a> {
             Some(error_msg),
             Some(error_msg),
         )?;
-        if let Ok(Some(run)) = self.get_workflow_run(workflow_run_id) {
+        if let Ok(Some(run)) = super::queries::get_workflow_run(self.conn, workflow_run_id) {
             Ok(run.parent_run_id)
         } else {
             Err(ConductorError::InvalidInput(format!(

--- a/conductor-core/src/workflow/manager/mod.rs
+++ b/conductor-core/src/workflow/manager/mod.rs
@@ -19,18 +19,11 @@ use rusqlite::Connection;
 
 /// Manages workflow definitions, execution, and persistence.
 pub struct WorkflowManager<'a> {
-    pub(super) conn: &'a Connection,
+    pub(crate) conn: &'a Connection,
 }
 
 impl<'a> WorkflowManager<'a> {
     pub fn new(conn: &'a Connection) -> Self {
         Self { conn }
-    }
-
-    /// Borrow the underlying connection. Used by callers that need to invoke
-    /// module-level free functions in `crate::workflow::manager::queries` (and,
-    /// in subsequent migration PRs, the other manager-module free functions).
-    pub fn conn(&self) -> &'a Connection {
-        self.conn
     }
 }

--- a/conductor-core/src/workflow/manager/mod.rs
+++ b/conductor-core/src/workflow/manager/mod.rs
@@ -19,7 +19,7 @@ use rusqlite::Connection;
 
 /// Manages workflow definitions, execution, and persistence.
 pub struct WorkflowManager<'a> {
-    pub(crate) conn: &'a Connection,
+    pub(super) conn: &'a Connection,
 }
 
 impl<'a> WorkflowManager<'a> {

--- a/conductor-core/src/workflow/manager/mod.rs
+++ b/conductor-core/src/workflow/manager/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod definitions;
 mod fan_out;
 mod helpers;
 mod lifecycle;
-mod queries;
+pub(crate) mod queries;
 pub(crate) mod recovery;
 mod steps;
 
@@ -25,5 +25,12 @@ pub struct WorkflowManager<'a> {
 impl<'a> WorkflowManager<'a> {
     pub fn new(conn: &'a Connection) -> Self {
         Self { conn }
+    }
+
+    /// Borrow the underlying connection. Used by callers that need to invoke
+    /// module-level free functions in `crate::workflow::manager::queries` (and,
+    /// in subsequent migration PRs, the other manager-module free functions).
+    pub fn conn(&self) -> &'a Connection {
+        self.conn
     }
 }

--- a/conductor-core/src/workflow/manager/queries.rs
+++ b/conductor-core/src/workflow/manager/queries.rs
@@ -525,35 +525,30 @@ pub fn list_all_workflow_runs_filtered_paginated(
     limit: usize,
     offset: usize,
 ) -> Result<Vec<WorkflowRun>> {
-    if let Some(s) = status {
-        let status_str = s.to_string();
-        query_collect(
-            conn,
-            &format!(
-                "SELECT workflow_runs.* \
-                     FROM workflow_runs \
-                     LEFT JOIN worktrees ON worktrees.id = workflow_runs.worktree_id \
-                     WHERE ({ACTIVE_WORKTREE_GUARD}) \
-                       AND workflow_runs.status = :status \
-                     ORDER BY workflow_runs.started_at DESC LIMIT :limit OFFSET :offset"
-            ),
-            named_params! { ":status": status_str, ":limit": limit as i64, ":offset": offset as i64 },
-            row_to_workflow_run,
-        )
+    let status_str = status.map(|s| s.to_string());
+    let status_clause = if status_str.is_some() {
+        " AND workflow_runs.status = :status"
     } else {
-        query_collect(
-            conn,
-            &format!(
-                "SELECT workflow_runs.* \
-                     FROM workflow_runs \
-                     LEFT JOIN worktrees ON worktrees.id = workflow_runs.worktree_id \
-                     WHERE {ACTIVE_WORKTREE_GUARD} \
-                     ORDER BY workflow_runs.started_at DESC LIMIT :limit OFFSET :offset"
-            ),
-            named_params! { ":limit": limit as i64, ":offset": offset as i64 },
-            row_to_workflow_run,
-        )
+        ""
+    };
+    let sql = format!(
+        "SELECT workflow_runs.* \
+                 FROM workflow_runs \
+                 LEFT JOIN worktrees ON worktrees.id = workflow_runs.worktree_id \
+                 WHERE ({ACTIVE_WORKTREE_GUARD}){status_clause} \
+                 ORDER BY workflow_runs.started_at DESC LIMIT :limit OFFSET :offset"
+    );
+
+    let limit_i64 = limit as i64;
+    let offset_i64 = offset as i64;
+    let mut stmt = conn.prepare(&sql)?;
+    let mut params: Vec<(&str, &dyn rusqlite::ToSql)> =
+        vec![(":limit", &limit_i64), (":offset", &offset_i64)];
+    if let Some(ref s) = status_str {
+        params.push((":status", s));
     }
+    let rows = stmt.query_map(params.as_slice(), row_to_workflow_run)?;
+    Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
 }
 
 /// List recent workflow runs for a specific repo, ordered by started_at DESC.

--- a/conductor-core/src/workflow/manager/queries.rs
+++ b/conductor-core/src/workflow/manager/queries.rs
@@ -10,16 +10,16 @@ use super::helpers::{
     pending_gate_row_mapper, row_to_workflow_run, row_to_workflow_step,
     waiting_gate_step_row_mapper,
 };
-use super::WorkflowManager;
 use crate::workflow::constants::{
     REGRESSION_COST_THRESHOLD_PCT, REGRESSION_DURATION_THRESHOLD_PCT,
     REGRESSION_FAILURE_RATE_THRESHOLD_PP, RUN_COLUMNS, STEP_COLUMNS_WITH_PREFIX,
 };
+use rusqlite::Connection;
 
 /// Pre-expanded SELECT clause for step queries with agent-run token/cost columns.
 /// Computed once to avoid re-allocating the same `String` on every query.
 static STEP_SELECT_EXPANDED: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
-    WorkflowManager::STEP_SELECT_WITH_TOKENS.replace("{cols}", &STEP_COLUMNS_WITH_PREFIX)
+    STEP_SELECT_WITH_TOKENS.replace("{cols}", &STEP_COLUMNS_WITH_PREFIX)
 });
 use crate::workflow::WorkflowRunStatus;
 
@@ -51,575 +51,588 @@ fn granularity_to_strftime_format(granularity: TimeGranularity) -> &'static str 
     }
 }
 
-impl<'a> WorkflowManager<'a> {
-    /// Common SELECT clause for step queries. Token / cost / duration columns
-    /// live on `workflow_run_steps` directly since migration 081 — no JOIN to
-    /// `agent_runs` required.
-    const STEP_SELECT_WITH_TOKENS: &'static str = "SELECT {cols} FROM workflow_run_steps s";
+/// Common SELECT clause for step queries. Token / cost / duration columns
+/// live on `workflow_run_steps` directly since migration 081 — no JOIN to
+/// `agent_runs` required.
+const STEP_SELECT_WITH_TOKENS: &str = "SELECT {cols} FROM workflow_run_steps s";
 
-    /// Common subquery to get N most recent completed runs for a workflow.
-    const N_RECENT_COMPLETED_RUNS_SUBQUERY: &'static str = "SELECT id FROM workflow_runs \
-                 WHERE workflow_name = ?1 AND status = 'completed' \
-                 ORDER BY started_at DESC LIMIT ?2";
+/// Common subquery to get N most recent completed runs for a workflow.
+const N_RECENT_COMPLETED_RUNS_SUBQUERY: &str = "SELECT id FROM workflow_runs \
+             WHERE workflow_name = ?1 AND status = 'completed' \
+             ORDER BY started_at DESC LIMIT ?2";
 
-    /// Common subquery to get N most recent terminal runs (completed or failed) for a workflow.
-    const N_RECENT_TERMINAL_RUNS_SUBQUERY: &'static str = "SELECT id FROM workflow_runs \
-                 WHERE workflow_name = ?1 AND status IN ('completed', 'failed') \
-                 ORDER BY started_at DESC LIMIT ?2";
+/// Common subquery to get N most recent terminal runs (completed or failed) for a workflow.
+const N_RECENT_TERMINAL_RUNS_SUBQUERY: &str = "SELECT id FROM workflow_runs \
+             WHERE workflow_name = ?1 AND status IN ('completed', 'failed') \
+             ORDER BY started_at DESC LIMIT ?2";
 
-    /// Returns counts of active workflow runs (pending / running / waiting) per repo_id.
-    /// Repos with no active runs are absent from the map. Rows where repo_id IS NULL are skipped.
-    pub fn active_run_counts_by_repo(&self) -> Result<HashMap<String, ActiveWorkflowCounts>> {
-        let placeholders = sql_placeholders(WorkflowRunStatus::ACTIVE.len());
-        let sql = format!(
-            "SELECT repo_id, status, COUNT(*) AS cnt \
+/// Returns counts of active workflow runs (pending / running / waiting) per repo_id.
+/// Repos with no active runs are absent from the map. Rows where repo_id IS NULL are skipped.
+pub fn active_run_counts_by_repo(
+    conn: &Connection,
+) -> Result<HashMap<String, ActiveWorkflowCounts>> {
+    let placeholders = sql_placeholders(WorkflowRunStatus::ACTIVE.len());
+    let sql = format!(
+        "SELECT repo_id, status, COUNT(*) AS cnt \
              FROM workflow_runs \
              WHERE status IN ({placeholders}) \
                AND repo_id IS NOT NULL \
              GROUP BY repo_id, status"
-        );
-        let active_strings = WorkflowRunStatus::active_strings();
-        let mut stmt = self.conn.prepare_cached(&sql)?;
-        let rows = stmt.query_map(rusqlite::params_from_iter(active_strings.iter()), |row| {
-            let repo_id: String = row.get("repo_id")?;
-            let status: String = row.get("status")?;
-            let cnt: u32 = row.get("cnt")?;
-            Ok((repo_id, status, cnt))
-        })?;
-        let mut map: HashMap<String, ActiveWorkflowCounts> = HashMap::new();
-        for row in rows {
-            let (repo_id, status, cnt) = row?;
-            let entry = map.entry(repo_id).or_default();
-            match status.as_str() {
-                "pending" => entry.pending += cnt,
-                "running" => entry.running += cnt,
-                "waiting" => entry.waiting += cnt,
-                _ => {}
-            }
+    );
+    let active_strings = WorkflowRunStatus::active_strings();
+    let mut stmt = conn.prepare_cached(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(active_strings.iter()), |row| {
+        let repo_id: String = row.get("repo_id")?;
+        let status: String = row.get("status")?;
+        let cnt: u32 = row.get("cnt")?;
+        Ok((repo_id, status, cnt))
+    })?;
+    let mut map: HashMap<String, ActiveWorkflowCounts> = HashMap::new();
+    for row in rows {
+        let (repo_id, status, cnt) = row?;
+        let entry = map.entry(repo_id).or_default();
+        match status.as_str() {
+            "pending" => entry.pending += cnt,
+            "running" => entry.running += cnt,
+            "waiting" => entry.waiting += cnt,
+            _ => {}
         }
-        Ok(map)
     }
+    Ok(map)
+}
 
-    pub fn is_run_cancelled(&self, run_id: &str) -> Result<bool> {
-        let status: Option<String> = self
-            .conn
-            .query_row(
-                "SELECT status FROM workflow_runs WHERE id = ?1",
-                rusqlite::params![run_id],
-                |row| row.get(0),
-            )
-            .optional()?;
-        Ok(matches!(
-            status.as_deref(),
-            Some("cancelled") | Some("cancelling")
-        ))
-    }
-
-    pub fn get_workflow_run(&self, id: &str) -> Result<Option<WorkflowRun>> {
-        Ok(self
-            .conn
-            .query_row(
-                &format!("SELECT {RUN_COLUMNS} FROM workflow_runs WHERE id = :id"),
-                named_params! { ":id": id },
-                row_to_workflow_run,
-            )
-            .optional()?)
-    }
-
-    pub fn list_runs_by_status(
-        &self,
-        statuses: &[&str],
-        workflow_name: Option<&str>,
-    ) -> Result<Vec<(String, String)>> {
-        let placeholders = sql_placeholders(statuses.len());
-        let mut conditions = vec![format!("status IN ({placeholders})")];
-        let mut param_values: Vec<String> = statuses.iter().map(|s| s.to_string()).collect();
-
-        if let Some(name) = workflow_name {
-            param_values.push(name.to_string());
-            conditions.push(format!("workflow_name = ?{}", param_values.len()));
-        }
-
-        let sql = format!(
-            "SELECT id, workflow_name FROM workflow_runs WHERE {} ORDER BY started_at ASC",
-            conditions.join(" AND ")
-        );
-
-        query_collect(
-            self.conn,
-            &sql,
-            rusqlite::params_from_iter(param_values.iter()),
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+pub fn is_run_cancelled(conn: &Connection, run_id: &str) -> Result<bool> {
+    let status: Option<String> = conn
+        .query_row(
+            "SELECT status FROM workflow_runs WHERE id = ?1",
+            rusqlite::params![run_id],
+            |row| row.get(0),
         )
+        .optional()?;
+    Ok(matches!(
+        status.as_deref(),
+        Some("cancelled") | Some("cancelling")
+    ))
+}
+
+pub fn get_workflow_run(conn: &Connection, id: &str) -> Result<Option<WorkflowRun>> {
+    Ok(conn
+        .query_row(
+            &format!("SELECT {RUN_COLUMNS} FROM workflow_runs WHERE id = :id"),
+            named_params! { ":id": id },
+            row_to_workflow_run,
+        )
+        .optional()?)
+}
+
+pub fn list_runs_by_status(
+    conn: &Connection,
+    statuses: &[&str],
+    workflow_name: Option<&str>,
+) -> Result<Vec<(String, String)>> {
+    let placeholders = sql_placeholders(statuses.len());
+    let mut conditions = vec![format!("status IN ({placeholders})")];
+    let mut param_values: Vec<String> = statuses.iter().map(|s| s.to_string()).collect();
+
+    if let Some(name) = workflow_name {
+        param_values.push(name.to_string());
+        conditions.push(format!("workflow_name = ?{}", param_values.len()));
     }
 
-    /// List child workflow runs for a given parent run, ordered by start time.
-    pub fn list_child_workflow_runs(&self, parent_run_id: &str) -> Result<Vec<WorkflowRun>> {
-        let mut stmt = self.conn.prepare_cached(&format!(
-            "SELECT {RUN_COLUMNS} FROM workflow_runs \
+    let sql = format!(
+        "SELECT id, workflow_name FROM workflow_runs WHERE {} ORDER BY started_at ASC",
+        conditions.join(" AND ")
+    );
+
+    query_collect(
+        conn,
+        &sql,
+        rusqlite::params_from_iter(param_values.iter()),
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+    )
+}
+
+/// List child workflow runs for a given parent run, ordered by start time.
+pub fn list_child_workflow_runs(
+    conn: &Connection,
+    parent_run_id: &str,
+) -> Result<Vec<WorkflowRun>> {
+    let mut stmt = conn.prepare_cached(&format!(
+        "SELECT {RUN_COLUMNS} FROM workflow_runs \
              WHERE parent_workflow_run_id = :parent_workflow_run_id \
              ORDER BY started_at ASC"
-        ))?;
-        let rows = stmt.query_map(
-            named_params! { ":parent_workflow_run_id": parent_run_id },
-            row_to_workflow_run,
-        )?;
-        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
-    }
+    ))?;
+    let rows = stmt.query_map(
+        named_params! { ":parent_workflow_run_id": parent_run_id },
+        row_to_workflow_run,
+    )?;
+    Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+}
 
-    /// Resolve the execution context (working directory, repo path, and IDs) for
-    /// a workflow that targets a prior workflow run.
-    ///
-    /// The prior run must have either a `worktree_id` or a `repo_id` set.
-    /// Returns an error if the run is not found or its paths no longer exist on disk.
-    pub fn resolve_run_context(&self, run_id: &str, config: &Config) -> Result<WorkflowRunContext> {
-        let prior_run = self.get_workflow_run(run_id)?.ok_or_else(|| {
-            ConductorError::Workflow(format!("workflow run '{run_id}' not found"))
-        })?;
+/// Resolve the execution context (working directory, repo path, and IDs) for
+/// a workflow that targets a prior workflow run.
+///
+/// The prior run must have either a `worktree_id` or a `repo_id` set.
+/// Returns an error if the run is not found or its paths no longer exist on disk.
+pub fn resolve_run_context(
+    conn: &Connection,
+    run_id: &str,
+    config: &Config,
+) -> Result<WorkflowRunContext> {
+    let prior_run = get_workflow_run(conn, run_id)?
+        .ok_or_else(|| ConductorError::Workflow(format!("workflow run '{run_id}' not found")))?;
 
-        if let Some(ref wt_id) = prior_run.worktree_id {
-            let wt_mgr = crate::worktree::WorktreeManager::new(self.conn, config);
-            let wt = wt_mgr.get_by_id(wt_id)?;
-            if !std::path::Path::new(&wt.path).exists() {
-                return Err(ConductorError::Workflow(format!(
-                    "worktree path '{}' no longer exists on disk",
-                    wt.path
-                )));
-            }
-            let repo = crate::repo::RepoManager::new(self.conn, config).get_by_id(&wt.repo_id)?;
-            Ok(WorkflowRunContext {
-                working_dir: wt.path,
-                repo_path: repo.local_path,
-                worktree_id: Some(wt_id.clone()),
-                repo_id: Some(wt.repo_id),
-            })
-        } else if let Some(ref repo_id) = prior_run.repo_id {
-            let repo = crate::repo::RepoManager::new(self.conn, config).get_by_id(repo_id)?;
-            Ok(WorkflowRunContext {
-                working_dir: repo.local_path.clone(),
-                repo_path: repo.local_path,
-                worktree_id: None,
-                repo_id: Some(repo_id.clone()),
-            })
-        } else {
-            Err(ConductorError::Workflow(format!(
-                "workflow run '{run_id}' has no associated worktree or repo"
-            )))
+    if let Some(ref wt_id) = prior_run.worktree_id {
+        let wt_mgr = crate::worktree::WorktreeManager::new(conn, config);
+        let wt = wt_mgr.get_by_id(wt_id)?;
+        if !std::path::Path::new(&wt.path).exists() {
+            return Err(ConductorError::Workflow(format!(
+                "worktree path '{}' no longer exists on disk",
+                wt.path
+            )));
         }
+        let repo = crate::repo::RepoManager::new(conn, config).get_by_id(&wt.repo_id)?;
+        Ok(WorkflowRunContext {
+            working_dir: wt.path,
+            repo_path: repo.local_path,
+            worktree_id: Some(wt_id.clone()),
+            repo_id: Some(wt.repo_id),
+        })
+    } else if let Some(ref repo_id) = prior_run.repo_id {
+        let repo = crate::repo::RepoManager::new(conn, config).get_by_id(repo_id)?;
+        Ok(WorkflowRunContext {
+            working_dir: repo.local_path.clone(),
+            repo_path: repo.local_path,
+            worktree_id: None,
+            repo_id: Some(repo_id.clone()),
+        })
+    } else {
+        Err(ConductorError::Workflow(format!(
+            "workflow run '{run_id}' has no associated worktree or repo"
+        )))
     }
+}
 
-    pub fn get_workflow_steps(&self, workflow_run_id: &str) -> Result<Vec<WorkflowRunStep>> {
-        query_collect(
-            self.conn,
-            &format!(
-                "{} \
+pub fn get_workflow_steps(
+    conn: &Connection,
+    workflow_run_id: &str,
+) -> Result<Vec<WorkflowRunStep>> {
+    query_collect(
+        conn,
+        &format!(
+            "{} \
                  WHERE s.workflow_run_id = :workflow_run_id \
                  ORDER BY s.position",
-                &*STEP_SELECT_EXPANDED
-            ),
-            named_params! { ":workflow_run_id": workflow_run_id },
-            row_to_workflow_step,
-        )
-    }
+            &*STEP_SELECT_EXPANDED
+        ),
+        named_params! { ":workflow_run_id": workflow_run_id },
+        row_to_workflow_step,
+    )
+}
 
-    /// Batch-fetch steps for multiple runs in a single query.
-    /// Returns a map of run_id → steps (sorted by position).
-    pub fn get_steps_for_runs(
-        &self,
-        run_ids: &[&str],
-    ) -> Result<HashMap<String, Vec<WorkflowRunStep>>> {
-        self.fetch_steps_for_runs_filtered(run_ids, None)
-    }
+/// Batch-fetch steps for multiple runs in a single query.
+/// Returns a map of run_id → steps (sorted by position).
+pub fn get_steps_for_runs(
+    conn: &Connection,
+    run_ids: &[&str],
+) -> Result<HashMap<String, Vec<WorkflowRunStep>>> {
+    fetch_steps_for_runs_filtered(conn, run_ids, None)
+}
 
-    /// Batch-fetch only running/waiting steps for multiple runs in a single query.
-    /// Returns a map of run_id → active steps (sorted by position).
-    pub fn get_active_steps_for_runs(
-        &self,
-        run_ids: &[&str],
-    ) -> Result<HashMap<String, Vec<WorkflowRunStep>>> {
-        self.fetch_steps_for_runs_filtered(run_ids, Some(&["running", "waiting"]))
-    }
+/// Batch-fetch only running/waiting steps for multiple runs in a single query.
+/// Returns a map of run_id → active steps (sorted by position).
+pub fn get_active_steps_for_runs(
+    conn: &Connection,
+    run_ids: &[&str],
+) -> Result<HashMap<String, Vec<WorkflowRunStep>>> {
+    fetch_steps_for_runs_filtered(conn, run_ids, Some(&["running", "waiting"]))
+}
 
-    /// Batch-fetch running, waiting, and failed steps for multiple runs.
-    /// Used by the API to compute progress for both active and failed workflows.
-    pub fn get_progress_steps_for_runs(
-        &self,
-        run_ids: &[&str],
-    ) -> Result<HashMap<String, Vec<WorkflowRunStep>>> {
-        self.fetch_steps_for_runs_filtered(run_ids, Some(&["running", "waiting", "failed"]))
-    }
+/// Batch-fetch running, waiting, and failed steps for multiple runs.
+/// Used by the API to compute progress for both active and failed workflows.
+pub fn get_progress_steps_for_runs(
+    conn: &Connection,
+    run_ids: &[&str],
+) -> Result<HashMap<String, Vec<WorkflowRunStep>>> {
+    fetch_steps_for_runs_filtered(conn, run_ids, Some(&["running", "waiting", "failed"]))
+}
 
-    fn fetch_steps_for_runs_filtered(
-        &self,
-        run_ids: &[&str],
-        status_filter: Option<&[&str]>,
-    ) -> Result<HashMap<String, Vec<WorkflowRunStep>>> {
-        if run_ids.is_empty() {
-            return Ok(HashMap::new());
-        }
-        let placeholders = sql_placeholders(run_ids.len());
-        // Status placeholders must be offset so their ?N indices don't collide
-        // with the run_id placeholders (which use ?1..?run_ids.len()).
-        let status_clause = if let Some(statuses) = status_filter {
-            let offset = run_ids.len();
-            let status_placeholders = (1..=statuses.len())
-                .map(|i| format!("?{}", offset + i))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!(" AND s.status IN ({status_placeholders})")
-        } else {
-            String::new()
-        };
-        let sql = format!(
-            "{} \
+fn fetch_steps_for_runs_filtered(
+    conn: &Connection,
+    run_ids: &[&str],
+    status_filter: Option<&[&str]>,
+) -> Result<HashMap<String, Vec<WorkflowRunStep>>> {
+    if run_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let placeholders = sql_placeholders(run_ids.len());
+    // Status placeholders must be offset so their ?N indices don't collide
+    // with the run_id placeholders (which use ?1..?run_ids.len()).
+    let status_clause = if let Some(statuses) = status_filter {
+        let offset = run_ids.len();
+        let status_placeholders = (1..=statuses.len())
+            .map(|i| format!("?{}", offset + i))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(" AND s.status IN ({status_placeholders})")
+    } else {
+        String::new()
+    };
+    let sql = format!(
+        "{} \
              WHERE s.workflow_run_id IN ({placeholders}){status_clause} \
              ORDER BY s.workflow_run_id, s.position",
-            &*STEP_SELECT_EXPANDED
-        );
-        let combined = run_ids
-            .iter()
-            .copied()
-            .chain(status_filter.unwrap_or_default().iter().copied());
-        let mut stmt = self.conn.prepare_cached(&sql)?;
-        let steps = stmt
-            .query_map(rusqlite::params_from_iter(combined), row_to_workflow_step)?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-        let mut map: HashMap<String, Vec<WorkflowRunStep>> = HashMap::new();
-        for step in steps {
-            map.entry(step.workflow_run_id.clone())
-                .or_default()
-                .push(step);
-        }
-        Ok(map)
+        &*STEP_SELECT_EXPANDED
+    );
+    let combined = run_ids
+        .iter()
+        .copied()
+        .chain(status_filter.unwrap_or_default().iter().copied());
+    let mut stmt = conn.prepare_cached(&sql)?;
+    let steps = stmt
+        .query_map(rusqlite::params_from_iter(combined), row_to_workflow_step)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut map: HashMap<String, Vec<WorkflowRunStep>> = HashMap::new();
+    for step in steps {
+        map.entry(step.workflow_run_id.clone())
+            .or_default()
+            .push(step);
     }
+    Ok(map)
+}
 
-    pub fn get_step_by_id(&self, step_id: &str) -> Result<Option<WorkflowRunStep>> {
-        let mut stmt = self.conn.prepare_cached(&format!(
-            "{} \
+pub fn get_step_by_id(conn: &Connection, step_id: &str) -> Result<Option<WorkflowRunStep>> {
+    let mut stmt = conn.prepare_cached(&format!(
+        "{} \
              WHERE s.id = :id",
-            &*STEP_SELECT_EXPANDED
-        ))?;
-        let mut rows = stmt.query_map(named_params! { ":id": step_id }, row_to_workflow_step)?;
-        match rows.next() {
-            Some(row) => Ok(Some(row?)),
-            None => Ok(None),
-        }
+        &*STEP_SELECT_EXPANDED
+    ))?;
+    let mut rows = stmt.query_map(named_params! { ":id": step_id }, row_to_workflow_step)?;
+    match rows.next() {
+        Some(row) => Ok(Some(row?)),
+        None => Ok(None),
     }
+}
 
-    /// Find the most recent non-completed step for a given `(workflow_run_id, step_name, iteration)`.
-    ///
-    /// Returns `None` when no such row exists (fresh execution) or when the most recent
-    /// matching row is completed. Used by `execute_foreach` on resume to detect and reuse
-    /// a prior interrupted step rather than creating a duplicate row, which would make the
-    /// old step's fan_out_items invisible and violate `max_parallel`.
-    pub fn find_step_by_name_and_iteration(
-        &self,
-        workflow_run_id: &str,
-        step_name: &str,
-        iteration: i64,
-    ) -> Result<Option<WorkflowRunStep>> {
-        let mut stmt = self.conn.prepare_cached(&format!(
-            "{} \
+/// Find the most recent non-completed step for a given `(workflow_run_id, step_name, iteration)`.
+///
+/// Returns `None` when no such row exists (fresh execution) or when the most recent
+/// matching row is completed. Used by `execute_foreach` on resume to detect and reuse
+/// a prior interrupted step rather than creating a duplicate row, which would make the
+/// old step's fan_out_items invisible and violate `max_parallel`.
+pub fn find_step_by_name_and_iteration(
+    conn: &Connection,
+    workflow_run_id: &str,
+    step_name: &str,
+    iteration: i64,
+) -> Result<Option<WorkflowRunStep>> {
+    let mut stmt = conn.prepare_cached(&format!(
+        "{} \
              WHERE s.workflow_run_id = :workflow_run_id \
                AND s.step_name = :step_name \
                AND s.iteration = :iteration \
                AND s.status != 'completed' \
              ORDER BY s.id DESC \
              LIMIT 1",
-            &*STEP_SELECT_EXPANDED
-        ))?;
-        let mut rows = stmt.query_map(
-            named_params! {
-                ":workflow_run_id": workflow_run_id,
-                ":step_name": step_name,
-                ":iteration": iteration,
-            },
-            row_to_workflow_step,
-        )?;
-        match rows.next() {
-            Some(row) => Ok(Some(row?)),
-            None => Ok(None),
-        }
+        &*STEP_SELECT_EXPANDED
+    ))?;
+    let mut rows = stmt.query_map(
+        named_params! {
+            ":workflow_run_id": workflow_run_id,
+            ":step_name": step_name,
+            ":iteration": iteration,
+        },
+        row_to_workflow_step,
+    )?;
+    match rows.next() {
+        Some(row) => Ok(Some(row?)),
+        None => Ok(None),
     }
+}
 
-    /// Return the first active (pending/running/waiting) top-level workflow run for a worktree,
-    /// or `None` if none exist.
-    pub fn get_active_run_for_worktree(&self, worktree_id: &str) -> Result<Option<WorkflowRun>> {
-        let placeholders = sql_placeholders(WorkflowRunStatus::ACTIVE.len());
-        let active_strings = WorkflowRunStatus::active_strings();
-        let sql = format!(
-            "SELECT {RUN_COLUMNS} FROM workflow_runs \
+/// Return the first active (pending/running/waiting) top-level workflow run for a worktree,
+/// or `None` if none exist.
+pub fn get_active_run_for_worktree(
+    conn: &Connection,
+    worktree_id: &str,
+) -> Result<Option<WorkflowRun>> {
+    let placeholders = sql_placeholders(WorkflowRunStatus::ACTIVE.len());
+    let active_strings = WorkflowRunStatus::active_strings();
+    let sql = format!(
+        "SELECT {RUN_COLUMNS} FROM workflow_runs \
              WHERE worktree_id = ? AND status IN ({placeholders}) \
              LIMIT 1"
-        );
-        let mut all_params: Vec<rusqlite::types::Value> =
-            vec![rusqlite::types::Value::Text(worktree_id.to_owned())];
-        all_params.extend(active_strings.into_iter().map(rusqlite::types::Value::Text));
-        Ok(self
-            .conn
-            .query_row(
-                &sql,
-                rusqlite::params_from_iter(all_params.iter()),
-                row_to_workflow_run,
-            )
-            .optional()?)
-    }
+    );
+    let mut all_params: Vec<rusqlite::types::Value> =
+        vec![rusqlite::types::Value::Text(worktree_id.to_owned())];
+    all_params.extend(active_strings.into_iter().map(rusqlite::types::Value::Text));
+    Ok(conn
+        .query_row(
+            &sql,
+            rusqlite::params_from_iter(all_params.iter()),
+            row_to_workflow_run,
+        )
+        .optional()?)
+}
 
-    pub fn list_workflow_runs(&self, worktree_id: &str) -> Result<Vec<WorkflowRun>> {
-        query_collect(
-            self.conn,
+pub fn list_workflow_runs(conn: &Connection, worktree_id: &str) -> Result<Vec<WorkflowRun>> {
+    query_collect(
+            conn,
             &format!("SELECT {RUN_COLUMNS} FROM workflow_runs WHERE worktree_id = :worktree_id ORDER BY started_at DESC"),
             named_params! { ":worktree_id": worktree_id },
             row_to_workflow_run,
         )
-    }
+}
 
-    pub fn list_workflow_runs_filtered(
-        &self,
-        worktree_id: &str,
-        status: Option<WorkflowRunStatus>,
-    ) -> Result<Vec<WorkflowRun>> {
-        if let Some(s) = status {
-            let status_str = s.to_string();
-            query_collect(
-                self.conn,
-                &format!(
-                    "SELECT {RUN_COLUMNS} FROM workflow_runs \
+pub fn list_workflow_runs_filtered(
+    conn: &Connection,
+    worktree_id: &str,
+    status: Option<WorkflowRunStatus>,
+) -> Result<Vec<WorkflowRun>> {
+    if let Some(s) = status {
+        let status_str = s.to_string();
+        query_collect(
+            conn,
+            &format!(
+                "SELECT {RUN_COLUMNS} FROM workflow_runs \
                      WHERE worktree_id = :worktree_id AND status = :status \
                      ORDER BY started_at DESC"
-                ),
-                named_params! { ":worktree_id": worktree_id, ":status": status_str },
-                row_to_workflow_run,
-            )
-        } else {
-            self.list_workflow_runs(worktree_id)
-        }
+            ),
+            named_params! { ":worktree_id": worktree_id, ":status": status_str },
+            row_to_workflow_run,
+        )
+    } else {
+        list_workflow_runs(conn, worktree_id)
     }
+}
 
-    pub fn list_workflow_runs_by_repo_id_filtered(
-        &self,
-        repo_id: &str,
-        limit: usize,
-        offset: usize,
-        status: Option<WorkflowRunStatus>,
-    ) -> Result<Vec<WorkflowRun>> {
-        if let Some(s) = status {
-            let status_str = s.to_string();
-            query_collect(
-                self.conn,
-                &format!(
-                    "SELECT workflow_runs.* \
+pub fn list_workflow_runs_by_repo_id_filtered(
+    conn: &Connection,
+    repo_id: &str,
+    limit: usize,
+    offset: usize,
+    status: Option<WorkflowRunStatus>,
+) -> Result<Vec<WorkflowRun>> {
+    if let Some(s) = status {
+        let status_str = s.to_string();
+        query_collect(
+            conn,
+            &format!(
+                "SELECT workflow_runs.* \
                      FROM workflow_runs \
                      LEFT JOIN worktrees ON worktrees.id = workflow_runs.worktree_id \
                      WHERE workflow_runs.repo_id = :repo_id \
                        AND ({ACTIVE_WORKTREE_GUARD}) \
                        AND workflow_runs.status = :status \
                      ORDER BY workflow_runs.started_at DESC LIMIT :limit OFFSET :offset"
-                ),
-                named_params! { ":repo_id": repo_id, ":status": status_str, ":limit": limit as i64, ":offset": offset as i64 },
-                row_to_workflow_run,
-            )
-        } else {
-            self.list_workflow_runs_by_repo_id(repo_id, limit, offset)
-        }
+            ),
+            named_params! { ":repo_id": repo_id, ":status": status_str, ":limit": limit as i64, ":offset": offset as i64 },
+            row_to_workflow_run,
+        )
+    } else {
+        list_workflow_runs_by_repo_id(conn, repo_id, limit, offset)
     }
+}
 
-    /// Like `list_workflow_runs_filtered` but with explicit limit and offset for pagination.
-    pub fn list_workflow_runs_filtered_paginated(
-        &self,
-        worktree_id: &str,
-        status: Option<WorkflowRunStatus>,
-        limit: usize,
-        offset: usize,
-    ) -> Result<Vec<WorkflowRun>> {
-        if let Some(s) = status {
-            let status_str = s.to_string();
-            query_collect(
-                self.conn,
-                &format!(
-                    "SELECT {RUN_COLUMNS} FROM workflow_runs \
+/// Like `list_workflow_runs_filtered` but with explicit limit and offset for pagination.
+pub fn list_workflow_runs_filtered_paginated(
+    conn: &Connection,
+    worktree_id: &str,
+    status: Option<WorkflowRunStatus>,
+    limit: usize,
+    offset: usize,
+) -> Result<Vec<WorkflowRun>> {
+    if let Some(s) = status {
+        let status_str = s.to_string();
+        query_collect(
+            conn,
+            &format!(
+                "SELECT {RUN_COLUMNS} FROM workflow_runs \
                      WHERE worktree_id = :worktree_id AND status = :status \
                      ORDER BY started_at DESC LIMIT :limit OFFSET :offset"
-                ),
-                named_params! { ":worktree_id": worktree_id, ":status": status_str, ":limit": limit as i64, ":offset": offset as i64 },
-                row_to_workflow_run,
-            )
-        } else {
-            self.list_workflow_runs_paginated(worktree_id, limit, offset)
-        }
+            ),
+            named_params! { ":worktree_id": worktree_id, ":status": status_str, ":limit": limit as i64, ":offset": offset as i64 },
+            row_to_workflow_run,
+        )
+    } else {
+        list_workflow_runs_paginated(conn, worktree_id, limit, offset)
     }
+}
 
-    /// List recent workflow runs across all worktrees, ordered by started_at DESC.
-    /// Only includes runs whose associated worktree is `active` (or runs with no
-    /// worktree, i.e. ephemeral/repo-targeted runs).
-    pub fn list_all_workflow_runs(&self, limit: usize) -> Result<Vec<WorkflowRun>> {
-        query_collect(
-            self.conn,
-            &format!(
-                "SELECT workflow_runs.* \
+/// List recent workflow runs across all worktrees, ordered by started_at DESC.
+/// Only includes runs whose associated worktree is `active` (or runs with no
+/// worktree, i.e. ephemeral/repo-targeted runs).
+pub fn list_all_workflow_runs(conn: &Connection, limit: usize) -> Result<Vec<WorkflowRun>> {
+    query_collect(
+        conn,
+        &format!(
+            "SELECT workflow_runs.* \
                  FROM workflow_runs \
                  LEFT JOIN worktrees ON worktrees.id = workflow_runs.worktree_id \
                  WHERE {ACTIVE_WORKTREE_GUARD} \
                  ORDER BY workflow_runs.started_at DESC LIMIT :limit"
-            ),
-            named_params! { ":limit": limit as i64 },
-            row_to_workflow_run,
-        )
+        ),
+        named_params! { ":limit": limit as i64 },
+        row_to_workflow_run,
+    )
+}
+
+/// When `statuses` is empty, returns `WorkflowRunStatus::ACTIVE`; otherwise returns `statuses`.
+fn effective_statuses(statuses: &[WorkflowRunStatus]) -> &[WorkflowRunStatus] {
+    if statuses.is_empty() {
+        &WorkflowRunStatus::ACTIVE
+    } else {
+        statuses
     }
+}
 
-    /// When `statuses` is empty, returns `WorkflowRunStatus::ACTIVE`; otherwise returns `statuses`.
-    fn effective_statuses(statuses: &[WorkflowRunStatus]) -> &[WorkflowRunStatus] {
-        if statuses.is_empty() {
-            &WorkflowRunStatus::ACTIVE
-        } else {
-            statuses
-        }
-    }
+/// List workflow runs across all worktrees filtered by a set of statuses.
+/// When `statuses` is empty, defaults to `[running, waiting, pending]`.
+/// Only includes runs whose associated worktree is `active` (or runs with no worktree).
+/// Ordered by `started_at DESC`.
+pub fn list_active_workflow_runs(
+    conn: &Connection,
+    statuses: &[WorkflowRunStatus],
+) -> Result<Vec<WorkflowRun>> {
+    let effective = effective_statuses(statuses);
 
-    /// List workflow runs across all worktrees filtered by a set of statuses.
-    /// When `statuses` is empty, defaults to `[running, waiting, pending]`.
-    /// Only includes runs whose associated worktree is `active` (or runs with no worktree).
-    /// Ordered by `started_at DESC`.
-    pub fn list_active_workflow_runs(
-        &self,
-        statuses: &[WorkflowRunStatus],
-    ) -> Result<Vec<WorkflowRun>> {
-        let effective = Self::effective_statuses(statuses);
+    let placeholders = sql_placeholders(effective.len());
 
-        let placeholders = sql_placeholders(effective.len());
-
-        let sql = format!(
-            "SELECT workflow_runs.* \
+    let sql = format!(
+        "SELECT workflow_runs.* \
              FROM workflow_runs \
              LEFT JOIN worktrees ON worktrees.id = workflow_runs.worktree_id \
              WHERE ({ACTIVE_WORKTREE_GUARD}) \
                AND workflow_runs.status IN ({placeholders}) \
              ORDER BY workflow_runs.started_at DESC \
              LIMIT 500"
-        );
+    );
 
-        let status_strings: Vec<String> = effective.iter().map(|s| s.to_string()).collect();
-        let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(
-            rusqlite::params_from_iter(status_strings.iter()),
-            row_to_workflow_run,
-        )?;
-        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
-    }
+    let status_strings: Vec<String> = effective.iter().map(|s| s.to_string()).collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(
+        rusqlite::params_from_iter(status_strings.iter()),
+        row_to_workflow_run,
+    )?;
+    Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+}
 
-    /// Like `list_all_workflow_runs` but with an optional status filter and pagination offset.
-    /// Covers all repos; the active-worktree guard is identical to `list_all_workflow_runs`.
-    pub fn list_all_workflow_runs_filtered_paginated(
-        &self,
-        status: Option<WorkflowRunStatus>,
-        limit: usize,
-        offset: usize,
-    ) -> Result<Vec<WorkflowRun>> {
-        if let Some(s) = status {
-            let status_str = s.to_string();
-            query_collect(
-                self.conn,
-                &format!(
-                    "SELECT workflow_runs.* \
+/// Like `list_all_workflow_runs` but with an optional status filter and pagination offset.
+/// Covers all repos; the active-worktree guard is identical to `list_all_workflow_runs`.
+pub fn list_all_workflow_runs_filtered_paginated(
+    conn: &Connection,
+    status: Option<WorkflowRunStatus>,
+    limit: usize,
+    offset: usize,
+) -> Result<Vec<WorkflowRun>> {
+    if let Some(s) = status {
+        let status_str = s.to_string();
+        query_collect(
+            conn,
+            &format!(
+                "SELECT workflow_runs.* \
                      FROM workflow_runs \
                      LEFT JOIN worktrees ON worktrees.id = workflow_runs.worktree_id \
                      WHERE ({ACTIVE_WORKTREE_GUARD}) \
                        AND workflow_runs.status = :status \
                      ORDER BY workflow_runs.started_at DESC LIMIT :limit OFFSET :offset"
-                ),
-                named_params! { ":status": status_str, ":limit": limit as i64, ":offset": offset as i64 },
-                row_to_workflow_run,
-            )
-        } else {
-            query_collect(
-                self.conn,
-                &format!(
-                    "SELECT workflow_runs.* \
+            ),
+            named_params! { ":status": status_str, ":limit": limit as i64, ":offset": offset as i64 },
+            row_to_workflow_run,
+        )
+    } else {
+        query_collect(
+            conn,
+            &format!(
+                "SELECT workflow_runs.* \
                      FROM workflow_runs \
                      LEFT JOIN worktrees ON worktrees.id = workflow_runs.worktree_id \
                      WHERE {ACTIVE_WORKTREE_GUARD} \
                      ORDER BY workflow_runs.started_at DESC LIMIT :limit OFFSET :offset"
-                ),
-                named_params! { ":limit": limit as i64, ":offset": offset as i64 },
-                row_to_workflow_run,
-            )
-        }
+            ),
+            named_params! { ":limit": limit as i64, ":offset": offset as i64 },
+            row_to_workflow_run,
+        )
     }
+}
 
-    /// List recent workflow runs for a specific repo, ordered by started_at DESC.
-    /// Unlike `list_all_workflow_runs` + filter, this queries directly by `repo_id`
-    /// so older per-repo runs beyond a global cap are never silently omitted.
-    /// Only includes runs whose associated worktree is `active` (or runs with no worktree).
-    pub fn list_workflow_runs_by_repo_id(
-        &self,
-        repo_id: &str,
-        limit: usize,
-        offset: usize,
-    ) -> Result<Vec<WorkflowRun>> {
-        query_collect(
-            self.conn,
-            &format!(
-                "SELECT workflow_runs.* \
+/// List recent workflow runs for a specific repo, ordered by started_at DESC.
+/// Unlike `list_all_workflow_runs` + filter, this queries directly by `repo_id`
+/// so older per-repo runs beyond a global cap are never silently omitted.
+/// Only includes runs whose associated worktree is `active` (or runs with no worktree).
+pub fn list_workflow_runs_by_repo_id(
+    conn: &Connection,
+    repo_id: &str,
+    limit: usize,
+    offset: usize,
+) -> Result<Vec<WorkflowRun>> {
+    query_collect(
+        conn,
+        &format!(
+            "SELECT workflow_runs.* \
                  FROM workflow_runs \
                  LEFT JOIN worktrees ON worktrees.id = workflow_runs.worktree_id \
                  WHERE workflow_runs.repo_id = :repo_id \
                    AND ({ACTIVE_WORKTREE_GUARD}) \
                  ORDER BY workflow_runs.started_at DESC LIMIT :limit OFFSET :offset"
-            ),
-            named_params! { ":repo_id": repo_id, ":limit": limit as i64, ":offset": offset as i64 },
-            row_to_workflow_run,
-        )
-    }
+        ),
+        named_params! { ":repo_id": repo_id, ":limit": limit as i64, ":offset": offset as i64 },
+        row_to_workflow_run,
+    )
+}
 
-    /// Like `list_workflow_runs` but with explicit limit and offset for pagination.
-    /// `list_workflow_runs` is kept for TUI callers that return all runs.
-    pub fn list_workflow_runs_paginated(
-        &self,
-        worktree_id: &str,
-        limit: usize,
-        offset: usize,
-    ) -> Result<Vec<WorkflowRun>> {
-        query_collect(
-            self.conn,
-            &format!(
-                "SELECT {RUN_COLUMNS} FROM workflow_runs \
+/// Like `list_workflow_runs` but with explicit limit and offset for pagination.
+/// `list_workflow_runs` is kept for TUI callers that return all runs.
+pub fn list_workflow_runs_paginated(
+    conn: &Connection,
+    worktree_id: &str,
+    limit: usize,
+    offset: usize,
+) -> Result<Vec<WorkflowRun>> {
+    query_collect(
+        conn,
+        &format!(
+            "SELECT {RUN_COLUMNS} FROM workflow_runs \
                  WHERE worktree_id = :worktree_id \
                  ORDER BY started_at DESC LIMIT :limit OFFSET :offset"
-            ),
-            named_params! { ":worktree_id": worktree_id, ":limit": limit as i64, ":offset": offset as i64 },
-            row_to_workflow_run,
-        )
-    }
+        ),
+        named_params! { ":worktree_id": worktree_id, ":limit": limit as i64, ":offset": offset as i64 },
+        row_to_workflow_run,
+    )
+}
 
-    /// List recent root workflow runs (those with no parent workflow run) across all
-    /// worktrees, ordered by started_at DESC.  Used in the TUI per-worktree slot so that
-    /// the root run wins over any concurrently-active child run.
-    pub fn list_root_workflow_runs(&self, limit: usize) -> Result<Vec<WorkflowRun>> {
-        query_collect(
-            self.conn,
-            &format!(
-                "SELECT {RUN_COLUMNS} FROM workflow_runs \
+/// List recent root workflow runs (those with no parent workflow run) across all
+/// worktrees, ordered by started_at DESC.  Used in the TUI per-worktree slot so that
+/// the root run wins over any concurrently-active child run.
+pub fn list_root_workflow_runs(conn: &Connection, limit: usize) -> Result<Vec<WorkflowRun>> {
+    query_collect(
+        conn,
+        &format!(
+            "SELECT {RUN_COLUMNS} FROM workflow_runs \
                  WHERE parent_workflow_run_id IS NULL \
                  ORDER BY started_at DESC LIMIT :limit"
-            ),
-            named_params! { ":limit": limit as i64 },
-            row_to_workflow_run,
-        )
-    }
+        ),
+        named_params! { ":limit": limit as i64 },
+        row_to_workflow_run,
+    )
+}
 
-    /// List active (running or waiting) and recently-terminated root workflow runs that have no
-    /// associated worktree (`worktree_id IS NULL`).  These are repo- or ticket-targeted
-    /// workflows (e.g. `label-all-tickets`) that the TUI status bar would otherwise
-    /// never show.
-    ///
-    /// Recently-terminated runs (ended within the last 60 seconds) are included so that the
-    /// terminal-transition detector has at least one poll tick to observe the
-    /// `running → completed/failed` flip and fire the corresponding notification.
-    pub fn list_active_non_worktree_workflow_runs(&self, limit: i64) -> Result<Vec<WorkflowRun>> {
-        query_collect(
-            self.conn,
-            &format!(
-                "SELECT {RUN_COLUMNS} FROM workflow_runs \
+/// List active (running or waiting) and recently-terminated root workflow runs that have no
+/// associated worktree (`worktree_id IS NULL`).  These are repo- or ticket-targeted
+/// workflows (e.g. `label-all-tickets`) that the TUI status bar would otherwise
+/// never show.
+///
+/// Recently-terminated runs (ended within the last 60 seconds) are included so that the
+/// terminal-transition detector has at least one poll tick to observe the
+/// `running → completed/failed` flip and fire the corresponding notification.
+pub fn list_active_non_worktree_workflow_runs(
+    conn: &Connection,
+    limit: i64,
+) -> Result<Vec<WorkflowRun>> {
+    query_collect(
+        conn,
+        &format!(
+            "SELECT {RUN_COLUMNS} FROM workflow_runs \
                  WHERE parent_workflow_run_id IS NULL \
                    AND worktree_id IS NULL \
                    AND (\
@@ -630,99 +643,102 @@ impl<'a> WorkflowManager<'a> {
                        )\
                    ) \
                  ORDER BY started_at DESC LIMIT :limit"
-            ),
-            named_params! { ":limit": limit },
-            row_to_workflow_run,
-        )
-    }
+        ),
+        named_params! { ":limit": limit },
+        row_to_workflow_run,
+    )
+}
 
-    /// Walk the active child chain starting from `root_run_id` and return the
-    /// ordered list of `(id, workflow_name)` pairs below the root (the root is
-    /// excluded — the caller already has it).
-    ///
-    /// Iterates at most `MAX_WORKFLOW_DEPTH` times to match the execution depth cap.
-    pub fn get_active_chain_for_run(&self, root_run_id: &str) -> Result<Vec<(String, String)>> {
-        const MAX_DEPTH: usize = 5;
-        let mut chain: Vec<(String, String)> = Vec::new();
-        let mut current_id = root_run_id.to_string();
-        for _ in 0..MAX_DEPTH {
-            let mut stmt = self.conn.prepare_cached(
-                "SELECT id, workflow_name FROM workflow_runs \
+/// Walk the active child chain starting from `root_run_id` and return the
+/// ordered list of `(id, workflow_name)` pairs below the root (the root is
+/// excluded — the caller already has it).
+///
+/// Iterates at most `MAX_WORKFLOW_DEPTH` times to match the execution depth cap.
+pub fn get_active_chain_for_run(
+    conn: &Connection,
+    root_run_id: &str,
+) -> Result<Vec<(String, String)>> {
+    const MAX_DEPTH: usize = 5;
+    let mut chain: Vec<(String, String)> = Vec::new();
+    let mut current_id = root_run_id.to_string();
+    for _ in 0..MAX_DEPTH {
+        let mut stmt = conn.prepare_cached(
+            "SELECT id, workflow_name FROM workflow_runs \
                  WHERE parent_workflow_run_id = :parent_workflow_run_id \
                    AND status IN ('running', 'waiting') \
                  LIMIT 1",
-            )?;
-            let result: Option<(String, String)> = stmt
-                .query_row(
-                    named_params! { ":parent_workflow_run_id": current_id },
-                    |row| Ok((row.get("id")?, row.get("workflow_name")?)),
-                )
-                .optional()?;
-            match result {
-                Some((child_id, child_name)) => {
-                    chain.push((child_id.clone(), child_name));
-                    current_id = child_id;
-                }
-                None => break,
+        )?;
+        let result: Option<(String, String)> = stmt
+            .query_row(
+                named_params! { ":parent_workflow_run_id": current_id },
+                |row| Ok((row.get("id")?, row.get("workflow_name")?)),
+            )
+            .optional()?;
+        match result {
+            Some((child_id, child_name)) => {
+                chain.push((child_id.clone(), child_name));
+                current_id = child_id;
             }
-        }
-        Ok(chain)
-    }
-
-    /// Load runs for a single worktree, or the most recent `global_limit` runs across all
-    /// worktrees when `worktree_id` is `None`. Consolidates the scoped-vs-global branching
-    /// that would otherwise be duplicated at every call site.
-    pub fn list_workflow_runs_for_scope(
-        &self,
-        worktree_id: Option<&str>,
-        global_limit: usize,
-    ) -> Result<Vec<WorkflowRun>> {
-        match worktree_id {
-            Some(wt_id) => self.list_workflow_runs(wt_id),
-            None => self.list_all_workflow_runs(global_limit),
+            None => break,
         }
     }
+    Ok(chain)
+}
 
-    /// List recent workflow runs for a specific repo, ordered by started_at DESC.
-    /// Includes runs from all worktrees belonging to the repo, plus any repo-targeted runs.
-    /// Matches via `workflow_runs.repo_id` OR via the worktree join, since worktree-targeted
-    /// runs may have `repo_id = NULL` and are only linked to the repo through `worktrees.repo_id`.
-    pub fn list_workflow_runs_for_repo(
-        &self,
-        repo_id: &str,
-        limit: usize,
-    ) -> Result<Vec<WorkflowRun>> {
-        query_collect(
-            self.conn,
-            &format!(
-                "SELECT DISTINCT workflow_runs.* \
+/// Load runs for a single worktree, or the most recent `global_limit` runs across all
+/// worktrees when `worktree_id` is `None`. Consolidates the scoped-vs-global branching
+/// that would otherwise be duplicated at every call site.
+pub fn list_workflow_runs_for_scope(
+    conn: &Connection,
+    worktree_id: Option<&str>,
+    global_limit: usize,
+) -> Result<Vec<WorkflowRun>> {
+    match worktree_id {
+        Some(wt_id) => list_workflow_runs(conn, wt_id),
+        None => list_all_workflow_runs(conn, global_limit),
+    }
+}
+
+/// List recent workflow runs for a specific repo, ordered by started_at DESC.
+/// Includes runs from all worktrees belonging to the repo, plus any repo-targeted runs.
+/// Matches via `workflow_runs.repo_id` OR via the worktree join, since worktree-targeted
+/// runs may have `repo_id = NULL` and are only linked to the repo through `worktrees.repo_id`.
+pub fn list_workflow_runs_for_repo(
+    conn: &Connection,
+    repo_id: &str,
+    limit: usize,
+) -> Result<Vec<WorkflowRun>> {
+    query_collect(
+        conn,
+        &format!(
+            "SELECT DISTINCT workflow_runs.* \
                  FROM workflow_runs \
                  LEFT JOIN worktrees ON worktrees.id = workflow_runs.worktree_id \
                  WHERE workflow_runs.repo_id = :repo_id OR worktrees.repo_id = :repo_id \
                  ORDER BY workflow_runs.started_at DESC LIMIT {limit}"
-            ),
-            named_params! { ":repo_id": repo_id },
-            row_to_workflow_run,
-        )
-    }
+        ),
+        named_params! { ":repo_id": repo_id },
+        row_to_workflow_run,
+    )
+}
 
-    /// List workflow runs filtered by a set of statuses and scoped to a single repo.
-    /// Covers both direct association (`workflow_runs.repo_id = repo_id`) and indirect
-    /// association via a worktree (`worktrees.repo_id = repo_id`).
-    /// When `statuses` is empty, defaults to `[running, waiting, pending]`.
-    /// Only includes runs whose associated worktree is `active` (or runs with no worktree).
-    /// Ordered by `started_at DESC`.
-    pub fn list_active_workflow_runs_for_repo(
-        &self,
-        repo_id: &str,
-        statuses: &[WorkflowRunStatus],
-    ) -> Result<Vec<WorkflowRun>> {
-        let effective = Self::effective_statuses(statuses);
+/// List workflow runs filtered by a set of statuses and scoped to a single repo.
+/// Covers both direct association (`workflow_runs.repo_id = repo_id`) and indirect
+/// association via a worktree (`worktrees.repo_id = repo_id`).
+/// When `statuses` is empty, defaults to `[running, waiting, pending]`.
+/// Only includes runs whose associated worktree is `active` (or runs with no worktree).
+/// Ordered by `started_at DESC`.
+pub fn list_active_workflow_runs_for_repo(
+    conn: &Connection,
+    repo_id: &str,
+    statuses: &[WorkflowRunStatus],
+) -> Result<Vec<WorkflowRun>> {
+    let effective = effective_statuses(statuses);
 
-        let placeholders = sql_placeholders(effective.len());
+    let placeholders = sql_placeholders(effective.len());
 
-        let sql = format!(
-            "SELECT DISTINCT workflow_runs.* \
+    let sql = format!(
+        "SELECT DISTINCT workflow_runs.* \
              FROM workflow_runs \
              LEFT JOIN worktrees ON worktrees.id = workflow_runs.worktree_id \
              WHERE (workflow_runs.repo_id = ? OR worktrees.repo_id = ?) \
@@ -730,100 +746,102 @@ impl<'a> WorkflowManager<'a> {
                AND workflow_runs.status IN ({placeholders}) \
              ORDER BY workflow_runs.started_at DESC \
              LIMIT 500"
-        );
+    );
 
-        let status_strings: Vec<String> = effective.iter().map(|s| s.to_string()).collect();
-        let mut all_params: Vec<rusqlite::types::Value> = vec![
-            rusqlite::types::Value::Text(repo_id.to_owned()),
-            rusqlite::types::Value::Text(repo_id.to_owned()),
-        ];
-        all_params.extend(status_strings.into_iter().map(rusqlite::types::Value::Text));
-        let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(
-            rusqlite::params_from_iter(all_params.iter()),
-            row_to_workflow_run,
-        )?;
-        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+    let status_strings: Vec<String> = effective.iter().map(|s| s.to_string()).collect();
+    let mut all_params: Vec<rusqlite::types::Value> = vec![
+        rusqlite::types::Value::Text(repo_id.to_owned()),
+        rusqlite::types::Value::Text(repo_id.to_owned()),
+    ];
+    all_params.extend(status_strings.into_iter().map(rusqlite::types::Value::Text));
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(
+        rusqlite::params_from_iter(all_params.iter()),
+        row_to_workflow_run,
+    )?;
+    Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+}
+
+/// Batch-lookup the parent `workflow_run_id` for a set of agent run IDs.
+///
+/// Uses `workflow_run_steps.child_run_id` to find the link.  Returns a map
+/// of `agent_run_id → workflow_run_id`.  Agent runs that are not linked to
+/// any workflow step are simply absent from the map.
+///
+/// Avoids N+1 queries — one SQL round-trip regardless of slice size.
+pub fn get_workflow_run_ids_for_agent_runs(
+    conn: &Connection,
+    agent_run_ids: &[&str],
+) -> Result<std::collections::HashMap<String, String>> {
+    if agent_run_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
     }
-
-    /// Batch-lookup the parent `workflow_run_id` for a set of agent run IDs.
-    ///
-    /// Uses `workflow_run_steps.child_run_id` to find the link.  Returns a map
-    /// of `agent_run_id → workflow_run_id`.  Agent runs that are not linked to
-    /// any workflow step are simply absent from the map.
-    ///
-    /// Avoids N+1 queries — one SQL round-trip regardless of slice size.
-    pub fn get_workflow_run_ids_for_agent_runs(
-        &self,
-        agent_run_ids: &[&str],
-    ) -> Result<std::collections::HashMap<String, String>> {
-        if agent_run_ids.is_empty() {
-            return Ok(std::collections::HashMap::new());
-        }
-        let placeholders = sql_placeholders(agent_run_ids.len());
-        let sql = format!(
-            "SELECT child_run_id, workflow_run_id \
+    let placeholders = sql_placeholders(agent_run_ids.len());
+    let sql = format!(
+        "SELECT child_run_id, workflow_run_id \
              FROM workflow_run_steps \
              WHERE child_run_id IN ({placeholders}) \
              GROUP BY child_run_id"
-        );
-        let mut stmt = self.conn.prepare(&sql)?;
-        let mut map = std::collections::HashMap::new();
-        let params_iter = rusqlite::params_from_iter(agent_run_ids.iter());
-        let rows = stmt.query_map(params_iter, |row| {
-            Ok((
-                row.get::<_, String>("child_run_id")?,
-                row.get::<_, String>("workflow_run_id")?,
-            ))
-        })?;
-        for row in rows {
-            let (child_run_id, workflow_run_id) = row?;
-            map.insert(child_run_id, workflow_run_id);
-        }
-        Ok(map)
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut map = std::collections::HashMap::new();
+    let params_iter = rusqlite::params_from_iter(agent_run_ids.iter());
+    let rows = stmt.query_map(params_iter, |row| {
+        Ok((
+            row.get::<_, String>("child_run_id")?,
+            row.get::<_, String>("workflow_run_id")?,
+        ))
+    })?;
+    for row in rows {
+        let (child_run_id, workflow_run_id) = row?;
+        map.insert(child_run_id, workflow_run_id);
     }
+    Ok(map)
+}
 
-    /// Fetch the active waiting gate step for each of the given run IDs in one query.
-    ///
-    /// Returns a map from workflow_run_id → the single `running`/`waiting` gate step for that
-    /// run.  Runs that have no waiting gate are absent from the map.
-    pub fn find_waiting_gates_for_runs(
-        &self,
-        run_ids: &[&str],
-    ) -> Result<HashMap<String, WorkflowRunStep>> {
-        if run_ids.is_empty() {
-            return Ok(HashMap::new());
-        }
-        let placeholders = sql_placeholders(run_ids.len());
-        let sql = format!(
-            "{} \
+/// Fetch the active waiting gate step for each of the given run IDs in one query.
+///
+/// Returns a map from workflow_run_id → the single `running`/`waiting` gate step for that
+/// run.  Runs that have no waiting gate are absent from the map.
+pub fn find_waiting_gates_for_runs(
+    conn: &Connection,
+    run_ids: &[&str],
+) -> Result<HashMap<String, WorkflowRunStep>> {
+    if run_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let placeholders = sql_placeholders(run_ids.len());
+    let sql = format!(
+        "{} \
              WHERE s.workflow_run_id IN ({placeholders}) AND s.gate_type IS NOT NULL \
                AND s.gate_approved_at IS NULL \
                AND s.status IN ('running', 'waiting') \
              ORDER BY s.workflow_run_id, s.position DESC",
-            &*STEP_SELECT_EXPANDED
-        );
-        let steps: Vec<WorkflowRunStep> = {
-            let mut stmt = self.conn.prepare(&sql)?;
-            let rows = stmt.query_map(
-                rusqlite::params_from_iter(run_ids.iter().copied()),
-                row_to_workflow_step,
-            )?;
-            rows.collect::<rusqlite::Result<Vec<_>>>()?
-        };
-        // Keep only the highest-position step per run (ORDER BY position DESC means
-        // the first row for each run_id is the one we want).
-        let mut map: HashMap<String, WorkflowRunStep> = HashMap::new();
-        for step in steps {
-            map.entry(step.workflow_run_id.clone()).or_insert(step);
-        }
-        Ok(map)
+        &*STEP_SELECT_EXPANDED
+    );
+    let steps: Vec<WorkflowRunStep> = {
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(
+            rusqlite::params_from_iter(run_ids.iter().copied()),
+            row_to_workflow_step,
+        )?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    // Keep only the highest-position step per run (ORDER BY position DESC means
+    // the first row for each run_id is the one we want).
+    let mut map: HashMap<String, WorkflowRunStep> = HashMap::new();
+    for step in steps {
+        map.entry(step.workflow_run_id.clone()).or_insert(step);
     }
+    Ok(map)
+}
 
-    /// Find the waiting gate step for a workflow run.
-    pub fn find_waiting_gate(&self, workflow_run_id: &str) -> Result<Option<WorkflowRunStep>> {
-        Ok(self
-            .conn
+/// Find the waiting gate step for a workflow run.
+pub fn find_waiting_gate(
+    conn: &Connection,
+    workflow_run_id: &str,
+) -> Result<Option<WorkflowRunStep>> {
+    Ok(conn
             .query_row(
                 &format!(
                     "{} \
@@ -836,42 +854,45 @@ impl<'a> WorkflowManager<'a> {
                 row_to_workflow_step,
             )
             .optional()?)
-    }
+}
 
-    /// List all gate steps currently in `waiting` status across all workflow runs.
-    ///
-    /// Returns `(step, workflow_name, target_label)` tuples. Used by the TUI background poller to
-    /// fire cross-process gate-waiting notifications.
-    pub fn list_all_waiting_gate_steps(
-        &self,
-    ) -> Result<Vec<(WorkflowRunStep, String, Option<String>)>> {
-        let placeholders = sql_placeholders(WorkflowRunStatus::ACTIVE.len());
-        let active_strings = WorkflowRunStatus::active_strings();
-        let sql = format!(
-            "SELECT {cols}, r.workflow_name, r.target_label \
+/// List all gate steps currently in `waiting` status across all workflow runs.
+///
+/// Returns `(step, workflow_name, target_label)` tuples. Used by the TUI background poller to
+/// fire cross-process gate-waiting notifications.
+pub fn list_all_waiting_gate_steps(
+    conn: &Connection,
+) -> Result<Vec<(WorkflowRunStep, String, Option<String>)>> {
+    let placeholders = sql_placeholders(WorkflowRunStatus::ACTIVE.len());
+    let active_strings = WorkflowRunStatus::active_strings();
+    let sql = format!(
+        "SELECT {cols}, r.workflow_name, r.target_label \
              FROM workflow_run_steps s \
              JOIN workflow_runs r ON r.id = s.workflow_run_id \
              WHERE s.gate_type IS NOT NULL AND s.status = 'waiting' \
              AND r.status IN ({placeholders}) \
              ORDER BY s.started_at",
-            cols = &*STEP_COLUMNS_WITH_PREFIX,
-        );
-        crate::db::query_collect(
-            self.conn,
-            &sql,
-            rusqlite::params_from_iter(active_strings.iter()),
-            waiting_gate_step_row_mapper,
-        )
-    }
+        cols = &*STEP_COLUMNS_WITH_PREFIX,
+    );
+    crate::db::query_collect(
+        conn,
+        &sql,
+        rusqlite::params_from_iter(active_strings.iter()),
+        waiting_gate_step_row_mapper,
+    )
+}
 
-    /// List gate steps currently in `waiting` status for a specific repo.
-    ///
-    /// Returns enriched [`PendingGateRow`] values that include the worktree branch and linked
-    /// ticket source_id so the TUI can display context without additional queries.
-    pub fn list_waiting_gate_steps_for_repo(&self, repo_id: &str) -> Result<Vec<PendingGateRow>> {
-        let active_strings = WorkflowRunStatus::active_strings();
-        let status_placeholders = sql_placeholders(active_strings.len());
-        let sql = format!(
+/// List gate steps currently in `waiting` status for a specific repo.
+///
+/// Returns enriched [`PendingGateRow`] values that include the worktree branch and linked
+/// ticket source_id so the TUI can display context without additional queries.
+pub fn list_waiting_gate_steps_for_repo(
+    conn: &Connection,
+    repo_id: &str,
+) -> Result<Vec<PendingGateRow>> {
+    let active_strings = WorkflowRunStatus::active_strings();
+    let status_placeholders = sql_placeholders(active_strings.len());
+    let sql = format!(
             "SELECT {cols}, r.workflow_name, r.target_label, wt.branch, t.source_id AS ticket_ref, r.workflow_title \
              FROM workflow_run_steps s \
              JOIN workflow_runs r ON r.id = s.workflow_run_id \
@@ -883,38 +904,38 @@ impl<'a> WorkflowManager<'a> {
              ORDER BY s.started_at",
             cols = &*STEP_COLUMNS_WITH_PREFIX,
         );
-        let mut all_params: Vec<rusqlite::types::Value> = active_strings
-            .into_iter()
-            .map(rusqlite::types::Value::Text)
-            .collect();
-        // repo_id appears twice in the WHERE clause (once for r.repo_id, once for wt.repo_id)
-        all_params.push(rusqlite::types::Value::Text(repo_id.to_owned()));
-        all_params.push(rusqlite::types::Value::Text(repo_id.to_owned()));
-        crate::db::query_collect(
-            self.conn,
-            &sql,
-            rusqlite::params_from_iter(all_params.iter()),
-            pending_gate_row_mapper,
-        )
-    }
+    let mut all_params: Vec<rusqlite::types::Value> = active_strings
+        .into_iter()
+        .map(rusqlite::types::Value::Text)
+        .collect();
+    // repo_id appears twice in the WHERE clause (once for r.repo_id, once for wt.repo_id)
+    all_params.push(rusqlite::types::Value::Text(repo_id.to_owned()));
+    all_params.push(rusqlite::types::Value::Text(repo_id.to_owned()));
+    crate::db::query_collect(
+        conn,
+        &sql,
+        rusqlite::params_from_iter(all_params.iter()),
+        pending_gate_row_mapper,
+    )
+}
 
-    /// Batch-walk active child chains for all given root run IDs in a single recursive CTE query.
-    ///
-    /// Returns a map from `root_run_id` to the ordered list of `(child_id, child_workflow_name)`
-    /// pairs below that root (depth >= 1, ascending). Roots with no active children are absent
-    /// from the map. Depth is capped at 5 to match `get_active_chain_for_run`.
-    fn get_active_chains_for_runs_batch(
-        &self,
-        root_ids: &[&str],
-    ) -> Result<HashMap<String, Vec<(String, String)>>> {
-        if root_ids.is_empty() {
-            return Ok(HashMap::new());
-        }
-        let placeholders = sql_placeholders(root_ids.len());
-        // Seed the CTE with the root runs themselves (depth = 0), then recursively
-        // follow active children up to depth 5 (= MAX_DEPTH in get_active_chain_for_run).
-        let sql = format!(
-            "WITH RECURSIVE chain(root_id, id, workflow_name, depth) AS (\
+/// Batch-walk active child chains for all given root run IDs in a single recursive CTE query.
+///
+/// Returns a map from `root_run_id` to the ordered list of `(child_id, child_workflow_name)`
+/// pairs below that root (depth >= 1, ascending). Roots with no active children are absent
+/// from the map. Depth is capped at 5 to match `get_active_chain_for_run`.
+fn get_active_chains_for_runs_batch(
+    conn: &Connection,
+    root_ids: &[&str],
+) -> Result<HashMap<String, Vec<(String, String)>>> {
+    if root_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let placeholders = sql_placeholders(root_ids.len());
+    // Seed the CTE with the root runs themselves (depth = 0), then recursively
+    // follow active children up to depth 5 (= MAX_DEPTH in get_active_chain_for_run).
+    let sql = format!(
+        "WITH RECURSIVE chain(root_id, id, workflow_name, depth) AS (\
                SELECT id, id, workflow_name, 0 \
                FROM workflow_runs WHERE id IN ({placeholders}) \
                UNION ALL \
@@ -928,278 +949,280 @@ impl<'a> WorkflowManager<'a> {
              FROM chain \
              WHERE depth >= 1 \
              ORDER BY root_id, depth"
-        );
-        let params: Vec<rusqlite::types::Value> = root_ids
-            .iter()
-            .map(|s| rusqlite::types::Value::Text(s.to_string()))
-            .collect();
-        let mut stmt = self.conn.prepare(&sql)?;
-        let mut rows = stmt.query(rusqlite::params_from_iter(params.iter()))?;
-        let mut map: HashMap<String, Vec<(String, String)>> = HashMap::new();
-        while let Some(row) = rows.next()? {
-            let root_id: String = row.get(0)?;
-            let child_id: String = row.get(1)?;
-            let child_name: String = row.get(2)?;
-            map.entry(root_id).or_default().push((child_id, child_name));
-        }
-        Ok(map)
+    );
+    let params: Vec<rusqlite::types::Value> = root_ids
+        .iter()
+        .map(|s| rusqlite::types::Value::Text(s.to_string()))
+        .collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(rusqlite::params_from_iter(params.iter()))?;
+    let mut map: HashMap<String, Vec<(String, String)>> = HashMap::new();
+    while let Some(row) = rows.next()? {
+        let root_id: String = row.get(0)?;
+        let child_id: String = row.get(1)?;
+        let child_name: String = row.get(2)?;
+        map.entry(root_id).or_default().push((child_id, child_name));
     }
+    Ok(map)
+}
 
-    /// Batch-fetch the first running step for each of the given leaf run IDs.
-    ///
-    /// Returns a map from `leaf_run_id` to `(step_name, iteration)`. The first running step
-    /// by ascending position is returned per run, matching the per-leaf `LIMIT 1` semantics.
-    fn get_running_steps_for_leaf_runs(
-        &self,
-        leaf_ids: &[String],
-    ) -> Result<HashMap<String, (String, i64)>> {
-        if leaf_ids.is_empty() {
-            return Ok(HashMap::new());
-        }
-        let placeholders = sql_placeholders(leaf_ids.len());
-        let sql = format!(
-            "SELECT workflow_run_id, step_name, iteration \
+/// Batch-fetch the first running step for each of the given leaf run IDs.
+///
+/// Returns a map from `leaf_run_id` to `(step_name, iteration)`. The first running step
+/// by ascending position is returned per run, matching the per-leaf `LIMIT 1` semantics.
+fn get_running_steps_for_leaf_runs(
+    conn: &Connection,
+    leaf_ids: &[String],
+) -> Result<HashMap<String, (String, i64)>> {
+    if leaf_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let placeholders = sql_placeholders(leaf_ids.len());
+    let sql = format!(
+        "SELECT workflow_run_id, step_name, iteration \
              FROM workflow_run_steps \
              WHERE workflow_run_id IN ({placeholders}) AND status = 'running' \
              ORDER BY workflow_run_id, position ASC"
-        );
-        let params: Vec<rusqlite::types::Value> = leaf_ids
-            .iter()
-            .map(|s| rusqlite::types::Value::Text(s.clone()))
-            .collect();
-        let mut stmt = self.conn.prepare(&sql)?;
-        let mut rows = stmt.query(rusqlite::params_from_iter(params.iter()))?;
-        let mut map: HashMap<String, (String, i64)> = HashMap::new();
-        while let Some(row) = rows.next()? {
-            let run_id: String = row.get("workflow_run_id")?;
-            // Take only the first (lowest-position) row per run_id.
-            map.entry(run_id).or_insert_with(|| {
-                let step_name: String = row.get("step_name").unwrap_or_else(|e| {
-                    tracing::warn!("row.get('step_name') failed: {e}");
-                    String::new()
-                });
-                let iteration: i64 = row.get("iteration").unwrap_or_else(|e| {
-                    tracing::warn!("row.get('iteration') failed: {e}");
-                    0
-                });
-                (step_name, iteration)
+    );
+    let params: Vec<rusqlite::types::Value> = leaf_ids
+        .iter()
+        .map(|s| rusqlite::types::Value::Text(s.clone()))
+        .collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(rusqlite::params_from_iter(params.iter()))?;
+    let mut map: HashMap<String, (String, i64)> = HashMap::new();
+    while let Some(row) = rows.next()? {
+        let run_id: String = row.get("workflow_run_id")?;
+        // Take only the first (lowest-position) row per run_id.
+        map.entry(run_id).or_insert_with(|| {
+            let step_name: String = row.get("step_name").unwrap_or_else(|e| {
+                tracing::warn!("row.get('step_name') failed: {e}");
+                String::new()
             });
-        }
-        Ok(map)
+            let iteration: i64 = row.get("iteration").unwrap_or_else(|e| {
+                tracing::warn!("row.get('iteration') failed: {e}");
+                0
+            });
+            (step_name, iteration)
+        });
+    }
+    Ok(map)
+}
+
+/// Fetch the currently-running step for each of the given (root) workflow run IDs.
+/// Returns a map from root `workflow_run_id` to a `WorkflowStepSummary`.
+///
+/// For each root run the method walks down the active child chain to find the
+/// deepest active sub-workflow run (the *leaf*), queries its running step, and
+/// populates `workflow_chain` with the ordered workflow names from the root down
+/// to (but not including) the leaf's own name — which is already available via
+/// the `workflow_name` field of the root's `WorkflowRun`.
+///
+/// An empty `run_ids` slice returns an empty map without hitting the DB.
+/// Uses batch queries (3 total) regardless of N to avoid N+1 round-trips.
+pub fn get_step_summaries_for_runs(
+    conn: &Connection,
+    run_ids: &[&str],
+) -> Result<HashMap<String, WorkflowStepSummary>> {
+    if run_ids.is_empty() {
+        return Ok(HashMap::new());
     }
 
-    /// Fetch the currently-running step for each of the given (root) workflow run IDs.
-    /// Returns a map from root `workflow_run_id` to a `WorkflowStepSummary`.
-    ///
-    /// For each root run the method walks down the active child chain to find the
-    /// deepest active sub-workflow run (the *leaf*), queries its running step, and
-    /// populates `workflow_chain` with the ordered workflow names from the root down
-    /// to (but not including) the leaf's own name — which is already available via
-    /// the `workflow_name` field of the root's `WorkflowRun`.
-    ///
-    /// An empty `run_ids` slice returns an empty map without hitting the DB.
-    /// Uses batch queries (3 total) regardless of N to avoid N+1 round-trips.
-    pub fn get_step_summaries_for_runs(
-        &self,
-        run_ids: &[&str],
-    ) -> Result<HashMap<String, WorkflowStepSummary>> {
-        if run_ids.is_empty() {
-            return Ok(HashMap::new());
-        }
+    // 1. Fetch workflow names for the root runs (single query).
+    let placeholders = sql_placeholders(run_ids.len());
+    let name_sql =
+        format!("SELECT id, workflow_name FROM workflow_runs WHERE id IN ({placeholders})");
+    let name_params: Vec<&dyn rusqlite::ToSql> =
+        run_ids.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+    let mut name_stmt = conn.prepare(&name_sql)?;
+    let mut name_rows = name_stmt.query(name_params.as_slice())?;
+    let mut root_names: HashMap<String, String> = HashMap::new();
+    while let Some(row) = name_rows.next()? {
+        let id: String = row.get("id")?;
+        let name: String = row.get("workflow_name")?;
+        root_names.insert(id, name);
+    }
 
-        // 1. Fetch workflow names for the root runs (single query).
-        let placeholders = sql_placeholders(run_ids.len());
-        let name_sql =
-            format!("SELECT id, workflow_name FROM workflow_runs WHERE id IN ({placeholders})");
-        let name_params: Vec<&dyn rusqlite::ToSql> =
-            run_ids.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
-        let mut name_stmt = self.conn.prepare(&name_sql)?;
-        let mut name_rows = name_stmt.query(name_params.as_slice())?;
-        let mut root_names: HashMap<String, String> = HashMap::new();
-        while let Some(row) = name_rows.next()? {
-            let id: String = row.get("id")?;
-            let name: String = row.get("workflow_name")?;
-            root_names.insert(id, name);
-        }
+    // 2. Walk all active child chains for all roots in one recursive CTE query.
+    let chains_map = get_active_chains_for_runs_batch(conn, run_ids)?;
 
-        // 2. Walk all active child chains for all roots in one recursive CTE query.
-        let chains_map = self.get_active_chains_for_runs_batch(run_ids)?;
+    // Derive the leaf run ID per root (deepest child, or root itself).
+    let leaf_ids: Vec<String> = run_ids
+        .iter()
+        .map(|root_id| {
+            chains_map
+                .get(*root_id)
+                .and_then(|chain| chain.last())
+                .map(|(id, _)| id.clone())
+                .unwrap_or_else(|| root_id.to_string())
+        })
+        .collect();
 
-        // Derive the leaf run ID per root (deepest child, or root itself).
-        let leaf_ids: Vec<String> = run_ids
-            .iter()
-            .map(|root_id| {
-                chains_map
-                    .get(*root_id)
-                    .and_then(|chain| chain.last())
-                    .map(|(id, _)| id.clone())
-                    .unwrap_or_else(|| root_id.to_string())
-            })
-            .collect();
+    // 3. Batch-fetch the running step for all leaf runs (single query).
+    let steps_map = get_running_steps_for_leaf_runs(conn, &leaf_ids)?;
 
-        // 3. Batch-fetch the running step for all leaf runs (single query).
-        let steps_map = self.get_running_steps_for_leaf_runs(&leaf_ids)?;
+    // Re-assemble WorkflowStepSummary entries.
+    let mut map: HashMap<String, WorkflowStepSummary> = HashMap::new();
+    for root_id in run_ids {
+        let Some(root_name) = root_names.get(*root_id) else {
+            continue;
+        };
 
-        // Re-assemble WorkflowStepSummary entries.
-        let mut map: HashMap<String, WorkflowStepSummary> = HashMap::new();
-        for root_id in run_ids {
-            let Some(root_name) = root_names.get(*root_id) else {
-                continue;
+        let child_chain = chains_map.get(*root_id).map(Vec::as_slice).unwrap_or(&[]);
+
+        let leaf_id = child_chain
+            .last()
+            .map(|(id, _)| id.as_str())
+            .unwrap_or(root_id);
+
+        if let Some((step_name, iteration)) = steps_map.get(leaf_id) {
+            // For single-level (no children), expose an empty vec to keep
+            // existing rendering unchanged. Otherwise build:
+            // root_name + child names excluding the leaf (which owns the step).
+            let workflow_chain = if child_chain.is_empty() {
+                Vec::new()
+            } else {
+                let mut wc = vec![root_name.clone()];
+                // child_chain is (id, name); exclude the last entry (the leaf).
+                wc.extend(
+                    child_chain[..child_chain.len() - 1]
+                        .iter()
+                        .map(|(_, name)| name.clone()),
+                );
+                wc
             };
 
-            let child_chain = chains_map.get(*root_id).map(Vec::as_slice).unwrap_or(&[]);
-
-            let leaf_id = child_chain
-                .last()
-                .map(|(id, _)| id.as_str())
-                .unwrap_or(root_id);
-
-            if let Some((step_name, iteration)) = steps_map.get(leaf_id) {
-                // For single-level (no children), expose an empty vec to keep
-                // existing rendering unchanged. Otherwise build:
-                // root_name + child names excluding the leaf (which owns the step).
-                let workflow_chain = if child_chain.is_empty() {
-                    Vec::new()
-                } else {
-                    let mut wc = vec![root_name.clone()];
-                    // child_chain is (id, name); exclude the last entry (the leaf).
-                    wc.extend(
-                        child_chain[..child_chain.len() - 1]
-                            .iter()
-                            .map(|(_, name)| name.clone()),
-                    );
-                    wc
-                };
-
-                map.insert(
-                    root_id.to_string(),
-                    WorkflowStepSummary {
-                        step_name: step_name.clone(),
-                        iteration: *iteration,
-                        workflow_chain,
-                    },
-                );
-            }
+            map.insert(
+                root_id.to_string(),
+                WorkflowStepSummary {
+                    step_name: step_name.clone(),
+                    iteration: *iteration,
+                    workflow_chain,
+                },
+            );
         }
-        Ok(map)
     }
+    Ok(map)
+}
 
-    /// Lightweight cancellation check — queries only the status column.
-    ///
-    /// Returns `true` when the run exists and its status is `cancelled`.
-    /// Returns `false` for any other status or if the run is not found.
-    /// Propagates DB errors so callers can decide how to handle them.
-    pub fn is_workflow_cancelled(&self, run_id: &str) -> Result<bool> {
-        let status: Option<String> = self
-            .conn
-            .query_row(
-                "SELECT status FROM workflow_runs WHERE id = :id",
-                named_params! { ":id": run_id },
-                |row| row.get("status"),
-            )
-            .optional()?;
-        Ok(status.as_deref() == Some("cancelled"))
-    }
+/// Lightweight cancellation check — queries only the status column.
+///
+/// Returns `true` when the run exists and its status is `cancelled`.
+/// Returns `false` for any other status or if the run is not found.
+/// Propagates DB errors so callers can decide how to handle them.
+pub fn is_workflow_cancelled(conn: &Connection, run_id: &str) -> Result<bool> {
+    let status: Option<String> = conn
+        .query_row(
+            "SELECT status FROM workflow_runs WHERE id = :id",
+            named_params! { ":id": run_id },
+            |row| row.get("status"),
+        )
+        .optional()?;
+    Ok(status.as_deref() == Some("cancelled"))
+}
 
-    /// Return `total_duration_ms` values for the most recent completed runs of
-    /// the given workflow name. Returns up to `limit` durations, newest first.
-    pub fn get_completed_run_durations(
-        &self,
-        workflow_name: &str,
-        limit: usize,
-    ) -> Result<Vec<i64>> {
-        let sql = "SELECT total_duration_ms FROM workflow_runs \
+/// Return `total_duration_ms` values for the most recent completed runs of
+/// the given workflow name. Returns up to `limit` durations, newest first.
+pub fn get_completed_run_durations(
+    conn: &Connection,
+    workflow_name: &str,
+    limit: usize,
+) -> Result<Vec<i64>> {
+    let sql = "SELECT total_duration_ms FROM workflow_runs \
                    WHERE workflow_name = :workflow_name \
                      AND status = 'completed' \
                      AND total_duration_ms IS NOT NULL \
                    ORDER BY ended_at DESC \
                    LIMIT :limit";
-        let mut stmt = self.conn.prepare_cached(sql)?;
-        let rows = stmt.query_map(
-            named_params! { ":workflow_name": workflow_name, ":limit": limit as i64 },
-            |row| row.get("total_duration_ms"),
-        )?;
-        let mut durations = Vec::new();
-        for row in rows {
-            durations.push(row?);
-        }
-        Ok(durations)
+    let mut stmt = conn.prepare_cached(sql)?;
+    let rows = stmt.query_map(
+        named_params! { ":workflow_name": workflow_name, ":limit": limit as i64 },
+        |row| row.get("total_duration_ms"),
+    )?;
+    let mut durations = Vec::new();
+    for row in rows {
+        durations.push(row?);
     }
+    Ok(durations)
+}
 
-    /// Batch-fetch the LLM `estimated_minutes` from plan-step structured output
-    /// for the given run IDs. Returns a map of `run_id → estimate_ms`.
-    ///
-    /// Scans completed steps with non-null `structured_output` and parses the
-    /// JSON to find an `estimated_minutes` field. Only the first match per run
-    /// is returned.
-    pub fn get_plan_estimates_for_runs(&self, run_ids: &[&str]) -> Result<HashMap<String, i64>> {
-        if run_ids.is_empty() {
-            return Ok(HashMap::new());
-        }
-        let placeholders = sql_placeholders(run_ids.len());
-        let sql = format!(
-            "SELECT workflow_run_id, structured_output FROM workflow_run_steps \
+/// Batch-fetch the LLM `estimated_minutes` from plan-step structured output
+/// for the given run IDs. Returns a map of `run_id → estimate_ms`.
+///
+/// Scans completed steps with non-null `structured_output` and parses the
+/// JSON to find an `estimated_minutes` field. Only the first match per run
+/// is returned.
+pub fn get_plan_estimates_for_runs(
+    conn: &Connection,
+    run_ids: &[&str],
+) -> Result<HashMap<String, i64>> {
+    if run_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let placeholders = sql_placeholders(run_ids.len());
+    let sql = format!(
+        "SELECT workflow_run_id, structured_output FROM workflow_run_steps \
              WHERE workflow_run_id IN ({placeholders}) \
                AND status = 'completed' \
                AND structured_output IS NOT NULL \
              ORDER BY position ASC"
-        );
-        let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(rusqlite::params_from_iter(run_ids.iter()), |row| {
-            let run_id: String = row.get(0)?;
-            let json_str: String = row.get(1)?;
-            Ok((run_id, json_str))
-        })?;
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(run_ids.iter()), |row| {
+        let run_id: String = row.get(0)?;
+        let json_str: String = row.get(1)?;
+        Ok((run_id, json_str))
+    })?;
 
-        let mut result: HashMap<String, i64> = HashMap::new();
-        for row in rows {
-            let (run_id, json_str) = row?;
-            // Only keep the first match per run
-            if result.contains_key(&run_id) {
-                continue;
-            }
-            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json_str) {
-                if let Some(minutes) = val.get("estimated_minutes").and_then(|v| v.as_f64()) {
-                    result.insert(run_id, (minutes * 60_000.0) as i64);
-                }
+    let mut result: HashMap<String, i64> = HashMap::new();
+    for row in rows {
+        let (run_id, json_str) = row?;
+        // Only keep the first match per run
+        if result.contains_key(&run_id) {
+            continue;
+        }
+        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json_str) {
+            if let Some(minutes) = val.get("estimated_minutes").and_then(|v| v.as_f64()) {
+                result.insert(run_id, (minutes * 60_000.0) as i64);
             }
         }
-        Ok(result)
     }
+    Ok(result)
+}
 
-    /// Return historical step durations grouped by step_name for a given workflow.
-    ///
-    /// Queries completed steps from the most recent completed runs. Duration is
-    /// computed from `started_at`/`ended_at` timestamps since there is no
-    /// pre-computed duration column on steps.
-    ///
-    /// Returns `step_name → Vec<duration_ms>`.
-    pub fn get_completed_step_durations(
-        &self,
-        workflow_name: &str,
-        limit_runs: usize,
-    ) -> Result<HashMap<String, Vec<i64>>> {
-        // Phase 1: get IDs of recent completed runs
-        let run_sql = "SELECT id FROM workflow_runs \
+/// Return historical step durations grouped by step_name for a given workflow.
+///
+/// Queries completed steps from the most recent completed runs. Duration is
+/// computed from `started_at`/`ended_at` timestamps since there is no
+/// pre-computed duration column on steps.
+///
+/// Returns `step_name → Vec<duration_ms>`.
+pub fn get_completed_step_durations(
+    conn: &Connection,
+    workflow_name: &str,
+    limit_runs: usize,
+) -> Result<HashMap<String, Vec<i64>>> {
+    // Phase 1: get IDs of recent completed runs
+    let run_sql = "SELECT id FROM workflow_runs \
                        WHERE workflow_name = :workflow_name \
                          AND status = 'completed' \
                        ORDER BY ended_at DESC \
                        LIMIT :limit";
-        let mut run_stmt = self.conn.prepare_cached(run_sql)?;
-        let run_ids: Vec<String> = run_stmt
-            .query_map(
-                named_params! { ":workflow_name": workflow_name, ":limit": limit_runs as i64 },
-                |row| row.get("id"),
-            )?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
+    let mut run_stmt = conn.prepare_cached(run_sql)?;
+    let run_ids: Vec<String> = run_stmt
+        .query_map(
+            named_params! { ":workflow_name": workflow_name, ":limit": limit_runs as i64 },
+            |row| row.get("id"),
+        )?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
 
-        if run_ids.is_empty() {
-            return Ok(HashMap::new());
-        }
+    if run_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
 
-        // Phase 2: get step durations from those runs
-        let placeholders = sql_placeholders(run_ids.len());
-        let step_sql = format!(
+    // Phase 2: get step durations from those runs
+    let placeholders = sql_placeholders(run_ids.len());
+    let step_sql = format!(
             "SELECT step_name, \
                     CAST((julianday(ended_at) - julianday(started_at)) * 86400000 AS INTEGER) AS duration_ms \
              FROM workflow_run_steps \
@@ -1208,31 +1231,31 @@ impl<'a> WorkflowManager<'a> {
                AND started_at IS NOT NULL \
                AND ended_at IS NOT NULL"
         );
-        let mut step_stmt = self.conn.prepare(&step_sql)?;
-        let rows = step_stmt.query_map(rusqlite::params_from_iter(run_ids.iter()), |row| {
-            let name: String = row.get("step_name")?;
-            let dur: i64 = row.get("duration_ms")?;
-            Ok((name, dur))
-        })?;
+    let mut step_stmt = conn.prepare(&step_sql)?;
+    let rows = step_stmt.query_map(rusqlite::params_from_iter(run_ids.iter()), |row| {
+        let name: String = row.get("step_name")?;
+        let dur: i64 = row.get("duration_ms")?;
+        Ok((name, dur))
+    })?;
 
-        let mut result: HashMap<String, Vec<i64>> = HashMap::new();
-        for row in rows {
-            let (name, dur) = row?;
-            if dur > 0 {
-                result.entry(name).or_default().push(dur);
-            }
+    let mut result: HashMap<String, Vec<i64>> = HashMap::new();
+    for row in rows {
+        let (name, dur) = row?;
+        if dur > 0 {
+            result.entry(name).or_default().push(dur);
         }
-        Ok(result)
     }
+    Ok(result)
+}
 
-    /// Aggregate token usage per workflow name across all terminal runs (completed + failed).
-    /// Token averages are computed only over completed runs to avoid skewing with failed runs.
-    /// When `repo_id` is `Some`, restricts to runs for that repo.
-    pub fn get_workflow_token_aggregates(
-        &self,
-        repo_id: Option<&str>,
-    ) -> Result<Vec<WorkflowTokenAggregate>> {
-        let mut stmt = self.conn.prepare_cached(
+/// Aggregate token usage per workflow name across all terminal runs (completed + failed).
+/// Token averages are computed only over completed runs to avoid skewing with failed runs.
+/// When `repo_id` is `Some`, restricts to runs for that repo.
+pub fn get_workflow_token_aggregates(
+    conn: &Connection,
+    repo_id: Option<&str>,
+) -> Result<Vec<WorkflowTokenAggregate>> {
+    let mut stmt = conn.prepare_cached(
             "SELECT workflow_name, \
                     COALESCE(AVG(CASE WHEN status='completed' THEN total_input_tokens END), 0.0) AS avg_input, \
                     COALESCE(AVG(CASE WHEN status='completed' THEN total_output_tokens END), 0.0) AS avg_output, \
@@ -1247,30 +1270,30 @@ impl<'a> WorkflowManager<'a> {
              GROUP BY workflow_name \
              ORDER BY avg_input + avg_output DESC, run_count DESC",
         )?;
-        let rows = stmt.query_map(named_params! { ":repo_id": repo_id }, |row| {
-            let workflow_title: Option<String> = row.get("workflow_title")?;
-            Ok(WorkflowTokenAggregate {
-                workflow_name: row.get("workflow_name")?,
-                avg_input: row.get("avg_input")?,
-                avg_output: row.get("avg_output")?,
-                avg_cache_read: row.get("avg_cache_read")?,
-                avg_cache_creation: row.get("avg_cache_creation")?,
-                run_count: row.get("run_count")?,
-                success_rate: row.get("success_rate")?,
-                workflow_title,
-            })
-        })?;
-        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
-    }
+    let rows = stmt.query_map(named_params! { ":repo_id": repo_id }, |row| {
+        let workflow_title: Option<String> = row.get("workflow_title")?;
+        Ok(WorkflowTokenAggregate {
+            workflow_name: row.get("workflow_name")?,
+            avg_input: row.get("avg_input")?,
+            avg_output: row.get("avg_output")?,
+            avg_cache_read: row.get("avg_cache_read")?,
+            avg_cache_creation: row.get("avg_cache_creation")?,
+            run_count: row.get("run_count")?,
+            success_rate: row.get("success_rate")?,
+            workflow_title,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
 
-    /// Token totals grouped by time period (daily or weekly) for a specific workflow.
-    pub fn get_workflow_token_trend(
-        &self,
-        workflow_name: &str,
-        granularity: TimeGranularity,
-    ) -> Result<Vec<WorkflowTokenTrendRow>> {
-        let fmt = granularity_to_strftime_format(granularity);
-        let sql = format!(
+/// Token totals grouped by time period (daily or weekly) for a specific workflow.
+pub fn get_workflow_token_trend(
+    conn: &Connection,
+    workflow_name: &str,
+    granularity: TimeGranularity,
+) -> Result<Vec<WorkflowTokenTrendRow>> {
+    let fmt = granularity_to_strftime_format(granularity);
+    let sql = format!(
             "SELECT strftime('{fmt}', started_at) as period, \
                     COALESCE(SUM(total_input_tokens), 0) as total_input, \
                     COALESCE(SUM(total_output_tokens), 0) as total_output, \
@@ -1282,27 +1305,27 @@ impl<'a> WorkflowManager<'a> {
              ORDER BY period DESC \
              LIMIT 30"
         );
-        let mut stmt = self.conn.prepare_cached(&sql)?;
-        let rows = stmt.query_map(named_params! { ":workflow_name": workflow_name }, |row| {
-            Ok(WorkflowTokenTrendRow {
-                period: row.get("period")?,
-                total_input: row.get("total_input")?,
-                total_output: row.get("total_output")?,
-                total_cache_read: row.get("total_cache_read")?,
-                total_cache_creation: row.get("total_cache_creation")?,
-            })
-        })?;
-        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
-    }
+    let mut stmt = conn.prepare_cached(&sql)?;
+    let rows = stmt.query_map(named_params! { ":workflow_name": workflow_name }, |row| {
+        Ok(WorkflowTokenTrendRow {
+            period: row.get("period")?,
+            total_input: row.get("total_input")?,
+            total_output: row.get("total_output")?,
+            total_cache_read: row.get("total_cache_read")?,
+            total_cache_creation: row.get("total_cache_creation")?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
 
-    /// Per-step average token usage across the N most recent completed runs of a workflow.
-    pub fn get_step_token_heatmap(
-        &self,
-        workflow_name: &str,
-        limit_runs: usize,
-    ) -> Result<Vec<StepTokenHeatmapRow>> {
-        let mut stmt = self.conn.prepare_cached(&format!(
-            "SELECT wrs.step_name, \
+/// Per-step average token usage across the N most recent completed runs of a workflow.
+pub fn get_step_token_heatmap(
+    conn: &Connection,
+    workflow_name: &str,
+    limit_runs: usize,
+) -> Result<Vec<StepTokenHeatmapRow>> {
+    let mut stmt = conn.prepare_cached(&format!(
+        "SELECT wrs.step_name, \
                     COALESCE(AVG(ar.input_tokens), 0.0) as avg_input, \
                     COALESCE(AVG(ar.output_tokens), 0.0) as avg_output, \
                     COALESCE(AVG(ar.cache_read_input_tokens), 0.0) as avg_cache_read, \
@@ -1316,29 +1339,29 @@ impl<'a> WorkflowManager<'a> {
                ) \
              GROUP BY wrs.step_name \
              ORDER BY (AVG(ar.input_tokens) + AVG(ar.output_tokens)) DESC",
-            Self::N_RECENT_COMPLETED_RUNS_SUBQUERY
-        ))?;
-        let rows = stmt.query_map(rusqlite::params![workflow_name, limit_runs as i64], |row| {
-            Ok(StepTokenHeatmapRow {
-                step_name: row.get("step_name")?,
-                avg_input: row.get("avg_input")?,
-                avg_output: row.get("avg_output")?,
-                avg_cache_read: row.get("avg_cache_read")?,
-                run_count: row.get("run_count")?,
-            })
-        })?;
-        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
-    }
+        N_RECENT_COMPLETED_RUNS_SUBQUERY
+    ))?;
+    let rows = stmt.query_map(rusqlite::params![workflow_name, limit_runs as i64], |row| {
+        Ok(StepTokenHeatmapRow {
+            step_name: row.get("step_name")?,
+            avg_input: row.get("avg_input")?,
+            avg_output: row.get("avg_output")?,
+            avg_cache_read: row.get("avg_cache_read")?,
+            run_count: row.get("run_count")?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
 
-    /// Failure rate grouped by time period (daily or weekly) for a specific workflow.
-    /// Counts all terminal runs (completed + failed) per period and computes success rate.
-    pub fn get_workflow_failure_rate_trend(
-        &self,
-        workflow_name: &str,
-        granularity: TimeGranularity,
-    ) -> Result<Vec<WorkflowFailureRateTrendRow>> {
-        let fmt = granularity_to_strftime_format(granularity);
-        let sql = format!(
+/// Failure rate grouped by time period (daily or weekly) for a specific workflow.
+/// Counts all terminal runs (completed + failed) per period and computes success rate.
+pub fn get_workflow_failure_rate_trend(
+    conn: &Connection,
+    workflow_name: &str,
+    granularity: TimeGranularity,
+) -> Result<Vec<WorkflowFailureRateTrendRow>> {
+    let fmt = granularity_to_strftime_format(granularity);
+    let sql = format!(
             "SELECT strftime('{fmt}', started_at) AS period, \
                     COUNT(*) AS total_runs, \
                     SUM(CASE WHEN status='failed' THEN 1 ELSE 0 END) AS failed_runs, \
@@ -1349,26 +1372,26 @@ impl<'a> WorkflowManager<'a> {
              ORDER BY period DESC \
              LIMIT 30"
         );
-        let mut stmt = self.conn.prepare_cached(&sql)?;
-        let rows = stmt.query_map(named_params! { ":workflow_name": workflow_name }, |row| {
-            Ok(WorkflowFailureRateTrendRow {
-                period: row.get("period")?,
-                total_runs: row.get("total_runs")?,
-                failed_runs: row.get("failed_runs")?,
-                success_rate: row.get("success_rate")?,
-            })
-        })?;
-        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
-    }
+    let mut stmt = conn.prepare_cached(&sql)?;
+    let rows = stmt.query_map(named_params! { ":workflow_name": workflow_name }, |row| {
+        Ok(WorkflowFailureRateTrendRow {
+            period: row.get("period")?,
+            total_runs: row.get("total_runs")?,
+            failed_runs: row.get("failed_runs")?,
+            success_rate: row.get("success_rate")?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
 
-    /// Per-step failure statistics across the N most recent terminal runs of a workflow.
-    /// Only counts steps with status `completed` or `failed` (skipped steps are excluded).
-    pub fn get_step_failure_heatmap(
-        &self,
-        workflow_name: &str,
-        limit_runs: usize,
-    ) -> Result<Vec<StepFailureHeatmapRow>> {
-        let mut stmt = self.conn.prepare_cached(&format!(
+/// Per-step failure statistics across the N most recent terminal runs of a workflow.
+/// Only counts steps with status `completed` or `failed` (skipped steps are excluded).
+pub fn get_step_failure_heatmap(
+    conn: &Connection,
+    workflow_name: &str,
+    limit_runs: usize,
+) -> Result<Vec<StepFailureHeatmapRow>> {
+    let mut stmt = conn.prepare_cached(&format!(
             "SELECT wrs.step_name, \
                     COUNT(*) AS total_executions, \
                     SUM(CASE WHEN wrs.status='failed' THEN 1 ELSE 0 END) AS failed_executions, \
@@ -1384,28 +1407,28 @@ impl<'a> WorkflowManager<'a> {
                ) \
              GROUP BY wrs.step_name \
              ORDER BY failure_rate DESC, total_executions DESC",
-            Self::N_RECENT_TERMINAL_RUNS_SUBQUERY
+            N_RECENT_TERMINAL_RUNS_SUBQUERY
         ))?;
-        let rows = stmt.query_map(rusqlite::params![workflow_name, limit_runs as i64], |row| {
-            Ok(StepFailureHeatmapRow {
-                step_name: row.get("step_name")?,
-                total_executions: row.get("total_executions")?,
-                failed_executions: row.get("failed_executions")?,
-                failure_rate: row.get("failure_rate")?,
-                avg_retry_count: row.get("avg_retry_count")?,
-            })
-        })?;
-        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
-    }
+    let rows = stmt.query_map(rusqlite::params![workflow_name, limit_runs as i64], |row| {
+        Ok(StepFailureHeatmapRow {
+            step_name: row.get("step_name")?,
+            total_executions: row.get("total_executions")?,
+            failed_executions: row.get("failed_executions")?,
+            failure_rate: row.get("failure_rate")?,
+            avg_retry_count: row.get("avg_retry_count")?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
 
-    /// Per-step retry statistics across the N most recent terminal runs of a workflow.
-    /// Only counts steps with status `completed` or `failed` (skipped steps are excluded).
-    pub fn get_step_retry_analytics(
-        &self,
-        workflow_name: &str,
-        limit_runs: usize,
-    ) -> Result<Vec<StepRetryAnalyticsRow>> {
-        let mut stmt = self.conn.prepare_cached(&format!(
+/// Per-step retry statistics across the N most recent terminal runs of a workflow.
+/// Only counts steps with status `completed` or `failed` (skipped steps are excluded).
+pub fn get_step_retry_analytics(
+    conn: &Connection,
+    workflow_name: &str,
+    limit_runs: usize,
+) -> Result<Vec<StepRetryAnalyticsRow>> {
+    let mut stmt = conn.prepare_cached(&format!(
             "SELECT wrs.step_name, \
                     COUNT(*) AS total_executions, \
                     SUM(CASE WHEN wrs.retry_count > 0 THEN 1 ELSE 0 END) AS executions_with_retries, \
@@ -1430,30 +1453,30 @@ impl<'a> WorkflowManager<'a> {
                ) \
              GROUP BY wrs.step_name \
              ORDER BY retry_rate DESC, total_executions DESC",
-            Self::N_RECENT_TERMINAL_RUNS_SUBQUERY
+            N_RECENT_TERMINAL_RUNS_SUBQUERY
         ))?;
-        let rows = stmt.query_map(rusqlite::params![workflow_name, limit_runs as i64], |row| {
-            Ok(StepRetryAnalyticsRow {
-                step_name: row.get("step_name")?,
-                total_executions: row.get("total_executions")?,
-                executions_with_retries: row.get("executions_with_retries")?,
-                retry_rate: row.get("retry_rate")?,
-                avg_retry_count: row.get("avg_retry_count")?,
-                retry_success_rate: row.get("retry_success_rate")?,
-            })
-        })?;
-        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
-    }
+    let rows = stmt.query_map(rusqlite::params![workflow_name, limit_runs as i64], |row| {
+        Ok(StepRetryAnalyticsRow {
+            step_name: row.get("step_name")?,
+            total_executions: row.get("total_executions")?,
+            executions_with_retries: row.get("executions_with_retries")?,
+            retry_rate: row.get("retry_rate")?,
+            avg_retry_count: row.get("avg_retry_count")?,
+            retry_success_rate: row.get("retry_success_rate")?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
 
-    /// Raw per-run metrics for completed runs of a workflow within the given day window.
-    /// Returns one row per run with duration_ms, input_tokens, output_tokens.
-    /// Binning happens client-side to avoid extra round-trips when switching metric toggles.
-    pub fn get_run_metrics(
-        &self,
-        workflow_name: &str,
-        days: u32,
-    ) -> Result<Vec<WorkflowRunMetricsRow>> {
-        let mut stmt = self.conn.prepare_cached(
+/// Raw per-run metrics for completed runs of a workflow within the given day window.
+/// Returns one row per run with duration_ms, input_tokens, output_tokens.
+/// Binning happens client-side to avoid extra round-trips when switching metric toggles.
+pub fn get_run_metrics(
+    conn: &Connection,
+    workflow_name: &str,
+    days: u32,
+) -> Result<Vec<WorkflowRunMetricsRow>> {
+    let mut stmt = conn.prepare_cached(
             "SELECT id, started_at, total_duration_ms, total_input_tokens, total_output_tokens, worktree_id, repo_id \
              FROM workflow_runs \
              WHERE workflow_name = :workflow_name \
@@ -1463,32 +1486,32 @@ impl<'a> WorkflowManager<'a> {
              ORDER BY started_at DESC \
              LIMIT 10000",
         )?;
-        let rows = stmt.query_map(
-            named_params! { ":workflow_name": workflow_name, ":days": days },
-            |row| {
-                Ok(WorkflowRunMetricsRow {
-                    run_id: row.get("id")?,
-                    started_at: row.get("started_at")?,
-                    duration_ms: row.get("total_duration_ms")?,
-                    input_tokens: row.get("total_input_tokens")?,
-                    output_tokens: row.get("total_output_tokens")?,
-                    worktree_id: row.get("worktree_id")?,
-                    repo_id: row.get("repo_id")?,
-                })
-            },
-        )?;
-        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
-    }
+    let rows = stmt.query_map(
+        named_params! { ":workflow_name": workflow_name, ":days": days },
+        |row| {
+            Ok(WorkflowRunMetricsRow {
+                run_id: row.get("id")?,
+                started_at: row.get("started_at")?,
+                duration_ms: row.get("total_duration_ms")?,
+                input_tokens: row.get("total_input_tokens")?,
+                output_tokens: row.get("total_output_tokens")?,
+                worktree_id: row.get("worktree_id")?,
+                repo_id: row.get("repo_id")?,
+            })
+        },
+    )?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
 
-    /// Compute P50/P75/P95/P99 percentiles for duration, cost, and total tokens.
-    ///
-    /// Returns `None` when there are no qualifying completed runs with duration data.
-    pub fn get_workflow_percentiles(
-        &self,
-        workflow_name: &str,
-        days: u32,
-    ) -> crate::error::Result<Option<WorkflowPercentiles>> {
-        let mut stmt = self.conn.prepare_cached(
+/// Compute P50/P75/P95/P99 percentiles for duration, cost, and total tokens.
+///
+/// Returns `None` when there are no qualifying completed runs with duration data.
+pub fn get_workflow_percentiles(
+    conn: &Connection,
+    workflow_name: &str,
+    days: u32,
+) -> crate::error::Result<Option<WorkflowPercentiles>> {
+    let mut stmt = conn.prepare_cached(
             "WITH ranked AS ( \
                SELECT \
                  total_duration_ms, \
@@ -1520,59 +1543,59 @@ impl<'a> WorkflowManager<'a> {
                MAX(cnt) AS run_count \
              FROM ranked",
         )?;
-        let row = stmt.query_row(
-            named_params! { ":workflow_name": workflow_name, ":days": days },
-            |row| {
-                let run_count: Option<i64> = row.get("run_count")?;
-                Ok((
-                    row.get::<_, Option<f64>>("p50_duration_ms")?,
-                    row.get::<_, Option<f64>>("p75_duration_ms")?,
-                    row.get::<_, Option<f64>>("p95_duration_ms")?,
-                    row.get::<_, Option<f64>>("p99_duration_ms")?,
-                    row.get::<_, Option<f64>>("p50_cost_usd")?,
-                    row.get::<_, Option<f64>>("p75_cost_usd")?,
-                    row.get::<_, Option<f64>>("p95_cost_usd")?,
-                    row.get::<_, Option<f64>>("p99_cost_usd")?,
-                    row.get::<_, Option<f64>>("p50_total_tokens")?,
-                    row.get::<_, Option<f64>>("p75_total_tokens")?,
-                    row.get::<_, Option<f64>>("p95_total_tokens")?,
-                    row.get::<_, Option<f64>>("p99_total_tokens")?,
-                    run_count,
-                ))
-            },
-        )?;
-        let run_count = row.12.unwrap_or(0);
-        if run_count == 0 {
-            return Ok(None);
-        }
-        Ok(Some(WorkflowPercentiles {
-            p50_duration_ms: row.0,
-            p75_duration_ms: row.1,
-            p95_duration_ms: row.2,
-            p99_duration_ms: row.3,
-            p50_cost_usd: row.4,
-            p75_cost_usd: row.5,
-            p95_cost_usd: row.6,
-            p99_cost_usd: row.7,
-            p50_total_tokens: row.8,
-            p75_total_tokens: row.9,
-            p95_total_tokens: row.10,
-            p99_total_tokens: row.11,
-            run_count,
-        }))
+    let row = stmt.query_row(
+        named_params! { ":workflow_name": workflow_name, ":days": days },
+        |row| {
+            let run_count: Option<i64> = row.get("run_count")?;
+            Ok((
+                row.get::<_, Option<f64>>("p50_duration_ms")?,
+                row.get::<_, Option<f64>>("p75_duration_ms")?,
+                row.get::<_, Option<f64>>("p95_duration_ms")?,
+                row.get::<_, Option<f64>>("p99_duration_ms")?,
+                row.get::<_, Option<f64>>("p50_cost_usd")?,
+                row.get::<_, Option<f64>>("p75_cost_usd")?,
+                row.get::<_, Option<f64>>("p95_cost_usd")?,
+                row.get::<_, Option<f64>>("p99_cost_usd")?,
+                row.get::<_, Option<f64>>("p50_total_tokens")?,
+                row.get::<_, Option<f64>>("p75_total_tokens")?,
+                row.get::<_, Option<f64>>("p95_total_tokens")?,
+                row.get::<_, Option<f64>>("p99_total_tokens")?,
+                run_count,
+            ))
+        },
+    )?;
+    let run_count = row.12.unwrap_or(0);
+    if run_count == 0 {
+        return Ok(None);
     }
+    Ok(Some(WorkflowPercentiles {
+        p50_duration_ms: row.0,
+        p75_duration_ms: row.1,
+        p95_duration_ms: row.2,
+        p99_duration_ms: row.3,
+        p50_cost_usd: row.4,
+        p75_cost_usd: row.5,
+        p95_cost_usd: row.6,
+        p99_cost_usd: row.7,
+        p50_total_tokens: row.8,
+        p75_total_tokens: row.9,
+        p95_total_tokens: row.10,
+        p99_total_tokens: row.11,
+        run_count,
+    }))
+}
 
-    /// Compute the 30-day spike detection baseline for a workflow.
-    ///
-    /// Returns `None` when fewer than `min_runs` completed root runs exist in the window,
-    /// or when `avg_cost_usd` is NULL (all runs have no cost data).
-    pub fn get_workflow_spike_baseline(
-        &self,
-        workflow_name: &str,
-        days: u32,
-        min_runs: usize,
-    ) -> crate::error::Result<Option<crate::workflow::SpikeBaseline>> {
-        let mut stmt = self.conn.prepare_cached(
+/// Compute the 30-day spike detection baseline for a workflow.
+///
+/// Returns `None` when fewer than `min_runs` completed root runs exist in the window,
+/// or when `avg_cost_usd` is NULL (all runs have no cost data).
+pub fn get_workflow_spike_baseline(
+    conn: &Connection,
+    workflow_name: &str,
+    days: u32,
+    min_runs: usize,
+) -> crate::error::Result<Option<crate::workflow::SpikeBaseline>> {
+    let mut stmt = conn.prepare_cached(
             "WITH ranked AS ( \
                SELECT \
                  total_cost_usd, \
@@ -1592,49 +1615,49 @@ impl<'a> WorkflowManager<'a> {
                MAX(cnt) AS run_count \
              FROM ranked",
         )?;
-        let row = stmt.query_row(
-            named_params! { ":workflow_name": workflow_name, ":days": days },
-            |row| {
-                Ok((
-                    row.get::<_, Option<f64>>("avg_cost_usd")?,
-                    row.get::<_, Option<f64>>("p75_duration_ms")?,
-                    row.get::<_, Option<i64>>("run_count")?,
-                ))
-            },
-        )?;
-        let run_count = row.2.unwrap_or(0);
-        if run_count < min_runs as i64 {
-            return Ok(None);
-        }
-        let avg_cost_usd = match row.0 {
-            Some(v) => v,
-            None => return Ok(None),
-        };
-        let p75_duration_ms = row.1.unwrap_or(0.0);
-        Ok(Some(crate::workflow::SpikeBaseline {
-            avg_cost_usd,
-            p75_duration_ms,
-            run_count,
-        }))
+    let row = stmt.query_row(
+        named_params! { ":workflow_name": workflow_name, ":days": days },
+        |row| {
+            Ok((
+                row.get::<_, Option<f64>>("avg_cost_usd")?,
+                row.get::<_, Option<f64>>("p75_duration_ms")?,
+                row.get::<_, Option<i64>>("run_count")?,
+            ))
+        },
+    )?;
+    let run_count = row.2.unwrap_or(0);
+    if run_count < min_runs as i64 {
+        return Ok(None);
     }
+    let avg_cost_usd = match row.0 {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+    let p75_duration_ms = row.1.unwrap_or(0.0);
+    Ok(Some(crate::workflow::SpikeBaseline {
+        avg_cost_usd,
+        p75_duration_ms,
+        run_count,
+    }))
+}
 
-    /// Compute passive regression signals for all workflows with sufficient recent run history.
-    ///
-    /// Compares a recent window (`recent_days`) against a baseline window
-    /// (`[recent_days, recent_days + baseline_days]` days ago) using P75 for duration and
-    /// cost, and failure rate (percentage) for the third signal. Workflows with fewer than
-    /// `min_recent_runs` completed runs in the recent window are excluded.
-    ///
-    /// Regression boolean flags are applied in Rust after the query using the threshold
-    /// constants from `constants.rs`, keeping the SQL readable and the raw numbers available
-    /// for display in the UI.
-    pub fn get_workflow_regression_signals(
-        &self,
-        min_recent_runs: i64,
-        recent_days: i64,
-        baseline_days: i64,
-    ) -> Result<Vec<WorkflowRegressionSignal>> {
-        let mut stmt = self.conn.prepare_cached(
+/// Compute passive regression signals for all workflows with sufficient recent run history.
+///
+/// Compares a recent window (`recent_days`) against a baseline window
+/// (`[recent_days, recent_days + baseline_days]` days ago) using P75 for duration and
+/// cost, and failure rate (percentage) for the third signal. Workflows with fewer than
+/// `min_recent_runs` completed runs in the recent window are excluded.
+///
+/// Regression boolean flags are applied in Rust after the query using the threshold
+/// constants from `constants.rs`, keeping the SQL readable and the raw numbers available
+/// for display in the UI.
+pub fn get_workflow_regression_signals(
+    conn: &Connection,
+    min_recent_runs: i64,
+    recent_days: i64,
+    baseline_days: i64,
+) -> Result<Vec<WorkflowRegressionSignal>> {
+    let mut stmt = conn.prepare_cached(
             // Two CTEs each computing per-workflow P75 for duration and cost via
             // ROW_NUMBER() OVER (PARTITION BY workflow_name), plus failure-rate aggregates.
             // INNER JOIN ensures workflows with no baseline history are excluded.
@@ -1707,7 +1730,7 @@ impl<'a> WorkflowManager<'a> {
              ORDER BY r.workflow_name",
         )?;
 
-        let rows = stmt.query_map(
+    let rows = stmt.query_map(
             named_params! { ":recent_days": recent_days, ":min_recent_runs": min_recent_runs, ":baseline_days": baseline_days },
             |row| {
                 let recent_runs: i64 = row.get("recent_runs")?;
@@ -1748,37 +1771,36 @@ impl<'a> WorkflowManager<'a> {
             },
         )?;
 
-        let mut signals: Vec<WorkflowRegressionSignal> = rows.collect::<rusqlite::Result<_>>()?;
+    let mut signals: Vec<WorkflowRegressionSignal> = rows.collect::<rusqlite::Result<_>>()?;
 
-        // Apply threshold flags in Rust so thresholds are co-located with their constants.
-        for s in &mut signals {
-            s.duration_regressed = s
-                .duration_change_pct
-                .map(|pct| pct > REGRESSION_DURATION_THRESHOLD_PCT)
-                .unwrap_or(false);
-            s.cost_regressed = s
-                .cost_change_pct
-                .map(|pct| pct > REGRESSION_COST_THRESHOLD_PCT)
-                .unwrap_or(false);
-            s.failure_rate_regressed =
-                s.failure_rate_change_pp > REGRESSION_FAILURE_RATE_THRESHOLD_PP;
-        }
-
-        Ok(signals)
+    // Apply threshold flags in Rust so thresholds are co-located with their constants.
+    for s in &mut signals {
+        s.duration_regressed = s
+            .duration_change_pct
+            .map(|pct| pct > REGRESSION_DURATION_THRESHOLD_PCT)
+            .unwrap_or(false);
+        s.cost_regressed = s
+            .cost_change_pct
+            .map(|pct| pct > REGRESSION_COST_THRESHOLD_PCT)
+            .unwrap_or(false);
+        s.failure_rate_regressed = s.failure_rate_change_pp > REGRESSION_FAILURE_RATE_THRESHOLD_PP;
     }
 
-    /// Per-gate-step aggregate analytics for a workflow within the given day window.
-    ///
-    /// Only counts terminal gate steps (`status IN ('completed', 'failed')`).
-    /// Approval is inferred from `status`: `completed` = approved, `failed` = rejected.
-    /// Wait time is computed via julianday arithmetic on `started_at` / `ended_at`.
-    /// P50 and P95 percentiles are computed per step using the ROW_NUMBER CTE pattern.
-    pub fn get_gate_analytics(
-        &self,
-        workflow_name: &str,
-        days: u32,
-    ) -> Result<Vec<GateAnalyticsRow>> {
-        let mut stmt = self.conn.prepare_cached(
+    Ok(signals)
+}
+
+/// Per-gate-step aggregate analytics for a workflow within the given day window.
+///
+/// Only counts terminal gate steps (`status IN ('completed', 'failed')`).
+/// Approval is inferred from `status`: `completed` = approved, `failed` = rejected.
+/// Wait time is computed via julianday arithmetic on `started_at` / `ended_at`.
+/// P50 and P95 percentiles are computed per step using the ROW_NUMBER CTE pattern.
+pub fn get_gate_analytics(
+    conn: &Connection,
+    workflow_name: &str,
+    days: u32,
+) -> Result<Vec<GateAnalyticsRow>> {
+    let mut stmt = conn.prepare_cached(
             "WITH gate_rows AS ( \
                SELECT \
                  wrs.step_name, \
@@ -1817,29 +1839,29 @@ impl<'a> WorkflowManager<'a> {
              GROUP BY step_name \
              ORDER BY total_gate_hits DESC, step_name",
         )?;
-        let rows = stmt.query_map(
-            named_params! { ":workflow_name": workflow_name, ":days": days },
-            |row| {
-                Ok(GateAnalyticsRow {
-                    step_name: row.get("step_name")?,
-                    total_gate_hits: row.get("total_gate_hits")?,
-                    approved_count: row.get("approved_count")?,
-                    rejected_count: row.get("rejected_count")?,
-                    approval_rate: row.get("approval_rate")?,
-                    avg_wait_ms: row.get("avg_wait_ms")?,
-                    p50_wait_ms: row.get("p50_wait_ms")?,
-                    p95_wait_ms: row.get("p95_wait_ms")?,
-                    avg_feedback_length: row.get("avg_feedback_length")?,
-                })
-            },
-        )?;
-        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
-    }
+    let rows = stmt.query_map(
+        named_params! { ":workflow_name": workflow_name, ":days": days },
+        |row| {
+            Ok(GateAnalyticsRow {
+                step_name: row.get("step_name")?,
+                total_gate_hits: row.get("total_gate_hits")?,
+                approved_count: row.get("approved_count")?,
+                rejected_count: row.get("rejected_count")?,
+                approval_rate: row.get("approval_rate")?,
+                avg_wait_ms: row.get("avg_wait_ms")?,
+                p50_wait_ms: row.get("p50_wait_ms")?,
+                p95_wait_ms: row.get("p95_wait_ms")?,
+                avg_feedback_length: row.get("avg_feedback_length")?,
+            })
+        },
+    )?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
 
-    /// Cross-workflow snapshot of all currently-waiting gate steps, ordered by `started_at` ASC
-    /// (longest-waiting first). `wait_ms_so_far` is computed via julianday arithmetic.
-    pub fn get_all_pending_gates(&self) -> Result<Vec<PendingGateAnalyticsRow>> {
-        let mut stmt = self.conn.prepare_cached(
+/// Cross-workflow snapshot of all currently-waiting gate steps, ordered by `started_at` ASC
+/// (longest-waiting first). `wait_ms_so_far` is computed via julianday arithmetic.
+pub fn get_all_pending_gates(conn: &Connection) -> Result<Vec<PendingGateAnalyticsRow>> {
+    let mut stmt = conn.prepare_cached(
             "SELECT \
                wrs.id AS step_id, \
                wrs.step_name, \
@@ -1855,27 +1877,25 @@ impl<'a> WorkflowManager<'a> {
                AND wrs.gate_type IS NOT NULL \
              ORDER BY wrs.started_at ASC",
         )?;
-        let rows = stmt.query_map([], |row| {
-            Ok(PendingGateAnalyticsRow {
-                step_id: row.get("step_id")?,
-                step_name: row.get("step_name")?,
-                gate_type: row.get("gate_type")?,
-                gate_prompt: row.get("gate_prompt")?,
-                workflow_name: row.get("workflow_name")?,
-                workflow_run_id: row.get("workflow_run_id")?,
-                started_at: row.get("started_at")?,
-                wait_ms_so_far: row.get("wait_ms_so_far")?,
-            })
-        })?;
-        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
-    }
+    let rows = stmt.query_map([], |row| {
+        Ok(PendingGateAnalyticsRow {
+            step_id: row.get("step_id")?,
+            step_name: row.get("step_name")?,
+            gate_type: row.get("gate_type")?,
+            gate_prompt: row.get("gate_prompt")?,
+            workflow_name: row.get("workflow_name")?,
+            workflow_run_id: row.get("workflow_run_id")?,
+            started_at: row.get("started_at")?,
+            wait_ms_so_far: row.get("wait_ms_so_far")?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
 #[cfg(test)]
 mod tests {
     use super::pct_change;
     use crate::db::migrations;
-    use crate::workflow::manager::WorkflowManager;
     use rusqlite::Connection;
 
     fn setup_db() -> Connection {
@@ -1896,8 +1916,7 @@ mod tests {
             [],
         )
         .unwrap();
-        let mgr = WorkflowManager::new(&conn);
-        let runs = mgr.list_active_non_worktree_workflow_runs(10).unwrap();
+        let runs = super::list_active_non_worktree_workflow_runs(&conn, 10).unwrap();
         assert!(
             runs.iter().any(|r| r.id == "run-active"),
             "active running run should be returned"
@@ -1915,8 +1934,7 @@ mod tests {
             [],
         )
         .unwrap();
-        let mgr = WorkflowManager::new(&conn);
-        let runs = mgr.list_active_non_worktree_workflow_runs(10).unwrap();
+        let runs = super::list_active_non_worktree_workflow_runs(&conn, 10).unwrap();
         assert!(
             runs.iter().any(|r| r.id == "run-recent"),
             "recently-completed run (ended 5s ago) should be returned"
@@ -1935,8 +1953,7 @@ mod tests {
             [],
         )
         .unwrap();
-        let mgr = WorkflowManager::new(&conn);
-        let runs = mgr.list_active_non_worktree_workflow_runs(10).unwrap();
+        let runs = super::list_active_non_worktree_workflow_runs(&conn, 10).unwrap();
         assert!(
             !runs.iter().any(|r| r.id == "run-old"),
             "completed run ended 120s ago should NOT be returned"
@@ -2009,13 +2026,10 @@ mod tests {
         )
         .unwrap();
 
-        let mgr = WorkflowManager::new(&conn);
-
         // Query both runs at once — this exercises the variable-length IN clause that
         // previously triggered the prepare_cached bug.
-        let estimates = mgr
-            .get_plan_estimates_for_runs(&["run-est-1", "run-est-2"])
-            .unwrap();
+        let estimates =
+            super::get_plan_estimates_for_runs(&conn, &["run-est-1", "run-est-2"]).unwrap();
 
         assert_eq!(
             estimates.get("run-est-1"),
@@ -2029,7 +2043,7 @@ mod tests {
         );
 
         // Empty input should return an empty map without querying the DB.
-        let empty = mgr.get_plan_estimates_for_runs(&[]).unwrap();
+        let empty = super::get_plan_estimates_for_runs(&conn, &[]).unwrap();
         assert!(empty.is_empty(), "empty input → empty result");
     }
 
@@ -2061,9 +2075,7 @@ mod tests {
         )
         .unwrap();
 
-        let mgr = WorkflowManager::new(&conn);
-        let step = mgr
-            .find_waiting_gate("run-gate-1")
+        let step = super::find_waiting_gate(&conn, "run-gate-1")
             .unwrap()
             .expect("should find a waiting gate step");
 
@@ -2076,8 +2088,7 @@ mod tests {
     #[test]
     fn find_waiting_gates_for_runs_empty_input_returns_empty() {
         let conn = setup_db();
-        let mgr = WorkflowManager::new(&conn);
-        let result = mgr.find_waiting_gates_for_runs(&[]).unwrap();
+        let result = super::find_waiting_gates_for_runs(&conn, &[]).unwrap();
         assert!(
             result.is_empty(),
             "empty input should return empty map without querying DB"
@@ -2123,10 +2134,7 @@ mod tests {
         )
         .unwrap();
 
-        let mgr = WorkflowManager::new(&conn);
-        let result = mgr
-            .find_waiting_gates_for_runs(&["run-g-1", "run-g-2"])
-            .unwrap();
+        let result = super::find_waiting_gates_for_runs(&conn, &["run-g-1", "run-g-2"]).unwrap();
 
         assert_eq!(result.len(), 2, "both runs should have an entry");
         assert_eq!(
@@ -2171,10 +2179,7 @@ mod tests {
         )
         .unwrap();
 
-        let mgr = WorkflowManager::new(&conn);
-        let result = mgr
-            .find_waiting_gates_for_runs(&["run-h-1", "run-h-2"])
-            .unwrap();
+        let result = super::find_waiting_gates_for_runs(&conn, &["run-h-1", "run-h-2"]).unwrap();
 
         assert!(
             !result.contains_key("run-h-1"),
@@ -2208,9 +2213,7 @@ mod tests {
         )
         .unwrap();
 
-        let mgr = WorkflowManager::new(&conn);
-        let step = mgr
-            .find_waiting_gate("run-gate-2")
+        let step = super::find_waiting_gate(&conn, "run-gate-2")
             .unwrap()
             .expect("should find a waiting gate step");
 

--- a/conductor-core/src/workflow/manager/recovery.rs
+++ b/conductor-core/src/workflow/manager/recovery.rs
@@ -339,7 +339,7 @@ impl<'a> WorkflowManager<'a> {
 
         // Batch-fetch the active waiting gate step for each run to avoid N+1 queries.
         let run_id_refs: Vec<&str> = waiting_runs.iter().map(|(id, _)| id.as_str()).collect();
-        let gate_steps = self.find_waiting_gates_for_runs(&run_id_refs)?;
+        let gate_steps = super::queries::find_waiting_gates_for_runs(self.conn, &run_id_refs)?;
 
         let mut reaped = 0usize;
         let now = Utc::now();
@@ -1019,7 +1019,7 @@ impl<'a> WorkflowManager<'a> {
     /// Skip-set construction for the resume execution path is handled internally
     /// by `FlowEngine::resume()`.
     pub fn get_completed_step_keys(&self, workflow_run_id: &str) -> Result<HashSet<StepKey>> {
-        let steps = self.get_workflow_steps(workflow_run_id)?;
+        let steps = super::queries::get_workflow_steps(self.conn, workflow_run_id)?;
         Ok(steps
             .iter()
             .filter(|s| s.status == WorkflowStepStatus::Completed)

--- a/conductor-core/src/workflow/manager/steps.rs
+++ b/conductor-core/src/workflow/manager/steps.rs
@@ -568,7 +568,7 @@ mod tests {
         mgr.mark_step_running(&step_id, WorkflowStepStatus::Running, Some("child-run-1"))
             .unwrap();
 
-        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        let step = crate::workflow::get_step_by_id(&conn, &step_id)
             .unwrap()
             .unwrap();
         assert_eq!(step.status, WorkflowStepStatus::Running);
@@ -585,7 +585,7 @@ mod tests {
         mgr.mark_step_running(&step_id, WorkflowStepStatus::Waiting, None)
             .unwrap();
 
-        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        let step = crate::workflow::get_step_by_id(&conn, &step_id)
             .unwrap()
             .unwrap();
         assert_eq!(step.status, WorkflowStepStatus::Waiting);
@@ -611,7 +611,7 @@ mod tests {
         )
         .unwrap();
 
-        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        let step = crate::workflow::get_step_by_id(&conn, &step_id)
             .unwrap()
             .unwrap();
         assert_eq!(step.status, WorkflowStepStatus::Completed);
@@ -637,7 +637,7 @@ mod tests {
         mgr.mark_step_pending(&step_id, WorkflowStepStatus::Pending)
             .unwrap();
 
-        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        let step = crate::workflow::get_step_by_id(&conn, &step_id)
             .unwrap()
             .unwrap();
         assert_eq!(step.status, WorkflowStepStatus::Pending);
@@ -671,7 +671,7 @@ mod tests {
         )
         .unwrap();
 
-        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        let step = crate::workflow::get_step_by_id(&conn, &step_id)
             .unwrap()
             .unwrap();
         assert_eq!(step.status, WorkflowStepStatus::Failed);
@@ -703,7 +703,7 @@ mod tests {
         )
         .unwrap();
 
-        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        let step = crate::workflow::get_step_by_id(&conn, &step_id)
             .unwrap()
             .unwrap();
         assert_eq!(step.cost_usd, Some(1.23));
@@ -746,7 +746,7 @@ mod tests {
         )
         .unwrap();
 
-        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        let step = crate::workflow::get_step_by_id(&conn, &step_id)
             .unwrap()
             .unwrap();
         assert_eq!(step.cost_usd, Some(9.99), "cost_usd must be preserved");
@@ -773,7 +773,7 @@ mod tests {
         .unwrap();
 
         // Original step untouched.
-        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        let step = crate::workflow::get_step_by_id(&conn, &step_id)
             .unwrap()
             .unwrap();
         assert!(step.cost_usd.is_none());

--- a/conductor-core/src/workflow/manager/steps.rs
+++ b/conductor-core/src/workflow/manager/steps.rs
@@ -568,7 +568,9 @@ mod tests {
         mgr.mark_step_running(&step_id, WorkflowStepStatus::Running, Some("child-run-1"))
             .unwrap();
 
-        let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(step.status, WorkflowStepStatus::Running);
         assert_eq!(step.child_run_id.as_deref(), Some("child-run-1"));
         assert!(step.started_at.is_some(), "started_at should be set");
@@ -583,7 +585,9 @@ mod tests {
         mgr.mark_step_running(&step_id, WorkflowStepStatus::Waiting, None)
             .unwrap();
 
-        let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(step.status, WorkflowStepStatus::Waiting);
         assert!(step.child_run_id.is_none());
     }
@@ -607,7 +611,9 @@ mod tests {
         )
         .unwrap();
 
-        let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(step.status, WorkflowStepStatus::Completed);
         assert_eq!(step.child_run_id.as_deref(), Some("child-run-2"));
         assert_eq!(step.result_text.as_deref(), Some("result text"));
@@ -631,7 +637,9 @@ mod tests {
         mgr.mark_step_pending(&step_id, WorkflowStepStatus::Pending)
             .unwrap();
 
-        let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(step.status, WorkflowStepStatus::Pending);
         // started_at and child_run_id must be left as-is (mark_step_pending touches status only).
         assert!(step.started_at.is_some(), "started_at should be preserved");
@@ -663,7 +671,9 @@ mod tests {
         )
         .unwrap();
 
-        let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(step.status, WorkflowStepStatus::Failed);
         // COALESCE in SQL keeps the existing child_run_id when None is passed.
         assert_eq!(step.child_run_id.as_deref(), Some("child-run-3"));
@@ -693,7 +703,9 @@ mod tests {
         )
         .unwrap();
 
-        let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(step.cost_usd, Some(1.23));
         assert_eq!(step.num_turns, Some(5));
         assert_eq!(step.duration_ms, Some(1000));
@@ -734,7 +746,9 @@ mod tests {
         )
         .unwrap();
 
-        let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+            .unwrap()
+            .unwrap();
         assert_eq!(step.cost_usd, Some(9.99), "cost_usd must be preserved");
         assert_eq!(step.num_turns, Some(3), "num_turns must be preserved");
         assert_eq!(step.input_tokens, Some(42));
@@ -759,7 +773,9 @@ mod tests {
         .unwrap();
 
         // Original step untouched.
-        let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+        let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+            .unwrap()
+            .unwrap();
         assert!(step.cost_usd.is_none());
     }
 }

--- a/conductor-core/src/workflow/manager/tests.rs
+++ b/conductor-core/src/workflow/manager/tests.rs
@@ -175,7 +175,7 @@ fn test_list_active_workflow_runs_empty_slice_defaults_to_pending_running_waitin
     mgr.update_workflow_status(&completed_run.id, WorkflowRunStatus::Completed, None, None)
         .unwrap();
 
-    let runs = crate::workflow::list_active_workflow_runs(mgr.conn(), &[]).unwrap();
+    let runs = crate::workflow::list_active_workflow_runs(&conn, &[]).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -205,8 +205,7 @@ fn test_list_active_workflow_runs_explicit_status_filter() {
 
     // Ask only for running — pending must not appear.
     let runs =
-        crate::workflow::list_active_workflow_runs(mgr.conn(), &[WorkflowRunStatus::Running])
-            .unwrap();
+        crate::workflow::list_active_workflow_runs(&conn, &[WorkflowRunStatus::Running]).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -228,8 +227,7 @@ fn test_list_active_workflow_runs_null_worktree_included() {
     let repo_run = create_repo_run(&conn, "r1"); // worktree_id IS NULL
 
     let runs =
-        crate::workflow::list_active_workflow_runs(mgr.conn(), &[WorkflowRunStatus::Pending])
-            .unwrap();
+        crate::workflow::list_active_workflow_runs(&conn, &[WorkflowRunStatus::Pending]).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -251,8 +249,7 @@ fn test_list_active_workflow_runs_inactive_worktree_excluded() {
         .unwrap();
 
     let runs =
-        crate::workflow::list_active_workflow_runs(mgr.conn(), &[WorkflowRunStatus::Pending])
-            .unwrap();
+        crate::workflow::list_active_workflow_runs(&conn, &[WorkflowRunStatus::Pending]).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -289,7 +286,7 @@ fn test_list_all_waiting_gate_steps_returns_waiting_gate_steps() {
     // Mark step as waiting so it appears in the query.
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = crate::workflow::list_all_waiting_gate_steps(mgr.conn()).unwrap();
+    let steps = crate::workflow::list_all_waiting_gate_steps(&conn).unwrap();
     assert_eq!(steps.len(), 1, "one waiting gate step should be returned");
     let (step, workflow_name, target_label) = &steps[0];
     assert_eq!(step.id, step_id);
@@ -310,7 +307,7 @@ fn test_list_all_waiting_gate_steps_excludes_non_gate_steps() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = crate::workflow::list_all_waiting_gate_steps(mgr.conn()).unwrap();
+    let steps = crate::workflow::list_all_waiting_gate_steps(&conn).unwrap();
     assert!(
         steps.is_empty(),
         "steps without gate_type must not be returned"
@@ -332,7 +329,7 @@ fn test_list_active_workflow_runs_multiple_statuses_dynamic_placeholders() {
         .unwrap();
 
     let runs = crate::workflow::list_active_workflow_runs(
-        mgr.conn(),
+        &conn,
         &[WorkflowRunStatus::Pending, WorkflowRunStatus::Running],
     )
     .unwrap();
@@ -377,11 +374,9 @@ fn test_get_active_steps_for_runs_groups_by_run_id() {
         .unwrap();
     set_step_status(&mgr, &step2_active, WorkflowStepStatus::Running);
 
-    let result = crate::workflow::get_active_steps_for_runs(
-        mgr.conn(),
-        &[run1.id.as_str(), run2.id.as_str()],
-    )
-    .unwrap();
+    let result =
+        crate::workflow::get_active_steps_for_runs(&conn, &[run1.id.as_str(), run2.id.as_str()])
+            .unwrap();
 
     // Each run should be present with exactly its active step.
     assert_eq!(result.len(), 2, "expected entries for both runs");
@@ -415,8 +410,7 @@ fn test_get_active_steps_for_runs_includes_waiting_steps() {
         .insert_step(&run.id, "step-b", "actor", false, 1, 0)
         .unwrap();
 
-    let result =
-        crate::workflow::get_active_steps_for_runs(mgr.conn(), &[run.id.as_str()]).unwrap();
+    let result = crate::workflow::get_active_steps_for_runs(&conn, &[run.id.as_str()]).unwrap();
 
     // Only the Waiting step should appear.
     assert_eq!(result.len(), 1, "expected one run entry");
@@ -432,7 +426,7 @@ fn test_get_active_steps_for_runs_includes_waiting_steps() {
 fn test_get_active_steps_for_runs_empty_slice_returns_empty_map() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = crate::workflow::get_active_steps_for_runs(mgr.conn(), &[]).unwrap();
+    let result = crate::workflow::get_active_steps_for_runs(&conn, &[]).unwrap();
     assert!(result.is_empty(), "empty run_ids must yield an empty map");
 }
 
@@ -440,7 +434,7 @@ fn test_get_active_steps_for_runs_empty_slice_returns_empty_map() {
 fn test_get_steps_for_runs_empty_slice_returns_empty_map() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = crate::workflow::get_steps_for_runs(mgr.conn(), &[]).unwrap();
+    let result = crate::workflow::get_steps_for_runs(&conn, &[]).unwrap();
     assert!(result.is_empty(), "empty run_ids must yield an empty map");
 }
 
@@ -448,7 +442,7 @@ fn test_get_steps_for_runs_empty_slice_returns_empty_map() {
 fn test_get_workflow_run_ids_for_agent_runs_empty_slice_returns_empty_map() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = crate::workflow::get_workflow_run_ids_for_agent_runs(mgr.conn(), &[]).unwrap();
+    let result = crate::workflow::get_workflow_run_ids_for_agent_runs(&conn, &[]).unwrap();
     assert!(
         result.is_empty(),
         "empty agent_run_ids must yield an empty map"
@@ -459,7 +453,7 @@ fn test_get_workflow_run_ids_for_agent_runs_empty_slice_returns_empty_map() {
 fn test_get_step_summaries_for_runs_empty_slice_returns_empty_map() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[]).unwrap();
+    let result = crate::workflow::get_step_summaries_for_runs(&conn, &[]).unwrap();
     assert!(result.is_empty(), "empty run_ids must yield an empty map");
 }
 
@@ -489,8 +483,7 @@ fn test_get_steps_for_runs_returns_all_steps_regardless_of_status() {
         .unwrap();
 
     let result =
-        crate::workflow::get_steps_for_runs(mgr.conn(), &[run1.id.as_str(), run2.id.as_str()])
-            .unwrap();
+        crate::workflow::get_steps_for_runs(&conn, &[run1.id.as_str(), run2.id.as_str()]).unwrap();
 
     assert_eq!(result.len(), 2, "expected entries for both runs");
 
@@ -517,12 +510,9 @@ fn test_list_workflow_runs_filtered_with_status() {
     mgr.update_workflow_status(&running_run.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let runs = crate::workflow::list_workflow_runs_filtered(
-        mgr.conn(),
-        "w1",
-        Some(WorkflowRunStatus::Running),
-    )
-    .unwrap();
+    let runs =
+        crate::workflow::list_workflow_runs_filtered(&conn, "w1", Some(WorkflowRunStatus::Running))
+            .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -545,7 +535,7 @@ fn test_list_workflow_runs_filtered_none_returns_all() {
     mgr.update_workflow_status(&running_run.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let runs = crate::workflow::list_workflow_runs_filtered(mgr.conn(), "w1", None).unwrap();
+    let runs = crate::workflow::list_workflow_runs_filtered(&conn, "w1", None).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -572,7 +562,7 @@ fn test_list_workflow_runs_by_repo_id_filtered_with_status() {
         .unwrap();
 
     let runs = crate::workflow::list_workflow_runs_by_repo_id_filtered(
-        mgr.conn(),
+        &conn,
         "r1",
         50,
         0,
@@ -602,8 +592,7 @@ fn test_list_workflow_runs_by_repo_id_filtered_none_returns_all() {
         .unwrap();
 
     let runs =
-        crate::workflow::list_workflow_runs_by_repo_id_filtered(mgr.conn(), "r1", 50, 0, None)
-            .unwrap();
+        crate::workflow::list_workflow_runs_by_repo_id_filtered(&conn, "r1", 50, 0, None).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -632,7 +621,7 @@ fn test_list_workflow_runs_filtered_paginated_with_status() {
 
     // First page: limit=1, offset=0 — exactly one pending run.
     let page1 = crate::workflow::list_workflow_runs_filtered_paginated(
-        mgr.conn(),
+        &conn,
         "w1",
         Some(WorkflowRunStatus::Pending),
         1,
@@ -647,7 +636,7 @@ fn test_list_workflow_runs_filtered_paginated_with_status() {
 
     // Second page: limit=1, offset=1 — the other pending run.
     let page2 = crate::workflow::list_workflow_runs_filtered_paginated(
-        mgr.conn(),
+        &conn,
         "w1",
         Some(WorkflowRunStatus::Pending),
         1,
@@ -678,13 +667,11 @@ fn test_list_workflow_runs_filtered_paginated_none_delegates() {
 
     // None — no status filter, pagination alone controls results.
     let page1 =
-        crate::workflow::list_workflow_runs_filtered_paginated(mgr.conn(), "w1", None, 2, 0)
-            .unwrap();
+        crate::workflow::list_workflow_runs_filtered_paginated(&conn, "w1", None, 2, 0).unwrap();
     assert_eq!(page1.len(), 2, "limit=2 must return exactly 2 runs");
 
     let page2 =
-        crate::workflow::list_workflow_runs_filtered_paginated(mgr.conn(), "w1", None, 2, 2)
-            .unwrap();
+        crate::workflow::list_workflow_runs_filtered_paginated(&conn, "w1", None, 2, 2).unwrap();
     assert_eq!(
         page2.len(),
         1,
@@ -705,7 +692,7 @@ fn test_list_all_workflow_runs_filtered_paginated_with_status() {
         .unwrap();
 
     let runs = crate::workflow::list_all_workflow_runs_filtered_paginated(
-        mgr.conn(),
+        &conn,
         Some(WorkflowRunStatus::Running),
         50,
         0,
@@ -733,8 +720,8 @@ fn test_list_all_workflow_runs_filtered_paginated_none() {
     mgr.update_workflow_status(&run2.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let runs = crate::workflow::list_all_workflow_runs_filtered_paginated(mgr.conn(), None, 50, 0)
-        .unwrap();
+    let runs =
+        crate::workflow::list_all_workflow_runs_filtered_paginated(&conn, None, 50, 0).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(ids.contains(&run1.id.as_str()), "run1 must appear");
@@ -751,8 +738,8 @@ fn test_list_all_workflow_runs_filtered_paginated_excludes_inactive_worktrees() 
     conn.execute("UPDATE worktrees SET status = 'merged' WHERE id = 'w2'", [])
         .unwrap();
 
-    let runs = crate::workflow::list_all_workflow_runs_filtered_paginated(mgr.conn(), None, 50, 0)
-        .unwrap();
+    let runs =
+        crate::workflow::list_all_workflow_runs_filtered_paginated(&conn, None, 50, 0).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -776,7 +763,7 @@ fn test_list_all_workflow_runs_respects_limit() {
         create_worktree_run(&conn, "w1");
     }
 
-    let runs = crate::workflow::list_all_workflow_runs(mgr.conn(), 3).unwrap();
+    let runs = crate::workflow::list_all_workflow_runs(&conn, 3).unwrap();
     assert_eq!(runs.len(), 3, "limit=3 must return exactly 3 runs");
 }
 
@@ -790,7 +777,7 @@ fn test_list_all_workflow_runs_excludes_inactive_worktrees() {
     conn.execute("UPDATE worktrees SET status = 'merged' WHERE id = 'w2'", [])
         .unwrap();
 
-    let runs = crate::workflow::list_all_workflow_runs(mgr.conn(), 50).unwrap();
+    let runs = crate::workflow::list_all_workflow_runs(&conn, 50).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -820,7 +807,7 @@ fn test_list_all_waiting_gate_steps_excludes_approved_gate_steps() {
         rusqlite::named_params! { ":id": step_id },
     ).unwrap();
 
-    let steps = crate::workflow::list_all_waiting_gate_steps(mgr.conn()).unwrap();
+    let steps = crate::workflow::list_all_waiting_gate_steps(&conn).unwrap();
     assert!(
         steps.is_empty(),
         "approved (completed) gate steps must not be returned"
@@ -854,7 +841,7 @@ fn test_list_all_waiting_gate_steps_includes_target_label() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = crate::workflow::list_all_waiting_gate_steps(mgr.conn()).unwrap();
+    let steps = crate::workflow::list_all_waiting_gate_steps(&conn).unwrap();
     assert_eq!(steps.len(), 1);
     let (step, workflow_name, target_label) = &steps[0];
     assert_eq!(step.id, step_id);
@@ -895,7 +882,7 @@ fn test_list_waiting_gate_steps_for_repo_via_worktree() {
     .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(&conn, "r1").unwrap();
     assert_eq!(
         steps.len(),
         1,
@@ -931,7 +918,7 @@ fn test_list_waiting_gate_steps_for_repo_via_direct_repo_id() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(&conn, "r1").unwrap();
     assert_eq!(
         steps.len(),
         1,
@@ -975,7 +962,7 @@ fn test_list_waiting_gate_steps_for_repo_ticket_ref_populated() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(&conn, "r1").unwrap();
     assert_eq!(steps.len(), 1);
     assert_eq!(
         steps[0].ticket_ref.as_deref(),
@@ -999,10 +986,10 @@ fn test_list_waiting_gate_steps_for_repo_excludes_other_repo() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps_r1 = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
+    let steps_r1 = crate::workflow::list_waiting_gate_steps_for_repo(&conn, "r1").unwrap();
     assert!(steps_r1.is_empty(), "r1 must not see r2's gate steps");
 
-    let steps_r2 = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r2").unwrap();
+    let steps_r2 = crate::workflow::list_waiting_gate_steps_for_repo(&conn, "r2").unwrap();
     assert_eq!(steps_r2.len(), 1, "r2 should return its own gate step");
     assert_eq!(steps_r2[0].step.id, step_id);
 }
@@ -1019,7 +1006,7 @@ fn test_list_waiting_gate_steps_for_repo_excludes_non_gate_steps() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(&conn, "r1").unwrap();
     assert!(steps.is_empty(), "non-gate steps must not be returned");
 }
 
@@ -1039,7 +1026,7 @@ fn test_list_waiting_gate_steps_for_repo_excludes_completed_gate_steps() {
         rusqlite::named_params! { ":id": step_id },
     ).unwrap();
 
-    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(&conn, "r1").unwrap();
     assert!(
         steps.is_empty(),
         "completed gate steps must not be returned"
@@ -1063,7 +1050,7 @@ fn test_list_waiting_gate_steps_for_repo_excludes_cancelled_run() {
     )
     .unwrap();
 
-    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(&conn, "r1").unwrap();
     assert!(
         steps.is_empty(),
         "waiting gate steps from cancelled runs must not be returned"
@@ -1087,7 +1074,7 @@ fn test_list_waiting_gate_steps_for_repo_excludes_failed_run() {
     )
     .unwrap();
 
-    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(&conn, "r1").unwrap();
     assert!(
         steps.is_empty(),
         "waiting gate steps from failed runs must not be returned"
@@ -1101,21 +1088,21 @@ fn test_set_workflow_run_iteration() {
     let mgr = WorkflowManager::new(&conn);
 
     // Default iteration should be 0.
-    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(fetched.iteration, 0);
 
     // Set iteration to 3.
     mgr.set_workflow_run_iteration(&run.id, 3).unwrap();
-    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(fetched.iteration, 3);
 
     // Set iteration to 0 again.
     mgr.set_workflow_run_iteration(&run.id, 0).unwrap();
-    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(fetched.iteration, 0);
@@ -1265,7 +1252,7 @@ fn test_update_step_preserves_child_run_id_when_none_passed() {
     )
     .unwrap();
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     let step = steps.iter().find(|s| s.id == step_id).unwrap();
     assert_eq!(
         step.child_run_id.as_deref(),
@@ -1292,7 +1279,7 @@ fn test_get_step_summaries_for_runs_single_level_running_step() {
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Running);
 
     let summaries =
-        crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[run.id.as_str()]).unwrap();
+        crate::workflow::get_step_summaries_for_runs(&conn, &[run.id.as_str()]).unwrap();
     assert_eq!(summaries.len(), 1);
     let summary = summaries.get(&run.id).expect("root run missing");
     assert_eq!(summary.step_name, "build");
@@ -1341,7 +1328,7 @@ fn test_get_step_summaries_for_runs_child_chain_traversal() {
     set_step_status(&mgr, &child_step_id, WorkflowStepStatus::Running);
 
     let summaries =
-        crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[root.id.as_str()]).unwrap();
+        crate::workflow::get_step_summaries_for_runs(&conn, &[root.id.as_str()]).unwrap();
     assert_eq!(summaries.len(), 1);
     let summary = summaries.get(&root.id).expect("root run missing");
     assert_eq!(summary.step_name, "deploy");
@@ -1404,7 +1391,7 @@ fn test_get_step_summaries_for_runs_deep_chain() {
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Running);
 
     let summaries =
-        crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[root.id.as_str()]).unwrap();
+        crate::workflow::get_step_summaries_for_runs(&conn, &[root.id.as_str()]).unwrap();
     let summary = summaries.get(&root.id).expect("root run missing");
     assert_eq!(summary.step_name, "test");
     assert_eq!(
@@ -1430,7 +1417,7 @@ fn test_get_step_summaries_for_runs_no_running_step_omitted() {
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Completed);
 
     let summaries =
-        crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[run.id.as_str()]).unwrap();
+        crate::workflow::get_step_summaries_for_runs(&conn, &[run.id.as_str()]).unwrap();
     assert!(
         summaries.is_empty(),
         "run with no running step should be absent from summaries"
@@ -1460,11 +1447,9 @@ fn test_get_step_summaries_for_runs_multiple_roots() {
         .unwrap();
     set_step_status(&mgr, &step2_id, WorkflowStepStatus::Running);
 
-    let summaries = crate::workflow::get_step_summaries_for_runs(
-        mgr.conn(),
-        &[run1.id.as_str(), run2.id.as_str()],
-    )
-    .unwrap();
+    let summaries =
+        crate::workflow::get_step_summaries_for_runs(&conn, &[run1.id.as_str(), run2.id.as_str()])
+            .unwrap();
 
     assert_eq!(summaries.len(), 2);
     let s1 = summaries.get(&run1.id).expect("run1 missing");
@@ -1520,7 +1505,7 @@ fn test_get_step_summaries_for_runs_multiple_roots_with_chains() {
     set_step_status(&mgr, &step_b_id, WorkflowStepStatus::Running);
 
     let summaries = crate::workflow::get_step_summaries_for_runs(
-        mgr.conn(),
+        &conn,
         &[root_a.id.as_str(), root_b.id.as_str()],
     )
     .unwrap();
@@ -1556,7 +1541,7 @@ fn test_cancel_run_marks_run_cancelled() {
 
     mgr.cancel_run(&run.id, "user requested").unwrap();
 
-    let updated = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let updated = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(updated.status, WorkflowRunStatus::Cancelled);
@@ -1592,7 +1577,7 @@ fn test_cancel_run_idempotent_when_cancelling() {
         "cancel_run on a Cancelling run should be a no-op Ok(())"
     );
 
-    let updated = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let updated = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -1623,7 +1608,7 @@ fn test_cancel_run_marks_active_steps_failed() {
 
     mgr.cancel_run(&run.id, "abort").unwrap();
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     let running = steps.iter().find(|s| s.id == running_step).unwrap();
     assert_eq!(
         running.status,
@@ -1680,13 +1665,13 @@ fn test_cancel_run_kills_child_agent_subprocess() {
     mgr.cancel_run(&run.id, "Cancelled by user").unwrap();
 
     // Workflow run should be Cancelled.
-    let updated_run = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let updated_run = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(updated_run.status, WorkflowRunStatus::Cancelled);
 
     // Step should be Failed.
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     let step = steps.iter().find(|s| s.id == step_id).unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Failed);
 
@@ -1777,9 +1762,8 @@ fn test_cancel_run_not_found() {
 #[test]
 fn test_fail_workflow_run_returns_parent_id() {
     let conn = setup_db();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let agent_mgr = AgentManager::new(&conn);
-    let wf_mgr = WorkflowManager::new(&conn);
-
     let parent_run = agent_mgr
         .create_run(Some("w1"), "workflow parent", None)
         .unwrap();
@@ -1793,7 +1777,7 @@ fn test_fail_workflow_run_returns_parent_id() {
     assert_eq!(returned_parent_id, parent_run.id);
 
     // Workflow run should be marked as failed
-    let updated_wf = crate::workflow::get_workflow_run(wf_mgr.conn(), &wf_run.id)
+    let updated_wf = crate::workflow::get_workflow_run(&conn, &wf_run.id)
         .unwrap()
         .unwrap();
     assert_eq!(updated_wf.status, WorkflowRunStatus::Failed);
@@ -1898,7 +1882,7 @@ fn test_list_active_workflow_runs_for_repo_empty_slice_defaults_to_active() {
     mgr.update_workflow_status(&completed.id, WorkflowRunStatus::Completed, None, None)
         .unwrap();
 
-    let runs = crate::workflow::list_active_workflow_runs_for_repo(mgr.conn(), "r1", &[]).unwrap();
+    let runs = crate::workflow::list_active_workflow_runs_for_repo(&conn, "r1", &[]).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -1923,7 +1907,7 @@ fn test_list_active_workflow_runs_for_repo_explicit_status_filter() {
         .unwrap();
 
     let runs = crate::workflow::list_active_workflow_runs_for_repo(
-        mgr.conn(),
+        &conn,
         "r1",
         &[WorkflowRunStatus::Running],
     )
@@ -2033,7 +2017,7 @@ fn test_token_aggregates_excludes_non_terminal_runs() {
     mgr.update_workflow_status(&running.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let result = crate::workflow::get_workflow_token_aggregates(mgr.conn(), None).unwrap();
+    let result = crate::workflow::get_workflow_token_aggregates(&conn, None).unwrap();
     // pending and running are not terminal — they are excluded
     assert!(result.is_empty());
 }
@@ -2053,7 +2037,7 @@ fn test_token_aggregates_includes_completed_without_tokens() {
     )
     .unwrap();
 
-    let result = crate::workflow::get_workflow_token_aggregates(mgr.conn(), None).unwrap();
+    let result = crate::workflow::get_workflow_token_aggregates(&conn, None).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].workflow_name, "wf-a");
     assert_eq!(result[0].run_count, 1);
@@ -2077,7 +2061,7 @@ fn test_token_aggregates_includes_failed_runs() {
     mgr.update_workflow_status(&failed.id, WorkflowRunStatus::Failed, None, None)
         .unwrap();
 
-    let result = crate::workflow::get_workflow_token_aggregates(mgr.conn(), None).unwrap();
+    let result = crate::workflow::get_workflow_token_aggregates(&conn, None).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].run_count, 2);
     // token averages come from completed runs only
@@ -2226,7 +2210,7 @@ fn test_token_trend_excludes_non_completed_and_null_token_runs() {
         .unwrap();
 
     let result =
-        crate::workflow::get_workflow_token_trend(mgr.conn(), "trend-wf", TimeGranularity::Daily)
+        crate::workflow::get_workflow_token_trend(&conn, "trend-wf", TimeGranularity::Daily)
             .unwrap();
     assert!(result.is_empty());
 }
@@ -2487,7 +2471,7 @@ fn test_run_metrics_excludes_non_completed_runs() {
     // pending — should not appear
     create_named_worktree_run(&conn, "w1", "metrics-wf");
 
-    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(&conn, "metrics-wf", 30).unwrap();
     assert!(result.is_empty());
 }
 
@@ -2502,7 +2486,7 @@ fn test_run_metrics_returns_completed_run_data() {
     mgr.persist_workflow_metrics(&run.id, 100, 200, 0, 0, 1, 0.0, 5000, None)
         .unwrap();
 
-    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(&conn, "metrics-wf", 30).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].input_tokens, Some(100));
     assert_eq!(result[0].output_tokens, Some(200));
@@ -2528,7 +2512,7 @@ fn test_run_metrics_filters_by_workflow_name() {
     mgr.persist_workflow_metrics(&run_b.id, 999, 999, 0, 0, 1, 0.0, 9999, None)
         .unwrap();
 
-    let result = crate::workflow::get_run_metrics(mgr.conn(), "wf-a", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(&conn, "wf-a", 30).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].input_tokens, Some(100));
     assert!(!result[0].run_id.is_empty());
@@ -2555,7 +2539,7 @@ fn test_run_metrics_excludes_null_metric_runs() {
     )
     .unwrap();
 
-    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(&conn, "metrics-wf", 30).unwrap();
     assert_eq!(result.len(), 1, "all-null run should be excluded");
     assert_eq!(result[0].run_id, dur_run.id);
     assert_eq!(result[0].duration_ms, Some(3000));
@@ -2575,7 +2559,7 @@ fn test_run_metrics_excludes_zero_metric_runs() {
     mgr.persist_workflow_metrics(&zero_run.id, 0, 0, 0, 0, 0, 0.0, 0, None)
         .unwrap();
 
-    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(&conn, "metrics-wf", 30).unwrap();
     assert!(result.is_empty(), "all-zero metric run should be excluded");
 }
 
@@ -2591,7 +2575,7 @@ fn test_run_metrics_includes_partial_nonzero_run() {
     mgr.persist_workflow_metrics(&run.id, 0, 0, 0, 0, 1, 0.0, 2500, None)
         .unwrap();
 
-    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(&conn, "metrics-wf", 30).unwrap();
     assert_eq!(
         result.len(),
         1,
@@ -2613,7 +2597,7 @@ fn test_run_metrics_includes_worktree_and_repo_id() {
     mgr.persist_workflow_metrics(&run.id, 100, 200, 0, 0, 1, 0.0, 5000, None)
         .unwrap();
 
-    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(&conn, "metrics-wf", 30).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].worktree_id.as_deref(), Some("w1"));
     // repo_id is null when created via create_named_worktree_run (worktree context)
@@ -2647,12 +2631,9 @@ fn test_failure_rate_trend_excludes_non_terminal_runs() {
     mgr.update_workflow_status(&running.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let result = crate::workflow::get_workflow_failure_rate_trend(
-        mgr.conn(),
-        "trend-wf",
-        TimeGranularity::Daily,
-    )
-    .unwrap();
+    let result =
+        crate::workflow::get_workflow_failure_rate_trend(&conn, "trend-wf", TimeGranularity::Daily)
+            .unwrap();
     assert!(result.is_empty());
 }
 
@@ -2671,12 +2652,9 @@ fn test_failure_rate_trend_completed_only_period() {
     )
     .unwrap();
 
-    let result = crate::workflow::get_workflow_failure_rate_trend(
-        mgr.conn(),
-        "trend-wf",
-        TimeGranularity::Daily,
-    )
-    .unwrap();
+    let result =
+        crate::workflow::get_workflow_failure_rate_trend(&conn, "trend-wf", TimeGranularity::Daily)
+            .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].period, "2024-03-15");
     assert_eq!(result[0].total_runs, 1);
@@ -2709,12 +2687,9 @@ fn test_failure_rate_trend_mixed_completed_and_failed() {
     )
     .unwrap();
 
-    let result = crate::workflow::get_workflow_failure_rate_trend(
-        mgr.conn(),
-        "trend-wf",
-        TimeGranularity::Daily,
-    )
-    .unwrap();
+    let result =
+        crate::workflow::get_workflow_failure_rate_trend(&conn, "trend-wf", TimeGranularity::Daily)
+            .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].total_runs, 3);
     assert_eq!(result[0].failed_runs, 1);
@@ -2735,12 +2710,9 @@ fn test_failure_rate_trend_filters_by_workflow_name() {
     mgr.update_workflow_status(&run_b.id, WorkflowRunStatus::Completed, None, None)
         .unwrap();
 
-    let result = crate::workflow::get_workflow_failure_rate_trend(
-        mgr.conn(),
-        "wf-a",
-        TimeGranularity::Daily,
-    )
-    .unwrap();
+    let result =
+        crate::workflow::get_workflow_failure_rate_trend(&conn, "wf-a", TimeGranularity::Daily)
+            .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].failed_runs, 1);
     assert!((result[0].success_rate - 0.0).abs() < 0.01);
@@ -2764,7 +2736,7 @@ fn test_failure_rate_trend_weekly_granularity() {
     }
 
     let result = crate::workflow::get_workflow_failure_rate_trend(
-        mgr.conn(),
+        &conn,
         "trend-wf",
         TimeGranularity::Weekly,
     )
@@ -2817,7 +2789,7 @@ fn test_step_failure_heatmap_basic_failure_rate() {
     insert_step_with_status(&conn, "s1", &run1.id, "step-a", 0, "completed");
     insert_step_with_status(&conn, "s2", &run2.id, "step-a", 0, "failed");
 
-    let result = crate::workflow::get_step_failure_heatmap(mgr.conn(), "heat-wf", 10).unwrap();
+    let result = crate::workflow::get_step_failure_heatmap(&conn, "heat-wf", 10).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].step_name, "step-a");
     assert_eq!(result[0].total_executions, 2);
@@ -2840,7 +2812,7 @@ fn test_step_failure_heatmap_excludes_pending_and_skipped_steps() {
     // only this completed step should show up
     insert_step_with_status(&conn, "s-done", &run.id, "step-c", 2, "completed");
 
-    let result = crate::workflow::get_step_failure_heatmap(mgr.conn(), "heat-wf", 10).unwrap();
+    let result = crate::workflow::get_step_failure_heatmap(&conn, "heat-wf", 10).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].step_name, "step-c");
 }
@@ -2882,7 +2854,7 @@ fn test_step_failure_heatmap_limit_runs_respected() {
     insert_step_with_status(&conn, "s-r2", &run2.id, "step-a", 0, "completed");
     insert_step_with_status(&conn, "s-r3", &run3.id, "step-a", 0, "completed");
 
-    let result = crate::workflow::get_step_failure_heatmap(mgr.conn(), "heat-wf", 2).unwrap();
+    let result = crate::workflow::get_step_failure_heatmap(&conn, "heat-wf", 2).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].total_executions, 2);
     assert_eq!(result[0].failed_executions, 0);
@@ -2902,7 +2874,7 @@ fn test_step_failure_heatmap_ordered_by_failure_rate_desc() {
     insert_step_with_status(&conn, "s-ok", &run.id, "step-never-fails", 0, "completed");
     insert_step_with_status(&conn, "s-bad", &run.id, "step-always-fails", 1, "failed");
 
-    let result = crate::workflow::get_step_failure_heatmap(mgr.conn(), "heat-wf", 10).unwrap();
+    let result = crate::workflow::get_step_failure_heatmap(&conn, "heat-wf", 10).unwrap();
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].step_name, "step-always-fails");
     assert_eq!(result[1].step_name, "step-never-fails");
@@ -2946,7 +2918,7 @@ fn test_step_retry_analytics_no_retries() {
         .unwrap();
     insert_step_with_retries(&conn, "s1", &run.id, "step-a", 0, "completed", 0);
 
-    let result = crate::workflow::get_step_retry_analytics(mgr.conn(), "retry-wf", 10).unwrap();
+    let result = crate::workflow::get_step_retry_analytics(&conn, "retry-wf", 10).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].step_name, "step-a");
     assert_eq!(result[0].total_executions, 1);
@@ -2967,7 +2939,7 @@ fn test_step_retry_analytics_basic() {
         .unwrap();
     insert_step_with_retries(&conn, "s1", &run.id, "step-a", 0, "completed", 2);
 
-    let result = crate::workflow::get_step_retry_analytics(mgr.conn(), "retry-wf", 10).unwrap();
+    let result = crate::workflow::get_step_retry_analytics(&conn, "retry-wf", 10).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].total_executions, 1);
     assert_eq!(result[0].executions_with_retries, 1);
@@ -3003,7 +2975,7 @@ fn test_step_retry_analytics_mixed() {
         insert_step_with_retries(&conn, &format!("s{idx}"), &run.id, "step-a", 0, status, *rc);
     }
 
-    let result = crate::workflow::get_step_retry_analytics(mgr.conn(), "retry-wf", 10).unwrap();
+    let result = crate::workflow::get_step_retry_analytics(&conn, "retry-wf", 10).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].total_executions, 4);
     assert_eq!(result[0].executions_with_retries, 2);
@@ -3048,7 +3020,7 @@ fn test_step_retry_analytics_limit_runs() {
     insert_step_with_retries(&conn, "s-r2", &run2.id, "step-a", 0, "completed", 0);
     insert_step_with_retries(&conn, "s-r3", &run3.id, "step-a", 0, "completed", 0);
 
-    let result = crate::workflow::get_step_retry_analytics(mgr.conn(), "retry-wf", 2).unwrap();
+    let result = crate::workflow::get_step_retry_analytics(&conn, "retry-wf", 2).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].total_executions, 2);
     assert_eq!(result[0].executions_with_retries, 0);
@@ -3059,8 +3031,7 @@ fn test_step_retry_analytics_limit_runs() {
 fn test_get_workflow_percentiles_empty() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result =
-        crate::workflow::get_workflow_percentiles(mgr.conn(), "nonexistent-wf", 30).unwrap();
+    let result = crate::workflow::get_workflow_percentiles(&conn, "nonexistent-wf", 30).unwrap();
     assert!(result.is_none());
 }
 
@@ -3075,7 +3046,7 @@ fn test_get_workflow_percentiles_no_duration() {
     // persist_workflow_metrics with duration 0 — but do NOT set total_duration_ms directly
     // because persist_workflow_metrics sets it. Instead insert a run with NULL duration_ms
     // by completing without calling persist_workflow_metrics.
-    let result = crate::workflow::get_workflow_percentiles(mgr.conn(), "pct-wf", 30).unwrap();
+    let result = crate::workflow::get_workflow_percentiles(&conn, "pct-wf", 30).unwrap();
     assert!(result.is_none());
 }
 
@@ -3089,7 +3060,7 @@ fn test_get_workflow_percentiles_single_run() {
     mgr.persist_workflow_metrics(&run.id, 100, 200, 0, 0, 1, 0.05, 5000, None)
         .unwrap();
 
-    let result = crate::workflow::get_workflow_percentiles(mgr.conn(), "pct-wf", 30).unwrap();
+    let result = crate::workflow::get_workflow_percentiles(&conn, "pct-wf", 30).unwrap();
     assert!(result.is_some());
     let p = result.unwrap();
     assert_eq!(p.run_count, 1);
@@ -3123,7 +3094,7 @@ fn test_get_workflow_percentiles_multi_run() {
         .unwrap();
     }
 
-    let result = crate::workflow::get_workflow_percentiles(mgr.conn(), "pct-wf", 30).unwrap();
+    let result = crate::workflow::get_workflow_percentiles(&conn, "pct-wf", 30).unwrap();
     assert!(result.is_some());
     let p = result.unwrap();
     assert_eq!(p.run_count, 10);
@@ -3157,7 +3128,7 @@ fn test_get_workflow_percentiles_excludes_other_workflows() {
     mgr.persist_workflow_metrics(&run_b.id, 999, 999, 0, 0, 1, 9.99, 99000, None)
         .unwrap();
 
-    let result = crate::workflow::get_workflow_percentiles(mgr.conn(), "wf-a", 30).unwrap();
+    let result = crate::workflow::get_workflow_percentiles(&conn, "wf-a", 30).unwrap();
     assert!(result.is_some());
     let p = result.unwrap();
     assert_eq!(p.run_count, 1);
@@ -3213,7 +3184,7 @@ fn test_get_gate_analytics_single_approved() {
         Some("lgtm"),
     );
 
-    let rows = crate::workflow::get_gate_analytics(mgr.conn(), "gate-wf", 30).unwrap();
+    let rows = crate::workflow::get_gate_analytics(&conn, "gate-wf", 30).unwrap();
     assert_eq!(rows.len(), 1);
     let row = &rows[0];
     assert_eq!(row.step_name, "approve");
@@ -3275,7 +3246,7 @@ fn test_get_gate_analytics_approved_and_rejected() {
         None,
     );
 
-    let rows = crate::workflow::get_gate_analytics(mgr.conn(), "mixed-wf", 30).unwrap();
+    let rows = crate::workflow::get_gate_analytics(&conn, "mixed-wf", 30).unwrap();
     assert_eq!(rows.len(), 1);
     let row = &rows[0];
     assert_eq!(row.total_gate_hits, 3);
@@ -3316,7 +3287,7 @@ fn test_get_gate_analytics_multiple_step_names() {
         None,
     );
 
-    let rows = crate::workflow::get_gate_analytics(mgr.conn(), "multi-step-wf", 30).unwrap();
+    let rows = crate::workflow::get_gate_analytics(&conn, "multi-step-wf", 30).unwrap();
     assert_eq!(rows.len(), 2);
     let names: Vec<&str> = rows.iter().map(|r| r.step_name.as_str()).collect();
     assert!(names.contains(&"gate-a"), "gate-a missing from {names:?}");
@@ -3351,7 +3322,7 @@ fn test_get_gate_analytics_excludes_other_workflow() {
         None,
     );
 
-    let rows = crate::workflow::get_gate_analytics(mgr.conn(), "wf-a", 30).unwrap();
+    let rows = crate::workflow::get_gate_analytics(&conn, "wf-a", 30).unwrap();
     assert_eq!(rows.len(), 1, "must only return rows for wf-a");
 }
 
@@ -3369,7 +3340,7 @@ fn test_get_gate_analytics_excludes_waiting_steps() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let rows = crate::workflow::get_gate_analytics(mgr.conn(), "wait-wf", 30).unwrap();
+    let rows = crate::workflow::get_gate_analytics(&conn, "wait-wf", 30).unwrap();
     assert!(
         rows.is_empty(),
         "waiting steps must not appear in gate analytics"
@@ -3403,7 +3374,7 @@ fn test_get_all_pending_gates_returns_waiting_gate() {
     .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let rows = crate::workflow::get_all_pending_gates(mgr.conn()).unwrap();
+    let rows = crate::workflow::get_all_pending_gates(&conn).unwrap();
     assert_eq!(rows.len(), 1);
     let row = &rows[0];
     assert_eq!(row.step_id, step_id);
@@ -3434,7 +3405,7 @@ fn test_get_all_pending_gates_excludes_completed() {
     mgr.approve_gate(&step_id, "alice", None, None, None)
         .unwrap();
 
-    let rows = crate::workflow::get_all_pending_gates(mgr.conn()).unwrap();
+    let rows = crate::workflow::get_all_pending_gates(&conn).unwrap();
     assert!(rows.is_empty(), "completed gate must not appear");
 }
 
@@ -3450,7 +3421,7 @@ fn test_get_all_pending_gates_excludes_non_gate_steps() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let rows = crate::workflow::get_all_pending_gates(mgr.conn()).unwrap();
+    let rows = crate::workflow::get_all_pending_gates(&conn).unwrap();
     assert!(rows.is_empty(), "non-gate step must not appear");
 }
 
@@ -3476,7 +3447,7 @@ fn test_get_all_pending_gates_cross_workflow() {
         .unwrap();
     set_step_status(&mgr, &step_b, WorkflowStepStatus::Waiting);
 
-    let rows = crate::workflow::get_all_pending_gates(mgr.conn()).unwrap();
+    let rows = crate::workflow::get_all_pending_gates(&conn).unwrap();
     assert_eq!(rows.len(), 2);
     let wf_names: Vec<&str> = rows.iter().map(|r| r.workflow_name.as_str()).collect();
     assert!(wf_names.contains(&"wf-alpha"));
@@ -3504,7 +3475,7 @@ fn test_get_all_pending_gates_null_started_at() {
     )
     .unwrap();
 
-    let rows = crate::workflow::get_all_pending_gates(mgr.conn()).unwrap();
+    let rows = crate::workflow::get_all_pending_gates(&conn).unwrap();
     assert_eq!(rows.len(), 1);
     let row = &rows[0];
     assert_eq!(row.step_id, step_id);
@@ -3566,7 +3537,7 @@ fn test_regression_signals_excluded_below_min_recent_runs() {
         backdate_run(&conn, &run.id, 14);
     }
 
-    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 3, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(&conn, 3, 7, 30).unwrap();
     assert!(
         result.is_empty(),
         "workflow with only 2 recent runs should be excluded by HAVING min_recent_runs=3"
@@ -3582,7 +3553,7 @@ fn test_regression_signals_excluded_when_no_baseline() {
     let run = create_named_worktree_run(&conn, "w1", "no-baseline-wf");
     complete_with_duration_cost(&conn, &run.id, 1000, 0.01);
 
-    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(&conn, 1, 7, 30).unwrap();
     assert!(
         result.is_empty(),
         "workflow with no baseline runs should be excluded by INNER JOIN"
@@ -3610,7 +3581,7 @@ fn test_regression_signals_no_regression_when_stable() {
         complete_with_duration_cost(&conn, &run.id, d, c);
     }
 
-    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(&conn, 1, 7, 30).unwrap();
     assert_eq!(result.len(), 1);
     let s = &result[0];
     assert_eq!(s.workflow_name, "stable-wf");
@@ -3646,7 +3617,7 @@ fn test_regression_signals_duration_regressed() {
         complete_with_duration_cost(&conn, &run.id, d, 0.01);
     }
 
-    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(&conn, 1, 7, 30).unwrap();
     assert_eq!(result.len(), 1);
     let s = &result[0];
     assert!(
@@ -3675,7 +3646,7 @@ fn test_regression_signals_cost_regressed() {
         complete_with_duration_cost(&conn, &run.id, 1000, c);
     }
 
-    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(&conn, 1, 7, 30).unwrap();
     assert_eq!(result.len(), 1);
     let s = &result[0];
     assert!(!s.duration_regressed);
@@ -3706,7 +3677,7 @@ fn test_regression_signals_failure_rate_regressed() {
             .unwrap();
     }
 
-    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(&conn, 1, 7, 30).unwrap();
     assert_eq!(result.len(), 1);
     let s = &result[0];
     assert!(!s.duration_regressed);
@@ -3731,7 +3702,7 @@ fn test_regression_signals_excludes_runs_outside_both_windows() {
         backdate_run(&conn, &run.id, 40);
     }
 
-    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(&conn, 1, 7, 30).unwrap();
     assert!(
         result.is_empty(),
         "runs older than both windows (40 days > 7+30=37 days) should be excluded"
@@ -3765,7 +3736,7 @@ fn test_regression_signals_multiple_workflows_independent() {
         complete_with_duration_cost(&conn, &run.id, d, 0.01);
     }
 
-    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(&conn, 1, 7, 30).unwrap();
     assert_eq!(result.len(), 2, "both workflows should appear");
     // ORDER BY workflow_name → "wf-alpha" before "wf-beta".
     assert_eq!(result[0].workflow_name, "wf-alpha");
@@ -3943,8 +3914,7 @@ fn test_spike_baseline_insufficient_runs_returns_none() {
         let run = create_named_worktree_run(&conn, "w1", "spike-wf");
         complete_with_duration_cost(&conn, &run.id, 1000, 0.10);
     }
-    let result =
-        crate::workflow::get_workflow_spike_baseline(mgr.conn(), "spike-wf", 30, 5).unwrap();
+    let result = crate::workflow::get_workflow_spike_baseline(&conn, "spike-wf", 30, 5).unwrap();
     assert!(result.is_none(), "should return None with < 5 runs");
 }
 
@@ -3960,7 +3930,7 @@ fn test_spike_baseline_returns_correct_values() {
         let run = create_named_worktree_run(&conn, "w1", "spike-vals-wf");
         complete_with_duration_cost(&conn, &run.id, dur, cost_per_run);
     }
-    let baseline = crate::workflow::get_workflow_spike_baseline(mgr.conn(), "spike-vals-wf", 30, 5)
+    let baseline = crate::workflow::get_workflow_spike_baseline(&conn, "spike-vals-wf", 30, 5)
         .unwrap()
         .expect("should return Some with 5 runs");
     assert_eq!(baseline.run_count, 5);
@@ -4011,7 +3981,7 @@ fn test_spike_baseline_excludes_sub_workflow_runs() {
     }
 
     // Baseline should only see 6 root runs (5 + root_run).
-    let baseline = crate::workflow::get_workflow_spike_baseline(mgr.conn(), "excl-wf", 30, 5)
+    let baseline = crate::workflow::get_workflow_spike_baseline(&conn, "excl-wf", 30, 5)
         .unwrap()
         .expect("should return Some for 6 root runs");
     // avg_cost = (5 * 0.10 + 9.99) / 6 ≈ 1.748
@@ -4296,20 +4266,19 @@ fn test_find_step_by_name_and_iteration_returns_non_completed_step() {
     set_step_status(&mgr, &step_id, crate::workflow::WorkflowStepStatus::Running);
 
     // Should find the running step.
-    let found = crate::workflow::find_step_by_name_and_iteration(mgr.conn(), &run.id, step_name, 1)
-        .unwrap();
+    let found =
+        crate::workflow::find_step_by_name_and_iteration(&conn, &run.id, step_name, 1).unwrap();
     assert!(found.is_some(), "should find the non-completed step");
     assert_eq!(found.unwrap().id, step_id);
 
     // Non-matching iteration → None.
     let not_found =
-        crate::workflow::find_step_by_name_and_iteration(mgr.conn(), &run.id, step_name, 2)
-            .unwrap();
+        crate::workflow::find_step_by_name_and_iteration(&conn, &run.id, step_name, 2).unwrap();
     assert!(not_found.is_none(), "different iteration should not match");
 
     // Non-matching step_name → None.
     let not_found2 =
-        crate::workflow::find_step_by_name_and_iteration(mgr.conn(), &run.id, "foreach:other", 1)
+        crate::workflow::find_step_by_name_and_iteration(&conn, &run.id, "foreach:other", 1)
             .unwrap();
     assert!(not_found2.is_none(), "different step_name should not match");
 }
@@ -4337,8 +4306,8 @@ fn test_find_step_by_name_and_iteration_ignores_completed_steps() {
     );
 
     // Should NOT return a completed step.
-    let found = crate::workflow::find_step_by_name_and_iteration(mgr.conn(), &run.id, step_name, 0)
-        .unwrap();
+    let found =
+        crate::workflow::find_step_by_name_and_iteration(&conn, &run.id, step_name, 0).unwrap();
     assert!(
         found.is_none(),
         "completed step must not be returned — it would be skipped via should_skip"
@@ -4354,7 +4323,7 @@ fn test_set_dismissed_marks_run_dismissed() {
 
     mgr.set_dismissed(&run.id, true).unwrap();
 
-    let updated = crate::workflow::list_workflow_runs_for_repo(mgr.conn(), "r1", 50).unwrap();
+    let updated = crate::workflow::list_workflow_runs_for_repo(&conn, "r1", 50).unwrap();
     let found = updated.iter().find(|r| r.id == run.id).unwrap();
     assert!(
         found.dismissed,
@@ -4371,7 +4340,7 @@ fn test_set_dismissed_can_undismiss() {
     mgr.set_dismissed(&run.id, true).unwrap();
     mgr.set_dismissed(&run.id, false).unwrap();
 
-    let updated = crate::workflow::list_workflow_runs_for_repo(mgr.conn(), "r1", 50).unwrap();
+    let updated = crate::workflow::list_workflow_runs_for_repo(&conn, "r1", 50).unwrap();
     let found = updated.iter().find(|r| r.id == run.id).unwrap();
     assert!(
         !found.dismissed,
@@ -4457,7 +4426,7 @@ fn gate_kind_human_approval_roundtrips_through_db() {
     mgr.set_step_gate_info(&step_id, GateType::HumanApproval, None, "1h")
         .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -4501,7 +4470,7 @@ fn get_gate_approval_state_handles_unrecognised_status_without_panic() {
 #[test]
 fn test_workflow_title_stored_and_read_from_column() {
     let conn = setup_db();
-    let mgr = WorkflowManager::new(&conn);
+    let mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let parent_id = make_parent_id(&conn, "w1");
     let snapshot = r#"{"title":"My Workflow","steps":[]}"#;
 
@@ -4519,7 +4488,7 @@ fn test_workflow_title_stored_and_read_from_column() {
     assert_eq!(run.workflow_title.as_deref(), Some("My Workflow"));
 
     // Read back through the query layer to confirm the column is persisted.
-    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(fetched.workflow_title.as_deref(), Some("My Workflow"));
@@ -4530,7 +4499,7 @@ fn test_workflow_title_stored_and_read_from_column() {
         rusqlite::params![run.id],
     )
     .unwrap();
-    let fetched_no_snapshot = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let fetched_no_snapshot = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -4543,7 +4512,7 @@ fn test_workflow_title_stored_and_read_from_column() {
 #[test]
 fn test_workflow_title_null_snapshot_at_create_time() {
     let conn = setup_db();
-    let mgr = WorkflowManager::new(&conn);
+    let mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let parent_id = make_parent_id(&conn, "w1");
 
     let run = mgr
@@ -4561,7 +4530,7 @@ fn test_workflow_title_null_snapshot_at_create_time() {
         run.workflow_title, None,
         "NULL snapshot at write time must yield None workflow_title"
     );
-    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(fetched.workflow_title, None);
@@ -4570,7 +4539,7 @@ fn test_workflow_title_null_snapshot_at_create_time() {
 #[test]
 fn test_workflow_title_snapshot_without_title_field() {
     let conn = setup_db();
-    let mgr = WorkflowManager::new(&conn);
+    let mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let parent_id = make_parent_id(&conn, "w1");
     let snapshot = r#"{"steps":[],"description":"no title key here"}"#;
 
@@ -4589,7 +4558,7 @@ fn test_workflow_title_snapshot_without_title_field() {
         run.workflow_title, None,
         "snapshot without 'title' field must yield None workflow_title"
     );
-    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(fetched.workflow_title, None);
@@ -4598,7 +4567,7 @@ fn test_workflow_title_snapshot_without_title_field() {
 #[test]
 fn test_workflow_title_malformed_snapshot_json() {
     let conn = setup_db();
-    let mgr = WorkflowManager::new(&conn);
+    let mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let parent_id = make_parent_id(&conn, "w1");
     let snapshot = r#"{"title": "broken", "steps": [INVALID}"#;
 
@@ -4617,7 +4586,7 @@ fn test_workflow_title_malformed_snapshot_json() {
         run.workflow_title, None,
         "malformed JSON snapshot must yield None workflow_title (not panic)"
     );
-    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(fetched.workflow_title, None);

--- a/conductor-core/src/workflow/manager/tests.rs
+++ b/conductor-core/src/workflow/manager/tests.rs
@@ -73,9 +73,7 @@ fn test_list_workflow_runs_for_repo_includes_worktree_runs() {
     // Runs linked to a worktree (repo_id NULL) should appear when querying by repo.
     let conn = setup_db();
     let run = create_worktree_run(&conn, "w1");
-    let runs = WorkflowManager::new(&conn)
-        .list_workflow_runs_for_repo("r1", 50)
-        .unwrap();
+    let runs = crate::workflow::list_workflow_runs_for_repo(&conn, "r1", 50).unwrap();
     assert_eq!(runs.len(), 1);
     assert_eq!(runs[0].id, run.id);
 }
@@ -85,9 +83,7 @@ fn test_list_workflow_runs_for_repo_includes_repo_targeted_runs() {
     // Runs with repo_id set directly should also appear.
     let conn = setup_db();
     let run = create_repo_run(&conn, "r1");
-    let runs = WorkflowManager::new(&conn)
-        .list_workflow_runs_for_repo("r1", 50)
-        .unwrap();
+    let runs = crate::workflow::list_workflow_runs_for_repo(&conn, "r1", 50).unwrap();
     assert_eq!(runs.len(), 1);
     assert_eq!(runs[0].id, run.id);
 }
@@ -112,9 +108,7 @@ fn test_list_workflow_runs_for_repo_distinct_no_duplicates() {
             None,
         )
         .unwrap();
-    let runs = WorkflowManager::new(&conn)
-        .list_workflow_runs_for_repo("r1", 50)
-        .unwrap();
+    let runs = crate::workflow::list_workflow_runs_for_repo(&conn, "r1", 50).unwrap();
     assert_eq!(
         runs.len(),
         1,
@@ -130,13 +124,9 @@ fn test_list_workflow_runs_for_repo_cross_repo_filtering() {
     create_worktree_run(&conn, "w3"); // r2 via worktree
     create_repo_run(&conn, "r2"); // r2 directly
 
-    let r1_runs = WorkflowManager::new(&conn)
-        .list_workflow_runs_for_repo("r1", 50)
-        .unwrap();
+    let r1_runs = crate::workflow::list_workflow_runs_for_repo(&conn, "r1", 50).unwrap();
     assert_eq!(r1_runs.len(), 1);
-    let r2_runs = WorkflowManager::new(&conn)
-        .list_workflow_runs_for_repo("r2", 50)
-        .unwrap();
+    let r2_runs = crate::workflow::list_workflow_runs_for_repo(&conn, "r2", 50).unwrap();
     assert_eq!(r2_runs.len(), 2);
 }
 
@@ -147,9 +137,7 @@ fn test_list_workflow_runs_for_repo_limit() {
     for _ in 0..5 {
         create_worktree_run(&conn, "w1");
     }
-    let runs = WorkflowManager::new(&conn)
-        .list_workflow_runs_for_repo("r1", 3)
-        .unwrap();
+    let runs = crate::workflow::list_workflow_runs_for_repo(&conn, "r1", 3).unwrap();
     assert_eq!(runs.len(), 3);
 }
 
@@ -159,18 +147,14 @@ fn test_list_workflow_runs_for_repo_multiple_worktrees() {
     let conn = setup_db();
     create_worktree_run(&conn, "w1");
     create_worktree_run(&conn, "w2");
-    let runs = WorkflowManager::new(&conn)
-        .list_workflow_runs_for_repo("r1", 50)
-        .unwrap();
+    let runs = crate::workflow::list_workflow_runs_for_repo(&conn, "r1", 50).unwrap();
     assert_eq!(runs.len(), 2);
 }
 
 #[test]
 fn test_list_workflow_runs_for_repo_empty() {
     let conn = setup_db();
-    let runs = WorkflowManager::new(&conn)
-        .list_workflow_runs_for_repo("r1", 50)
-        .unwrap();
+    let runs = crate::workflow::list_workflow_runs_for_repo(&conn, "r1", 50).unwrap();
     assert!(runs.is_empty());
 }
 
@@ -191,7 +175,7 @@ fn test_list_active_workflow_runs_empty_slice_defaults_to_pending_running_waitin
     mgr.update_workflow_status(&completed_run.id, WorkflowRunStatus::Completed, None, None)
         .unwrap();
 
-    let runs = mgr.list_active_workflow_runs(&[]).unwrap();
+    let runs = crate::workflow::list_active_workflow_runs(mgr.conn(), &[]).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -220,9 +204,9 @@ fn test_list_active_workflow_runs_explicit_status_filter() {
         .unwrap();
 
     // Ask only for running — pending must not appear.
-    let runs = mgr
-        .list_active_workflow_runs(&[WorkflowRunStatus::Running])
-        .unwrap();
+    let runs =
+        crate::workflow::list_active_workflow_runs(mgr.conn(), &[WorkflowRunStatus::Running])
+            .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -243,9 +227,9 @@ fn test_list_active_workflow_runs_null_worktree_included() {
 
     let repo_run = create_repo_run(&conn, "r1"); // worktree_id IS NULL
 
-    let runs = mgr
-        .list_active_workflow_runs(&[WorkflowRunStatus::Pending])
-        .unwrap();
+    let runs =
+        crate::workflow::list_active_workflow_runs(mgr.conn(), &[WorkflowRunStatus::Pending])
+            .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -266,9 +250,9 @@ fn test_list_active_workflow_runs_inactive_worktree_excluded() {
     conn.execute("UPDATE worktrees SET status = 'merged' WHERE id = 'w1'", [])
         .unwrap();
 
-    let runs = mgr
-        .list_active_workflow_runs(&[WorkflowRunStatus::Pending])
-        .unwrap();
+    let runs =
+        crate::workflow::list_active_workflow_runs(mgr.conn(), &[WorkflowRunStatus::Pending])
+            .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -282,9 +266,7 @@ fn test_list_active_workflow_runs_inactive_worktree_excluded() {
 #[test]
 fn test_list_all_waiting_gate_steps_empty() {
     let conn = setup_db();
-    let steps = WorkflowManager::new(&conn)
-        .list_all_waiting_gate_steps()
-        .unwrap();
+    let steps = crate::workflow::list_all_waiting_gate_steps(&conn).unwrap();
     assert!(steps.is_empty(), "no gate steps should exist yet");
 }
 
@@ -307,7 +289,7 @@ fn test_list_all_waiting_gate_steps_returns_waiting_gate_steps() {
     // Mark step as waiting so it appears in the query.
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = mgr.list_all_waiting_gate_steps().unwrap();
+    let steps = crate::workflow::list_all_waiting_gate_steps(mgr.conn()).unwrap();
     assert_eq!(steps.len(), 1, "one waiting gate step should be returned");
     let (step, workflow_name, target_label) = &steps[0];
     assert_eq!(step.id, step_id);
@@ -328,7 +310,7 @@ fn test_list_all_waiting_gate_steps_excludes_non_gate_steps() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = mgr.list_all_waiting_gate_steps().unwrap();
+    let steps = crate::workflow::list_all_waiting_gate_steps(mgr.conn()).unwrap();
     assert!(
         steps.is_empty(),
         "steps without gate_type must not be returned"
@@ -349,9 +331,11 @@ fn test_list_active_workflow_runs_multiple_statuses_dynamic_placeholders() {
     mgr.update_workflow_status(&failed_run.id, WorkflowRunStatus::Failed, None, None)
         .unwrap();
 
-    let runs = mgr
-        .list_active_workflow_runs(&[WorkflowRunStatus::Pending, WorkflowRunStatus::Running])
-        .unwrap();
+    let runs = crate::workflow::list_active_workflow_runs(
+        mgr.conn(),
+        &[WorkflowRunStatus::Pending, WorkflowRunStatus::Running],
+    )
+    .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(ids.contains(&pending_run.id.as_str()));
@@ -393,9 +377,11 @@ fn test_get_active_steps_for_runs_groups_by_run_id() {
         .unwrap();
     set_step_status(&mgr, &step2_active, WorkflowStepStatus::Running);
 
-    let result = mgr
-        .get_active_steps_for_runs(&[run1.id.as_str(), run2.id.as_str()])
-        .unwrap();
+    let result = crate::workflow::get_active_steps_for_runs(
+        mgr.conn(),
+        &[run1.id.as_str(), run2.id.as_str()],
+    )
+    .unwrap();
 
     // Each run should be present with exactly its active step.
     assert_eq!(result.len(), 2, "expected entries for both runs");
@@ -429,7 +415,8 @@ fn test_get_active_steps_for_runs_includes_waiting_steps() {
         .insert_step(&run.id, "step-b", "actor", false, 1, 0)
         .unwrap();
 
-    let result = mgr.get_active_steps_for_runs(&[run.id.as_str()]).unwrap();
+    let result =
+        crate::workflow::get_active_steps_for_runs(mgr.conn(), &[run.id.as_str()]).unwrap();
 
     // Only the Waiting step should appear.
     assert_eq!(result.len(), 1, "expected one run entry");
@@ -445,7 +432,7 @@ fn test_get_active_steps_for_runs_includes_waiting_steps() {
 fn test_get_active_steps_for_runs_empty_slice_returns_empty_map() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = mgr.get_active_steps_for_runs(&[]).unwrap();
+    let result = crate::workflow::get_active_steps_for_runs(mgr.conn(), &[]).unwrap();
     assert!(result.is_empty(), "empty run_ids must yield an empty map");
 }
 
@@ -453,7 +440,7 @@ fn test_get_active_steps_for_runs_empty_slice_returns_empty_map() {
 fn test_get_steps_for_runs_empty_slice_returns_empty_map() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = mgr.get_steps_for_runs(&[]).unwrap();
+    let result = crate::workflow::get_steps_for_runs(mgr.conn(), &[]).unwrap();
     assert!(result.is_empty(), "empty run_ids must yield an empty map");
 }
 
@@ -461,7 +448,7 @@ fn test_get_steps_for_runs_empty_slice_returns_empty_map() {
 fn test_get_workflow_run_ids_for_agent_runs_empty_slice_returns_empty_map() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = mgr.get_workflow_run_ids_for_agent_runs(&[]).unwrap();
+    let result = crate::workflow::get_workflow_run_ids_for_agent_runs(mgr.conn(), &[]).unwrap();
     assert!(
         result.is_empty(),
         "empty agent_run_ids must yield an empty map"
@@ -472,7 +459,7 @@ fn test_get_workflow_run_ids_for_agent_runs_empty_slice_returns_empty_map() {
 fn test_get_step_summaries_for_runs_empty_slice_returns_empty_map() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = mgr.get_step_summaries_for_runs(&[]).unwrap();
+    let result = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[]).unwrap();
     assert!(result.is_empty(), "empty run_ids must yield an empty map");
 }
 
@@ -501,9 +488,9 @@ fn test_get_steps_for_runs_returns_all_steps_regardless_of_status() {
         .insert_step(&run2.id, "step-c", "actor", false, 0, 0)
         .unwrap();
 
-    let result = mgr
-        .get_steps_for_runs(&[run1.id.as_str(), run2.id.as_str()])
-        .unwrap();
+    let result =
+        crate::workflow::get_steps_for_runs(mgr.conn(), &[run1.id.as_str(), run2.id.as_str()])
+            .unwrap();
 
     assert_eq!(result.len(), 2, "expected entries for both runs");
 
@@ -530,9 +517,12 @@ fn test_list_workflow_runs_filtered_with_status() {
     mgr.update_workflow_status(&running_run.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let runs = mgr
-        .list_workflow_runs_filtered("w1", Some(WorkflowRunStatus::Running))
-        .unwrap();
+    let runs = crate::workflow::list_workflow_runs_filtered(
+        mgr.conn(),
+        "w1",
+        Some(WorkflowRunStatus::Running),
+    )
+    .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -555,7 +545,7 @@ fn test_list_workflow_runs_filtered_none_returns_all() {
     mgr.update_workflow_status(&running_run.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let runs = mgr.list_workflow_runs_filtered("w1", None).unwrap();
+    let runs = crate::workflow::list_workflow_runs_filtered(mgr.conn(), "w1", None).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -581,9 +571,14 @@ fn test_list_workflow_runs_by_repo_id_filtered_with_status() {
     mgr.update_workflow_status(&running_run.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let runs = mgr
-        .list_workflow_runs_by_repo_id_filtered("r1", 50, 0, Some(WorkflowRunStatus::Running))
-        .unwrap();
+    let runs = crate::workflow::list_workflow_runs_by_repo_id_filtered(
+        mgr.conn(),
+        "r1",
+        50,
+        0,
+        Some(WorkflowRunStatus::Running),
+    )
+    .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -606,9 +601,9 @@ fn test_list_workflow_runs_by_repo_id_filtered_none_returns_all() {
     mgr.update_workflow_status(&running_run.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let runs = mgr
-        .list_workflow_runs_by_repo_id_filtered("r1", 50, 0, None)
-        .unwrap();
+    let runs =
+        crate::workflow::list_workflow_runs_by_repo_id_filtered(mgr.conn(), "r1", 50, 0, None)
+            .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -636,9 +631,14 @@ fn test_list_workflow_runs_filtered_paginated_with_status() {
         .unwrap();
 
     // First page: limit=1, offset=0 — exactly one pending run.
-    let page1 = mgr
-        .list_workflow_runs_filtered_paginated("w1", Some(WorkflowRunStatus::Pending), 1, 0)
-        .unwrap();
+    let page1 = crate::workflow::list_workflow_runs_filtered_paginated(
+        mgr.conn(),
+        "w1",
+        Some(WorkflowRunStatus::Pending),
+        1,
+        0,
+    )
+    .unwrap();
     assert_eq!(
         page1.len(),
         1,
@@ -646,9 +646,14 @@ fn test_list_workflow_runs_filtered_paginated_with_status() {
     );
 
     // Second page: limit=1, offset=1 — the other pending run.
-    let page2 = mgr
-        .list_workflow_runs_filtered_paginated("w1", Some(WorkflowRunStatus::Pending), 1, 1)
-        .unwrap();
+    let page2 = crate::workflow::list_workflow_runs_filtered_paginated(
+        mgr.conn(),
+        "w1",
+        Some(WorkflowRunStatus::Pending),
+        1,
+        1,
+    )
+    .unwrap();
     assert_eq!(
         page2.len(),
         1,
@@ -672,14 +677,14 @@ fn test_list_workflow_runs_filtered_paginated_none_delegates() {
     }
 
     // None — no status filter, pagination alone controls results.
-    let page1 = mgr
-        .list_workflow_runs_filtered_paginated("w1", None, 2, 0)
-        .unwrap();
+    let page1 =
+        crate::workflow::list_workflow_runs_filtered_paginated(mgr.conn(), "w1", None, 2, 0)
+            .unwrap();
     assert_eq!(page1.len(), 2, "limit=2 must return exactly 2 runs");
 
-    let page2 = mgr
-        .list_workflow_runs_filtered_paginated("w1", None, 2, 2)
-        .unwrap();
+    let page2 =
+        crate::workflow::list_workflow_runs_filtered_paginated(mgr.conn(), "w1", None, 2, 2)
+            .unwrap();
     assert_eq!(
         page2.len(),
         1,
@@ -699,9 +704,13 @@ fn test_list_all_workflow_runs_filtered_paginated_with_status() {
     mgr.update_workflow_status(&running_run.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let runs = mgr
-        .list_all_workflow_runs_filtered_paginated(Some(WorkflowRunStatus::Running), 50, 0)
-        .unwrap();
+    let runs = crate::workflow::list_all_workflow_runs_filtered_paginated(
+        mgr.conn(),
+        Some(WorkflowRunStatus::Running),
+        50,
+        0,
+    )
+    .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -724,8 +733,7 @@ fn test_list_all_workflow_runs_filtered_paginated_none() {
     mgr.update_workflow_status(&run2.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let runs = mgr
-        .list_all_workflow_runs_filtered_paginated(None, 50, 0)
+    let runs = crate::workflow::list_all_workflow_runs_filtered_paginated(mgr.conn(), None, 50, 0)
         .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
@@ -743,8 +751,7 @@ fn test_list_all_workflow_runs_filtered_paginated_excludes_inactive_worktrees() 
     conn.execute("UPDATE worktrees SET status = 'merged' WHERE id = 'w2'", [])
         .unwrap();
 
-    let runs = mgr
-        .list_all_workflow_runs_filtered_paginated(None, 50, 0)
+    let runs = crate::workflow::list_all_workflow_runs_filtered_paginated(mgr.conn(), None, 50, 0)
         .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
@@ -769,7 +776,7 @@ fn test_list_all_workflow_runs_respects_limit() {
         create_worktree_run(&conn, "w1");
     }
 
-    let runs = mgr.list_all_workflow_runs(3).unwrap();
+    let runs = crate::workflow::list_all_workflow_runs(mgr.conn(), 3).unwrap();
     assert_eq!(runs.len(), 3, "limit=3 must return exactly 3 runs");
 }
 
@@ -783,7 +790,7 @@ fn test_list_all_workflow_runs_excludes_inactive_worktrees() {
     conn.execute("UPDATE worktrees SET status = 'merged' WHERE id = 'w2'", [])
         .unwrap();
 
-    let runs = mgr.list_all_workflow_runs(50).unwrap();
+    let runs = crate::workflow::list_all_workflow_runs(mgr.conn(), 50).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -813,7 +820,7 @@ fn test_list_all_waiting_gate_steps_excludes_approved_gate_steps() {
         rusqlite::named_params! { ":id": step_id },
     ).unwrap();
 
-    let steps = mgr.list_all_waiting_gate_steps().unwrap();
+    let steps = crate::workflow::list_all_waiting_gate_steps(mgr.conn()).unwrap();
     assert!(
         steps.is_empty(),
         "approved (completed) gate steps must not be returned"
@@ -847,7 +854,7 @@ fn test_list_all_waiting_gate_steps_includes_target_label() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = mgr.list_all_waiting_gate_steps().unwrap();
+    let steps = crate::workflow::list_all_waiting_gate_steps(mgr.conn()).unwrap();
     assert_eq!(steps.len(), 1);
     let (step, workflow_name, target_label) = &steps[0];
     assert_eq!(step.id, step_id);
@@ -864,9 +871,7 @@ fn test_list_all_waiting_gate_steps_includes_target_label() {
 #[test]
 fn test_list_waiting_gate_steps_for_repo_empty() {
     let conn = setup_db();
-    let steps = WorkflowManager::new(&conn)
-        .list_waiting_gate_steps_for_repo("r1")
-        .unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(&conn, "r1").unwrap();
     assert!(steps.is_empty(), "no gate steps should exist yet");
 }
 
@@ -890,7 +895,7 @@ fn test_list_waiting_gate_steps_for_repo_via_worktree() {
     .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = mgr.list_waiting_gate_steps_for_repo("r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
     assert_eq!(
         steps.len(),
         1,
@@ -926,7 +931,7 @@ fn test_list_waiting_gate_steps_for_repo_via_direct_repo_id() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = mgr.list_waiting_gate_steps_for_repo("r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
     assert_eq!(
         steps.len(),
         1,
@@ -970,7 +975,7 @@ fn test_list_waiting_gate_steps_for_repo_ticket_ref_populated() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = mgr.list_waiting_gate_steps_for_repo("r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
     assert_eq!(steps.len(), 1);
     assert_eq!(
         steps[0].ticket_ref.as_deref(),
@@ -994,10 +999,10 @@ fn test_list_waiting_gate_steps_for_repo_excludes_other_repo() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps_r1 = mgr.list_waiting_gate_steps_for_repo("r1").unwrap();
+    let steps_r1 = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
     assert!(steps_r1.is_empty(), "r1 must not see r2's gate steps");
 
-    let steps_r2 = mgr.list_waiting_gate_steps_for_repo("r2").unwrap();
+    let steps_r2 = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r2").unwrap();
     assert_eq!(steps_r2.len(), 1, "r2 should return its own gate step");
     assert_eq!(steps_r2[0].step.id, step_id);
 }
@@ -1014,7 +1019,7 @@ fn test_list_waiting_gate_steps_for_repo_excludes_non_gate_steps() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let steps = mgr.list_waiting_gate_steps_for_repo("r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
     assert!(steps.is_empty(), "non-gate steps must not be returned");
 }
 
@@ -1034,7 +1039,7 @@ fn test_list_waiting_gate_steps_for_repo_excludes_completed_gate_steps() {
         rusqlite::named_params! { ":id": step_id },
     ).unwrap();
 
-    let steps = mgr.list_waiting_gate_steps_for_repo("r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
     assert!(
         steps.is_empty(),
         "completed gate steps must not be returned"
@@ -1058,7 +1063,7 @@ fn test_list_waiting_gate_steps_for_repo_excludes_cancelled_run() {
     )
     .unwrap();
 
-    let steps = mgr.list_waiting_gate_steps_for_repo("r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
     assert!(
         steps.is_empty(),
         "waiting gate steps from cancelled runs must not be returned"
@@ -1082,7 +1087,7 @@ fn test_list_waiting_gate_steps_for_repo_excludes_failed_run() {
     )
     .unwrap();
 
-    let steps = mgr.list_waiting_gate_steps_for_repo("r1").unwrap();
+    let steps = crate::workflow::list_waiting_gate_steps_for_repo(mgr.conn(), "r1").unwrap();
     assert!(
         steps.is_empty(),
         "waiting gate steps from failed runs must not be returned"
@@ -1096,17 +1101,23 @@ fn test_set_workflow_run_iteration() {
     let mgr = WorkflowManager::new(&conn);
 
     // Default iteration should be 0.
-    let fetched = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(fetched.iteration, 0);
 
     // Set iteration to 3.
     mgr.set_workflow_run_iteration(&run.id, 3).unwrap();
-    let fetched = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(fetched.iteration, 3);
 
     // Set iteration to 0 again.
     mgr.set_workflow_run_iteration(&run.id, 0).unwrap();
-    let fetched = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(fetched.iteration, 0);
 }
 
@@ -1254,7 +1265,7 @@ fn test_update_step_preserves_child_run_id_when_none_passed() {
     )
     .unwrap();
 
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     let step = steps.iter().find(|s| s.id == step_id).unwrap();
     assert_eq!(
         step.child_run_id.as_deref(),
@@ -1280,7 +1291,8 @@ fn test_get_step_summaries_for_runs_single_level_running_step() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Running);
 
-    let summaries = mgr.get_step_summaries_for_runs(&[run.id.as_str()]).unwrap();
+    let summaries =
+        crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[run.id.as_str()]).unwrap();
     assert_eq!(summaries.len(), 1);
     let summary = summaries.get(&run.id).expect("root run missing");
     assert_eq!(summary.step_name, "build");
@@ -1328,9 +1340,8 @@ fn test_get_step_summaries_for_runs_child_chain_traversal() {
         .unwrap();
     set_step_status(&mgr, &child_step_id, WorkflowStepStatus::Running);
 
-    let summaries = mgr
-        .get_step_summaries_for_runs(&[root.id.as_str()])
-        .unwrap();
+    let summaries =
+        crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[root.id.as_str()]).unwrap();
     assert_eq!(summaries.len(), 1);
     let summary = summaries.get(&root.id).expect("root run missing");
     assert_eq!(summary.step_name, "deploy");
@@ -1392,9 +1403,8 @@ fn test_get_step_summaries_for_runs_deep_chain() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Running);
 
-    let summaries = mgr
-        .get_step_summaries_for_runs(&[root.id.as_str()])
-        .unwrap();
+    let summaries =
+        crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[root.id.as_str()]).unwrap();
     let summary = summaries.get(&root.id).expect("root run missing");
     assert_eq!(summary.step_name, "test");
     assert_eq!(
@@ -1419,7 +1429,8 @@ fn test_get_step_summaries_for_runs_no_running_step_omitted() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Completed);
 
-    let summaries = mgr.get_step_summaries_for_runs(&[run.id.as_str()]).unwrap();
+    let summaries =
+        crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[run.id.as_str()]).unwrap();
     assert!(
         summaries.is_empty(),
         "run with no running step should be absent from summaries"
@@ -1449,9 +1460,11 @@ fn test_get_step_summaries_for_runs_multiple_roots() {
         .unwrap();
     set_step_status(&mgr, &step2_id, WorkflowStepStatus::Running);
 
-    let summaries = mgr
-        .get_step_summaries_for_runs(&[run1.id.as_str(), run2.id.as_str()])
-        .unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(
+        mgr.conn(),
+        &[run1.id.as_str(), run2.id.as_str()],
+    )
+    .unwrap();
 
     assert_eq!(summaries.len(), 2);
     let s1 = summaries.get(&run1.id).expect("run1 missing");
@@ -1506,9 +1519,11 @@ fn test_get_step_summaries_for_runs_multiple_roots_with_chains() {
         .unwrap();
     set_step_status(&mgr, &step_b_id, WorkflowStepStatus::Running);
 
-    let summaries = mgr
-        .get_step_summaries_for_runs(&[root_a.id.as_str(), root_b.id.as_str()])
-        .unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(
+        mgr.conn(),
+        &[root_a.id.as_str(), root_b.id.as_str()],
+    )
+    .unwrap();
 
     assert_eq!(summaries.len(), 2);
 
@@ -1541,7 +1556,9 @@ fn test_cancel_run_marks_run_cancelled() {
 
     mgr.cancel_run(&run.id, "user requested").unwrap();
 
-    let updated = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let updated = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(updated.status, WorkflowRunStatus::Cancelled);
     assert_eq!(updated.result_summary.as_deref(), Some("user requested"));
 }
@@ -1575,7 +1592,9 @@ fn test_cancel_run_idempotent_when_cancelling() {
         "cancel_run on a Cancelling run should be a no-op Ok(())"
     );
 
-    let updated = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let updated = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         updated.status,
         WorkflowRunStatus::Cancelling,
@@ -1604,7 +1623,7 @@ fn test_cancel_run_marks_active_steps_failed() {
 
     mgr.cancel_run(&run.id, "abort").unwrap();
 
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     let running = steps.iter().find(|s| s.id == running_step).unwrap();
     assert_eq!(
         running.status,
@@ -1661,11 +1680,13 @@ fn test_cancel_run_kills_child_agent_subprocess() {
     mgr.cancel_run(&run.id, "Cancelled by user").unwrap();
 
     // Workflow run should be Cancelled.
-    let updated_run = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let updated_run = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(updated_run.status, WorkflowRunStatus::Cancelled);
 
     // Step should be Failed.
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     let step = steps.iter().find(|s| s.id == step_id).unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Failed);
 
@@ -1772,7 +1793,9 @@ fn test_fail_workflow_run_returns_parent_id() {
     assert_eq!(returned_parent_id, parent_run.id);
 
     // Workflow run should be marked as failed
-    let updated_wf = wf_mgr.get_workflow_run(&wf_run.id).unwrap().unwrap();
+    let updated_wf = crate::workflow::get_workflow_run(wf_mgr.conn(), &wf_run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(updated_wf.status, WorkflowRunStatus::Failed);
     assert_eq!(updated_wf.result_summary.as_deref(), Some("engine panic"));
 
@@ -1801,9 +1824,12 @@ fn test_list_active_workflow_runs_for_repo_includes_worktree_runs() {
     // Runs linked to a worktree whose repo_id = r1 must appear.
     let conn = setup_db();
     let run = create_worktree_run(&conn, "w1"); // w1 belongs to r1
-    let runs = WorkflowManager::new(&conn)
-        .list_active_workflow_runs_for_repo("r1", &[WorkflowRunStatus::Pending])
-        .unwrap();
+    let runs = crate::workflow::list_active_workflow_runs_for_repo(
+        &conn,
+        "r1",
+        &[WorkflowRunStatus::Pending],
+    )
+    .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
     assert!(ids.contains(&run.id.as_str()), "worktree run must appear");
 }
@@ -1813,9 +1839,12 @@ fn test_list_active_workflow_runs_for_repo_includes_repo_targeted_runs() {
     // Runs with repo_id = r1 set directly must appear.
     let conn = setup_db();
     let run = create_repo_run(&conn, "r1");
-    let runs = WorkflowManager::new(&conn)
-        .list_active_workflow_runs_for_repo("r1", &[WorkflowRunStatus::Pending])
-        .unwrap();
+    let runs = crate::workflow::list_active_workflow_runs_for_repo(
+        &conn,
+        "r1",
+        &[WorkflowRunStatus::Pending],
+    )
+    .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
     assert!(
         ids.contains(&run.id.as_str()),
@@ -1829,9 +1858,12 @@ fn test_list_active_workflow_runs_for_repo_excludes_other_repo() {
     let conn = setup_db();
     let _r2_wt_run = create_worktree_run(&conn, "w3"); // w3 belongs to r2
     let _r2_repo_run = create_repo_run(&conn, "r2");
-    let runs = WorkflowManager::new(&conn)
-        .list_active_workflow_runs_for_repo("r1", &[WorkflowRunStatus::Pending])
-        .unwrap();
+    let runs = crate::workflow::list_active_workflow_runs_for_repo(
+        &conn,
+        "r1",
+        &[WorkflowRunStatus::Pending],
+    )
+    .unwrap();
     assert!(runs.is_empty(), "r1 query must not return r2 runs");
 }
 
@@ -1842,9 +1874,12 @@ fn test_list_active_workflow_runs_for_repo_inactive_worktree_excluded() {
     let run = create_worktree_run(&conn, "w1");
     conn.execute("UPDATE worktrees SET status = 'merged' WHERE id = 'w1'", [])
         .unwrap();
-    let runs = WorkflowManager::new(&conn)
-        .list_active_workflow_runs_for_repo("r1", &[WorkflowRunStatus::Pending])
-        .unwrap();
+    let runs = crate::workflow::list_active_workflow_runs_for_repo(
+        &conn,
+        "r1",
+        &[WorkflowRunStatus::Pending],
+    )
+    .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
     assert!(
         !ids.contains(&run.id.as_str()),
@@ -1863,7 +1898,7 @@ fn test_list_active_workflow_runs_for_repo_empty_slice_defaults_to_active() {
     mgr.update_workflow_status(&completed.id, WorkflowRunStatus::Completed, None, None)
         .unwrap();
 
-    let runs = mgr.list_active_workflow_runs_for_repo("r1", &[]).unwrap();
+    let runs = crate::workflow::list_active_workflow_runs_for_repo(mgr.conn(), "r1", &[]).unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -1887,9 +1922,12 @@ fn test_list_active_workflow_runs_for_repo_explicit_status_filter() {
     mgr.update_workflow_status(&running.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let runs = mgr
-        .list_active_workflow_runs_for_repo("r1", &[WorkflowRunStatus::Running])
-        .unwrap();
+    let runs = crate::workflow::list_active_workflow_runs_for_repo(
+        mgr.conn(),
+        "r1",
+        &[WorkflowRunStatus::Running],
+    )
+    .unwrap();
     let ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
 
     assert!(
@@ -1921,9 +1959,12 @@ fn test_list_active_workflow_runs_for_repo_distinct_no_duplicates() {
             None,
         )
         .unwrap();
-    let runs = WorkflowManager::new(&conn)
-        .list_active_workflow_runs_for_repo("r1", &[WorkflowRunStatus::Pending])
-        .unwrap();
+    let runs = crate::workflow::list_active_workflow_runs_for_repo(
+        &conn,
+        "r1",
+        &[WorkflowRunStatus::Pending],
+    )
+    .unwrap();
     assert_eq!(
         runs.len(),
         1,
@@ -1975,9 +2016,7 @@ fn complete_with_metrics(conn: &rusqlite::Connection, run_id: &str, input: i64, 
 #[test]
 fn test_token_aggregates_empty_when_no_completed_runs() {
     let conn = setup_db();
-    let result = WorkflowManager::new(&conn)
-        .get_workflow_token_aggregates(None)
-        .unwrap();
+    let result = crate::workflow::get_workflow_token_aggregates(&conn, None).unwrap();
     assert!(result.is_empty());
 }
 
@@ -1994,7 +2033,7 @@ fn test_token_aggregates_excludes_non_terminal_runs() {
     mgr.update_workflow_status(&running.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let result = mgr.get_workflow_token_aggregates(None).unwrap();
+    let result = crate::workflow::get_workflow_token_aggregates(mgr.conn(), None).unwrap();
     // pending and running are not terminal — they are excluded
     assert!(result.is_empty());
 }
@@ -2014,7 +2053,7 @@ fn test_token_aggregates_includes_completed_without_tokens() {
     )
     .unwrap();
 
-    let result = mgr.get_workflow_token_aggregates(None).unwrap();
+    let result = crate::workflow::get_workflow_token_aggregates(mgr.conn(), None).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].workflow_name, "wf-a");
     assert_eq!(result[0].run_count, 1);
@@ -2038,7 +2077,7 @@ fn test_token_aggregates_includes_failed_runs() {
     mgr.update_workflow_status(&failed.id, WorkflowRunStatus::Failed, None, None)
         .unwrap();
 
-    let result = mgr.get_workflow_token_aggregates(None).unwrap();
+    let result = crate::workflow::get_workflow_token_aggregates(mgr.conn(), None).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].run_count, 2);
     // token averages come from completed runs only
@@ -2070,9 +2109,7 @@ fn test_token_aggregates_groups_and_averages() {
         50,
     );
 
-    let result = WorkflowManager::new(&conn)
-        .get_workflow_token_aggregates(None)
-        .unwrap();
+    let result = crate::workflow::get_workflow_token_aggregates(&conn, None).unwrap();
 
     assert_eq!(result.len(), 2);
     // wf-a has higher avg total (200+300=500 avg), wf-b has 100 avg — ordered desc
@@ -2105,9 +2142,7 @@ fn test_token_aggregates_repo_filter_some() {
         999,
     );
 
-    let result = WorkflowManager::new(&conn)
-        .get_workflow_token_aggregates(Some("r1"))
-        .unwrap();
+    let result = crate::workflow::get_workflow_token_aggregates(&conn, Some("r1")).unwrap();
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].workflow_name, "wf-a");
@@ -2131,9 +2166,7 @@ fn test_token_aggregates_repo_filter_none_includes_all() {
         50,
     );
 
-    let result = WorkflowManager::new(&conn)
-        .get_workflow_token_aggregates(None)
-        .unwrap();
+    let result = crate::workflow::get_workflow_token_aggregates(&conn, None).unwrap();
 
     assert_eq!(result.len(), 2);
 }
@@ -2161,9 +2194,7 @@ fn test_token_aggregates_ordered_by_total_desc() {
         100,
     );
 
-    let result = WorkflowManager::new(&conn)
-        .get_workflow_token_aggregates(None)
-        .unwrap();
+    let result = crate::workflow::get_workflow_token_aggregates(&conn, None).unwrap();
 
     assert_eq!(result[0].workflow_name, "high-wf");
     assert_eq!(result[1].workflow_name, "mid-wf");
@@ -2175,9 +2206,9 @@ fn test_token_aggregates_ordered_by_total_desc() {
 #[test]
 fn test_token_trend_empty_for_unknown_workflow() {
     let conn = setup_db();
-    let result = WorkflowManager::new(&conn)
-        .get_workflow_token_trend("no-such-wf", TimeGranularity::Daily)
-        .unwrap();
+    let result =
+        crate::workflow::get_workflow_token_trend(&conn, "no-such-wf", TimeGranularity::Daily)
+            .unwrap();
     assert!(result.is_empty());
 }
 
@@ -2194,9 +2225,9 @@ fn test_token_trend_excludes_non_completed_and_null_token_runs() {
     mgr.update_workflow_status(&no_tokens.id, WorkflowRunStatus::Completed, None, None)
         .unwrap();
 
-    let result = mgr
-        .get_workflow_token_trend("trend-wf", TimeGranularity::Daily)
-        .unwrap();
+    let result =
+        crate::workflow::get_workflow_token_trend(mgr.conn(), "trend-wf", TimeGranularity::Daily)
+            .unwrap();
     assert!(result.is_empty());
 }
 
@@ -2221,9 +2252,9 @@ fn test_token_trend_daily_granularity() {
     )
     .unwrap();
 
-    let result = WorkflowManager::new(&conn)
-        .get_workflow_token_trend("trend-wf", TimeGranularity::Daily)
-        .unwrap();
+    let result =
+        crate::workflow::get_workflow_token_trend(&conn, "trend-wf", TimeGranularity::Daily)
+            .unwrap();
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].period, "2024-03-15");
@@ -2251,9 +2282,9 @@ fn test_token_trend_daily_multiple_periods_ordered_desc() {
     )
     .unwrap();
 
-    let result = WorkflowManager::new(&conn)
-        .get_workflow_token_trend("trend-wf", TimeGranularity::Daily)
-        .unwrap();
+    let result =
+        crate::workflow::get_workflow_token_trend(&conn, "trend-wf", TimeGranularity::Daily)
+            .unwrap();
 
     assert_eq!(result.len(), 2);
     // ordered DESC — newer period first
@@ -2282,9 +2313,9 @@ fn test_token_trend_weekly_granularity() {
     )
     .unwrap();
 
-    let result = WorkflowManager::new(&conn)
-        .get_workflow_token_trend("trend-wf", TimeGranularity::Weekly)
-        .unwrap();
+    let result =
+        crate::workflow::get_workflow_token_trend(&conn, "trend-wf", TimeGranularity::Weekly)
+            .unwrap();
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].period, "2024-11");
@@ -2297,9 +2328,7 @@ fn test_token_trend_weekly_granularity() {
 #[test]
 fn test_step_heatmap_empty_for_unknown_workflow() {
     let conn = setup_db();
-    let result = WorkflowManager::new(&conn)
-        .get_step_token_heatmap("no-such-wf", 10)
-        .unwrap();
+    let result = crate::workflow::get_step_token_heatmap(&conn, "no-such-wf", 10).unwrap();
     assert!(result.is_empty());
 }
 
@@ -2358,9 +2387,7 @@ fn test_step_heatmap_basic_per_step_averages() {
     insert_workflow_step(&conn, "s1", &run1.id, "step-a", 0, "ar-r1-a");
     insert_workflow_step(&conn, "s2", &run2.id, "step-a", 0, "ar-r2-a");
 
-    let result = WorkflowManager::new(&conn)
-        .get_step_token_heatmap("heat-wf", 10)
-        .unwrap();
+    let result = crate::workflow::get_step_token_heatmap(&conn, "heat-wf", 10).unwrap();
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].step_name, "step-a");
@@ -2412,9 +2439,7 @@ fn test_step_heatmap_limit_runs_respected() {
     insert_workflow_step(&conn, "s-r2", &run2.id, "step-a", 0, "ar-r2");
     insert_workflow_step(&conn, "s-r3", &run3.id, "step-a", 0, "ar-r3");
 
-    let result = WorkflowManager::new(&conn)
-        .get_step_token_heatmap("heat-wf", 2)
-        .unwrap();
+    let result = crate::workflow::get_step_token_heatmap(&conn, "heat-wf", 2).unwrap();
 
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].step_name, "step-a");
@@ -2438,9 +2463,7 @@ fn test_step_heatmap_ordered_by_avg_total_tokens_desc() {
     insert_workflow_step(&conn, "s-high", &run.id, "step-high", 0, "ar-high");
     insert_workflow_step(&conn, "s-low", &run.id, "step-low", 1, "ar-low");
 
-    let result = WorkflowManager::new(&conn)
-        .get_step_token_heatmap("heat-wf", 10)
-        .unwrap();
+    let result = crate::workflow::get_step_token_heatmap(&conn, "heat-wf", 10).unwrap();
 
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].step_name, "step-high");
@@ -2452,9 +2475,7 @@ fn test_step_heatmap_ordered_by_avg_total_tokens_desc() {
 #[test]
 fn test_run_metrics_empty_when_no_runs() {
     let conn = setup_db();
-    let result = WorkflowManager::new(&conn)
-        .get_run_metrics("no-such-wf", 30)
-        .unwrap();
+    let result = crate::workflow::get_run_metrics(&conn, "no-such-wf", 30).unwrap();
     assert!(result.is_empty());
 }
 
@@ -2466,7 +2487,7 @@ fn test_run_metrics_excludes_non_completed_runs() {
     // pending — should not appear
     create_named_worktree_run(&conn, "w1", "metrics-wf");
 
-    let result = mgr.get_run_metrics("metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
     assert!(result.is_empty());
 }
 
@@ -2481,7 +2502,7 @@ fn test_run_metrics_returns_completed_run_data() {
     mgr.persist_workflow_metrics(&run.id, 100, 200, 0, 0, 1, 0.0, 5000, None)
         .unwrap();
 
-    let result = mgr.get_run_metrics("metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].input_tokens, Some(100));
     assert_eq!(result[0].output_tokens, Some(200));
@@ -2507,7 +2528,7 @@ fn test_run_metrics_filters_by_workflow_name() {
     mgr.persist_workflow_metrics(&run_b.id, 999, 999, 0, 0, 1, 0.0, 9999, None)
         .unwrap();
 
-    let result = mgr.get_run_metrics("wf-a", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(mgr.conn(), "wf-a", 30).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].input_tokens, Some(100));
     assert!(!result[0].run_id.is_empty());
@@ -2534,7 +2555,7 @@ fn test_run_metrics_excludes_null_metric_runs() {
     )
     .unwrap();
 
-    let result = mgr.get_run_metrics("metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
     assert_eq!(result.len(), 1, "all-null run should be excluded");
     assert_eq!(result[0].run_id, dur_run.id);
     assert_eq!(result[0].duration_ms, Some(3000));
@@ -2554,7 +2575,7 @@ fn test_run_metrics_excludes_zero_metric_runs() {
     mgr.persist_workflow_metrics(&zero_run.id, 0, 0, 0, 0, 0, 0.0, 0, None)
         .unwrap();
 
-    let result = mgr.get_run_metrics("metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
     assert!(result.is_empty(), "all-zero metric run should be excluded");
 }
 
@@ -2570,7 +2591,7 @@ fn test_run_metrics_includes_partial_nonzero_run() {
     mgr.persist_workflow_metrics(&run.id, 0, 0, 0, 0, 1, 0.0, 2500, None)
         .unwrap();
 
-    let result = mgr.get_run_metrics("metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
     assert_eq!(
         result.len(),
         1,
@@ -2592,7 +2613,7 @@ fn test_run_metrics_includes_worktree_and_repo_id() {
     mgr.persist_workflow_metrics(&run.id, 100, 200, 0, 0, 1, 0.0, 5000, None)
         .unwrap();
 
-    let result = mgr.get_run_metrics("metrics-wf", 30).unwrap();
+    let result = crate::workflow::get_run_metrics(mgr.conn(), "metrics-wf", 30).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].worktree_id.as_deref(), Some("w1"));
     // repo_id is null when created via create_named_worktree_run (worktree context)
@@ -2604,9 +2625,12 @@ fn test_run_metrics_includes_worktree_and_repo_id() {
 #[test]
 fn test_failure_rate_trend_empty_when_no_terminal_runs() {
     let conn = setup_db();
-    let result = WorkflowManager::new(&conn)
-        .get_workflow_failure_rate_trend("no-such-wf", TimeGranularity::Daily)
-        .unwrap();
+    let result = crate::workflow::get_workflow_failure_rate_trend(
+        &conn,
+        "no-such-wf",
+        TimeGranularity::Daily,
+    )
+    .unwrap();
     assert!(result.is_empty());
 }
 
@@ -2623,9 +2647,12 @@ fn test_failure_rate_trend_excludes_non_terminal_runs() {
     mgr.update_workflow_status(&running.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let result = mgr
-        .get_workflow_failure_rate_trend("trend-wf", TimeGranularity::Daily)
-        .unwrap();
+    let result = crate::workflow::get_workflow_failure_rate_trend(
+        mgr.conn(),
+        "trend-wf",
+        TimeGranularity::Daily,
+    )
+    .unwrap();
     assert!(result.is_empty());
 }
 
@@ -2644,9 +2671,12 @@ fn test_failure_rate_trend_completed_only_period() {
     )
     .unwrap();
 
-    let result = mgr
-        .get_workflow_failure_rate_trend("trend-wf", TimeGranularity::Daily)
-        .unwrap();
+    let result = crate::workflow::get_workflow_failure_rate_trend(
+        mgr.conn(),
+        "trend-wf",
+        TimeGranularity::Daily,
+    )
+    .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].period, "2024-03-15");
     assert_eq!(result[0].total_runs, 1);
@@ -2679,9 +2709,12 @@ fn test_failure_rate_trend_mixed_completed_and_failed() {
     )
     .unwrap();
 
-    let result = mgr
-        .get_workflow_failure_rate_trend("trend-wf", TimeGranularity::Daily)
-        .unwrap();
+    let result = crate::workflow::get_workflow_failure_rate_trend(
+        mgr.conn(),
+        "trend-wf",
+        TimeGranularity::Daily,
+    )
+    .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].total_runs, 3);
     assert_eq!(result[0].failed_runs, 1);
@@ -2702,9 +2735,12 @@ fn test_failure_rate_trend_filters_by_workflow_name() {
     mgr.update_workflow_status(&run_b.id, WorkflowRunStatus::Completed, None, None)
         .unwrap();
 
-    let result = mgr
-        .get_workflow_failure_rate_trend("wf-a", TimeGranularity::Daily)
-        .unwrap();
+    let result = crate::workflow::get_workflow_failure_rate_trend(
+        mgr.conn(),
+        "wf-a",
+        TimeGranularity::Daily,
+    )
+    .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].failed_runs, 1);
     assert!((result[0].success_rate - 0.0).abs() < 0.01);
@@ -2727,9 +2763,12 @@ fn test_failure_rate_trend_weekly_granularity() {
         .unwrap();
     }
 
-    let result = mgr
-        .get_workflow_failure_rate_trend("trend-wf", TimeGranularity::Weekly)
-        .unwrap();
+    let result = crate::workflow::get_workflow_failure_rate_trend(
+        mgr.conn(),
+        "trend-wf",
+        TimeGranularity::Weekly,
+    )
+    .unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].total_runs, 2);
 }
@@ -2757,9 +2796,7 @@ fn insert_step_with_status(
 #[test]
 fn test_step_failure_heatmap_empty_when_no_runs() {
     let conn = setup_db();
-    let result = WorkflowManager::new(&conn)
-        .get_step_failure_heatmap("no-such-wf", 10)
-        .unwrap();
+    let result = crate::workflow::get_step_failure_heatmap(&conn, "no-such-wf", 10).unwrap();
     assert!(result.is_empty());
 }
 
@@ -2780,7 +2817,7 @@ fn test_step_failure_heatmap_basic_failure_rate() {
     insert_step_with_status(&conn, "s1", &run1.id, "step-a", 0, "completed");
     insert_step_with_status(&conn, "s2", &run2.id, "step-a", 0, "failed");
 
-    let result = mgr.get_step_failure_heatmap("heat-wf", 10).unwrap();
+    let result = crate::workflow::get_step_failure_heatmap(mgr.conn(), "heat-wf", 10).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].step_name, "step-a");
     assert_eq!(result[0].total_executions, 2);
@@ -2803,7 +2840,7 @@ fn test_step_failure_heatmap_excludes_pending_and_skipped_steps() {
     // only this completed step should show up
     insert_step_with_status(&conn, "s-done", &run.id, "step-c", 2, "completed");
 
-    let result = mgr.get_step_failure_heatmap("heat-wf", 10).unwrap();
+    let result = crate::workflow::get_step_failure_heatmap(mgr.conn(), "heat-wf", 10).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].step_name, "step-c");
 }
@@ -2845,7 +2882,7 @@ fn test_step_failure_heatmap_limit_runs_respected() {
     insert_step_with_status(&conn, "s-r2", &run2.id, "step-a", 0, "completed");
     insert_step_with_status(&conn, "s-r3", &run3.id, "step-a", 0, "completed");
 
-    let result = mgr.get_step_failure_heatmap("heat-wf", 2).unwrap();
+    let result = crate::workflow::get_step_failure_heatmap(mgr.conn(), "heat-wf", 2).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].total_executions, 2);
     assert_eq!(result[0].failed_executions, 0);
@@ -2865,7 +2902,7 @@ fn test_step_failure_heatmap_ordered_by_failure_rate_desc() {
     insert_step_with_status(&conn, "s-ok", &run.id, "step-never-fails", 0, "completed");
     insert_step_with_status(&conn, "s-bad", &run.id, "step-always-fails", 1, "failed");
 
-    let result = mgr.get_step_failure_heatmap("heat-wf", 10).unwrap();
+    let result = crate::workflow::get_step_failure_heatmap(mgr.conn(), "heat-wf", 10).unwrap();
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].step_name, "step-always-fails");
     assert_eq!(result[1].step_name, "step-never-fails");
@@ -2895,9 +2932,7 @@ fn insert_step_with_retries(
 #[test]
 fn test_step_retry_analytics_empty_when_no_runs() {
     let conn = setup_db();
-    let result = WorkflowManager::new(&conn)
-        .get_step_retry_analytics("no-such-wf", 10)
-        .unwrap();
+    let result = crate::workflow::get_step_retry_analytics(&conn, "no-such-wf", 10).unwrap();
     assert!(result.is_empty());
 }
 
@@ -2911,7 +2946,7 @@ fn test_step_retry_analytics_no_retries() {
         .unwrap();
     insert_step_with_retries(&conn, "s1", &run.id, "step-a", 0, "completed", 0);
 
-    let result = mgr.get_step_retry_analytics("retry-wf", 10).unwrap();
+    let result = crate::workflow::get_step_retry_analytics(mgr.conn(), "retry-wf", 10).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].step_name, "step-a");
     assert_eq!(result[0].total_executions, 1);
@@ -2932,7 +2967,7 @@ fn test_step_retry_analytics_basic() {
         .unwrap();
     insert_step_with_retries(&conn, "s1", &run.id, "step-a", 0, "completed", 2);
 
-    let result = mgr.get_step_retry_analytics("retry-wf", 10).unwrap();
+    let result = crate::workflow::get_step_retry_analytics(mgr.conn(), "retry-wf", 10).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].total_executions, 1);
     assert_eq!(result[0].executions_with_retries, 1);
@@ -2968,7 +3003,7 @@ fn test_step_retry_analytics_mixed() {
         insert_step_with_retries(&conn, &format!("s{idx}"), &run.id, "step-a", 0, status, *rc);
     }
 
-    let result = mgr.get_step_retry_analytics("retry-wf", 10).unwrap();
+    let result = crate::workflow::get_step_retry_analytics(mgr.conn(), "retry-wf", 10).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].total_executions, 4);
     assert_eq!(result[0].executions_with_retries, 2);
@@ -3013,7 +3048,7 @@ fn test_step_retry_analytics_limit_runs() {
     insert_step_with_retries(&conn, "s-r2", &run2.id, "step-a", 0, "completed", 0);
     insert_step_with_retries(&conn, "s-r3", &run3.id, "step-a", 0, "completed", 0);
 
-    let result = mgr.get_step_retry_analytics("retry-wf", 2).unwrap();
+    let result = crate::workflow::get_step_retry_analytics(mgr.conn(), "retry-wf", 2).unwrap();
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].total_executions, 2);
     assert_eq!(result[0].executions_with_retries, 0);
@@ -3024,7 +3059,8 @@ fn test_step_retry_analytics_limit_runs() {
 fn test_get_workflow_percentiles_empty() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = mgr.get_workflow_percentiles("nonexistent-wf", 30).unwrap();
+    let result =
+        crate::workflow::get_workflow_percentiles(mgr.conn(), "nonexistent-wf", 30).unwrap();
     assert!(result.is_none());
 }
 
@@ -3039,7 +3075,7 @@ fn test_get_workflow_percentiles_no_duration() {
     // persist_workflow_metrics with duration 0 — but do NOT set total_duration_ms directly
     // because persist_workflow_metrics sets it. Instead insert a run with NULL duration_ms
     // by completing without calling persist_workflow_metrics.
-    let result = mgr.get_workflow_percentiles("pct-wf", 30).unwrap();
+    let result = crate::workflow::get_workflow_percentiles(mgr.conn(), "pct-wf", 30).unwrap();
     assert!(result.is_none());
 }
 
@@ -3053,7 +3089,7 @@ fn test_get_workflow_percentiles_single_run() {
     mgr.persist_workflow_metrics(&run.id, 100, 200, 0, 0, 1, 0.05, 5000, None)
         .unwrap();
 
-    let result = mgr.get_workflow_percentiles("pct-wf", 30).unwrap();
+    let result = crate::workflow::get_workflow_percentiles(mgr.conn(), "pct-wf", 30).unwrap();
     assert!(result.is_some());
     let p = result.unwrap();
     assert_eq!(p.run_count, 1);
@@ -3087,7 +3123,7 @@ fn test_get_workflow_percentiles_multi_run() {
         .unwrap();
     }
 
-    let result = mgr.get_workflow_percentiles("pct-wf", 30).unwrap();
+    let result = crate::workflow::get_workflow_percentiles(mgr.conn(), "pct-wf", 30).unwrap();
     assert!(result.is_some());
     let p = result.unwrap();
     assert_eq!(p.run_count, 10);
@@ -3121,7 +3157,7 @@ fn test_get_workflow_percentiles_excludes_other_workflows() {
     mgr.persist_workflow_metrics(&run_b.id, 999, 999, 0, 0, 1, 9.99, 99000, None)
         .unwrap();
 
-    let result = mgr.get_workflow_percentiles("wf-a", 30).unwrap();
+    let result = crate::workflow::get_workflow_percentiles(mgr.conn(), "wf-a", 30).unwrap();
     assert!(result.is_some());
     let p = result.unwrap();
     assert_eq!(p.run_count, 1);
@@ -3155,9 +3191,7 @@ fn insert_terminal_gate_step(
 #[test]
 fn test_get_gate_analytics_empty() {
     let conn = setup_db();
-    let result = WorkflowManager::new(&conn)
-        .get_gate_analytics("no-such-wf", 30)
-        .unwrap();
+    let result = crate::workflow::get_gate_analytics(&conn, "no-such-wf", 30).unwrap();
     assert!(result.is_empty());
 }
 
@@ -3179,7 +3213,7 @@ fn test_get_gate_analytics_single_approved() {
         Some("lgtm"),
     );
 
-    let rows = mgr.get_gate_analytics("gate-wf", 30).unwrap();
+    let rows = crate::workflow::get_gate_analytics(mgr.conn(), "gate-wf", 30).unwrap();
     assert_eq!(rows.len(), 1);
     let row = &rows[0];
     assert_eq!(row.step_name, "approve");
@@ -3241,7 +3275,7 @@ fn test_get_gate_analytics_approved_and_rejected() {
         None,
     );
 
-    let rows = mgr.get_gate_analytics("mixed-wf", 30).unwrap();
+    let rows = crate::workflow::get_gate_analytics(mgr.conn(), "mixed-wf", 30).unwrap();
     assert_eq!(rows.len(), 1);
     let row = &rows[0];
     assert_eq!(row.total_gate_hits, 3);
@@ -3282,7 +3316,7 @@ fn test_get_gate_analytics_multiple_step_names() {
         None,
     );
 
-    let rows = mgr.get_gate_analytics("multi-step-wf", 30).unwrap();
+    let rows = crate::workflow::get_gate_analytics(mgr.conn(), "multi-step-wf", 30).unwrap();
     assert_eq!(rows.len(), 2);
     let names: Vec<&str> = rows.iter().map(|r| r.step_name.as_str()).collect();
     assert!(names.contains(&"gate-a"), "gate-a missing from {names:?}");
@@ -3317,7 +3351,7 @@ fn test_get_gate_analytics_excludes_other_workflow() {
         None,
     );
 
-    let rows = mgr.get_gate_analytics("wf-a", 30).unwrap();
+    let rows = crate::workflow::get_gate_analytics(mgr.conn(), "wf-a", 30).unwrap();
     assert_eq!(rows.len(), 1, "must only return rows for wf-a");
 }
 
@@ -3335,7 +3369,7 @@ fn test_get_gate_analytics_excludes_waiting_steps() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let rows = mgr.get_gate_analytics("wait-wf", 30).unwrap();
+    let rows = crate::workflow::get_gate_analytics(mgr.conn(), "wait-wf", 30).unwrap();
     assert!(
         rows.is_empty(),
         "waiting steps must not appear in gate analytics"
@@ -3347,7 +3381,7 @@ fn test_get_gate_analytics_excludes_waiting_steps() {
 #[test]
 fn test_get_all_pending_gates_empty() {
     let conn = setup_db();
-    let result = WorkflowManager::new(&conn).get_all_pending_gates().unwrap();
+    let result = crate::workflow::get_all_pending_gates(&conn).unwrap();
     assert!(result.is_empty());
 }
 
@@ -3369,7 +3403,7 @@ fn test_get_all_pending_gates_returns_waiting_gate() {
     .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let rows = mgr.get_all_pending_gates().unwrap();
+    let rows = crate::workflow::get_all_pending_gates(mgr.conn()).unwrap();
     assert_eq!(rows.len(), 1);
     let row = &rows[0];
     assert_eq!(row.step_id, step_id);
@@ -3400,7 +3434,7 @@ fn test_get_all_pending_gates_excludes_completed() {
     mgr.approve_gate(&step_id, "alice", None, None, None)
         .unwrap();
 
-    let rows = mgr.get_all_pending_gates().unwrap();
+    let rows = crate::workflow::get_all_pending_gates(mgr.conn()).unwrap();
     assert!(rows.is_empty(), "completed gate must not appear");
 }
 
@@ -3416,7 +3450,7 @@ fn test_get_all_pending_gates_excludes_non_gate_steps() {
         .unwrap();
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
-    let rows = mgr.get_all_pending_gates().unwrap();
+    let rows = crate::workflow::get_all_pending_gates(mgr.conn()).unwrap();
     assert!(rows.is_empty(), "non-gate step must not appear");
 }
 
@@ -3442,7 +3476,7 @@ fn test_get_all_pending_gates_cross_workflow() {
         .unwrap();
     set_step_status(&mgr, &step_b, WorkflowStepStatus::Waiting);
 
-    let rows = mgr.get_all_pending_gates().unwrap();
+    let rows = crate::workflow::get_all_pending_gates(mgr.conn()).unwrap();
     assert_eq!(rows.len(), 2);
     let wf_names: Vec<&str> = rows.iter().map(|r| r.workflow_name.as_str()).collect();
     assert!(wf_names.contains(&"wf-alpha"));
@@ -3470,7 +3504,7 @@ fn test_get_all_pending_gates_null_started_at() {
     )
     .unwrap();
 
-    let rows = mgr.get_all_pending_gates().unwrap();
+    let rows = crate::workflow::get_all_pending_gates(mgr.conn()).unwrap();
     assert_eq!(rows.len(), 1);
     let row = &rows[0];
     assert_eq!(row.step_id, step_id);
@@ -3510,9 +3544,7 @@ fn complete_with_duration_cost(
 #[test]
 fn test_regression_signals_empty_when_no_runs() {
     let conn = setup_db();
-    let result = WorkflowManager::new(&conn)
-        .get_workflow_regression_signals(1, 7, 30)
-        .unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(&conn, 1, 7, 30).unwrap();
     assert!(result.is_empty());
 }
 
@@ -3534,7 +3566,7 @@ fn test_regression_signals_excluded_below_min_recent_runs() {
         backdate_run(&conn, &run.id, 14);
     }
 
-    let result = mgr.get_workflow_regression_signals(3, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 3, 7, 30).unwrap();
     assert!(
         result.is_empty(),
         "workflow with only 2 recent runs should be excluded by HAVING min_recent_runs=3"
@@ -3550,7 +3582,7 @@ fn test_regression_signals_excluded_when_no_baseline() {
     let run = create_named_worktree_run(&conn, "w1", "no-baseline-wf");
     complete_with_duration_cost(&conn, &run.id, 1000, 0.01);
 
-    let result = mgr.get_workflow_regression_signals(1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
     assert!(
         result.is_empty(),
         "workflow with no baseline runs should be excluded by INNER JOIN"
@@ -3578,7 +3610,7 @@ fn test_regression_signals_no_regression_when_stable() {
         complete_with_duration_cost(&conn, &run.id, d, c);
     }
 
-    let result = mgr.get_workflow_regression_signals(1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
     assert_eq!(result.len(), 1);
     let s = &result[0];
     assert_eq!(s.workflow_name, "stable-wf");
@@ -3614,7 +3646,7 @@ fn test_regression_signals_duration_regressed() {
         complete_with_duration_cost(&conn, &run.id, d, 0.01);
     }
 
-    let result = mgr.get_workflow_regression_signals(1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
     assert_eq!(result.len(), 1);
     let s = &result[0];
     assert!(
@@ -3643,7 +3675,7 @@ fn test_regression_signals_cost_regressed() {
         complete_with_duration_cost(&conn, &run.id, 1000, c);
     }
 
-    let result = mgr.get_workflow_regression_signals(1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
     assert_eq!(result.len(), 1);
     let s = &result[0];
     assert!(!s.duration_regressed);
@@ -3674,7 +3706,7 @@ fn test_regression_signals_failure_rate_regressed() {
             .unwrap();
     }
 
-    let result = mgr.get_workflow_regression_signals(1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
     assert_eq!(result.len(), 1);
     let s = &result[0];
     assert!(!s.duration_regressed);
@@ -3699,7 +3731,7 @@ fn test_regression_signals_excludes_runs_outside_both_windows() {
         backdate_run(&conn, &run.id, 40);
     }
 
-    let result = mgr.get_workflow_regression_signals(1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
     assert!(
         result.is_empty(),
         "runs older than both windows (40 days > 7+30=37 days) should be excluded"
@@ -3733,7 +3765,7 @@ fn test_regression_signals_multiple_workflows_independent() {
         complete_with_duration_cost(&conn, &run.id, d, 0.01);
     }
 
-    let result = mgr.get_workflow_regression_signals(1, 7, 30).unwrap();
+    let result = crate::workflow::get_workflow_regression_signals(mgr.conn(), 1, 7, 30).unwrap();
     assert_eq!(result.len(), 2, "both workflows should appear");
     // ORDER BY workflow_name → "wf-alpha" before "wf-beta".
     assert_eq!(result[0].workflow_name, "wf-alpha");
@@ -3911,7 +3943,8 @@ fn test_spike_baseline_insufficient_runs_returns_none() {
         let run = create_named_worktree_run(&conn, "w1", "spike-wf");
         complete_with_duration_cost(&conn, &run.id, 1000, 0.10);
     }
-    let result = mgr.get_workflow_spike_baseline("spike-wf", 30, 5).unwrap();
+    let result =
+        crate::workflow::get_workflow_spike_baseline(mgr.conn(), "spike-wf", 30, 5).unwrap();
     assert!(result.is_none(), "should return None with < 5 runs");
 }
 
@@ -3927,8 +3960,7 @@ fn test_spike_baseline_returns_correct_values() {
         let run = create_named_worktree_run(&conn, "w1", "spike-vals-wf");
         complete_with_duration_cost(&conn, &run.id, dur, cost_per_run);
     }
-    let baseline = mgr
-        .get_workflow_spike_baseline("spike-vals-wf", 30, 5)
+    let baseline = crate::workflow::get_workflow_spike_baseline(mgr.conn(), "spike-vals-wf", 30, 5)
         .unwrap()
         .expect("should return Some with 5 runs");
     assert_eq!(baseline.run_count, 5);
@@ -3979,8 +4011,7 @@ fn test_spike_baseline_excludes_sub_workflow_runs() {
     }
 
     // Baseline should only see 6 root runs (5 + root_run).
-    let baseline = mgr
-        .get_workflow_spike_baseline("excl-wf", 30, 5)
+    let baseline = crate::workflow::get_workflow_spike_baseline(mgr.conn(), "excl-wf", 30, 5)
         .unwrap()
         .expect("should return Some for 6 root runs");
     // avg_cost = (5 * 0.10 + 9.99) / 6 ≈ 1.748
@@ -4265,22 +4296,21 @@ fn test_find_step_by_name_and_iteration_returns_non_completed_step() {
     set_step_status(&mgr, &step_id, crate::workflow::WorkflowStepStatus::Running);
 
     // Should find the running step.
-    let found = mgr
-        .find_step_by_name_and_iteration(&run.id, step_name, 1)
+    let found = crate::workflow::find_step_by_name_and_iteration(mgr.conn(), &run.id, step_name, 1)
         .unwrap();
     assert!(found.is_some(), "should find the non-completed step");
     assert_eq!(found.unwrap().id, step_id);
 
     // Non-matching iteration → None.
-    let not_found = mgr
-        .find_step_by_name_and_iteration(&run.id, step_name, 2)
-        .unwrap();
+    let not_found =
+        crate::workflow::find_step_by_name_and_iteration(mgr.conn(), &run.id, step_name, 2)
+            .unwrap();
     assert!(not_found.is_none(), "different iteration should not match");
 
     // Non-matching step_name → None.
-    let not_found2 = mgr
-        .find_step_by_name_and_iteration(&run.id, "foreach:other", 1)
-        .unwrap();
+    let not_found2 =
+        crate::workflow::find_step_by_name_and_iteration(mgr.conn(), &run.id, "foreach:other", 1)
+            .unwrap();
     assert!(not_found2.is_none(), "different step_name should not match");
 }
 
@@ -4307,8 +4337,7 @@ fn test_find_step_by_name_and_iteration_ignores_completed_steps() {
     );
 
     // Should NOT return a completed step.
-    let found = mgr
-        .find_step_by_name_and_iteration(&run.id, step_name, 0)
+    let found = crate::workflow::find_step_by_name_and_iteration(mgr.conn(), &run.id, step_name, 0)
         .unwrap();
     assert!(
         found.is_none(),
@@ -4325,7 +4354,7 @@ fn test_set_dismissed_marks_run_dismissed() {
 
     mgr.set_dismissed(&run.id, true).unwrap();
 
-    let updated = mgr.list_workflow_runs_for_repo("r1", 50).unwrap();
+    let updated = crate::workflow::list_workflow_runs_for_repo(mgr.conn(), "r1", 50).unwrap();
     let found = updated.iter().find(|r| r.id == run.id).unwrap();
     assert!(
         found.dismissed,
@@ -4342,7 +4371,7 @@ fn test_set_dismissed_can_undismiss() {
     mgr.set_dismissed(&run.id, true).unwrap();
     mgr.set_dismissed(&run.id, false).unwrap();
 
-    let updated = mgr.list_workflow_runs_for_repo("r1", 50).unwrap();
+    let updated = crate::workflow::list_workflow_runs_for_repo(mgr.conn(), "r1", 50).unwrap();
     let found = updated.iter().find(|r| r.id == run.id).unwrap();
     assert!(
         !found.dismissed,
@@ -4428,7 +4457,9 @@ fn gate_kind_human_approval_roundtrips_through_db() {
     mgr.set_step_gate_info(&step_id, GateType::HumanApproval, None, "1h")
         .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         step.gate_type,
         Some(GateType::HumanApproval),
@@ -4488,7 +4519,9 @@ fn test_workflow_title_stored_and_read_from_column() {
     assert_eq!(run.workflow_title.as_deref(), Some("My Workflow"));
 
     // Read back through the query layer to confirm the column is persisted.
-    let fetched = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(fetched.workflow_title.as_deref(), Some("My Workflow"));
 
     // Null out definition_snapshot to prove workflow_title is read from its own column.
@@ -4497,7 +4530,9 @@ fn test_workflow_title_stored_and_read_from_column() {
         rusqlite::params![run.id],
     )
     .unwrap();
-    let fetched_no_snapshot = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched_no_snapshot = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         fetched_no_snapshot.workflow_title.as_deref(),
         Some("My Workflow"),
@@ -4526,7 +4561,9 @@ fn test_workflow_title_null_snapshot_at_create_time() {
         run.workflow_title, None,
         "NULL snapshot at write time must yield None workflow_title"
     );
-    let fetched = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(fetched.workflow_title, None);
 }
 
@@ -4552,7 +4589,9 @@ fn test_workflow_title_snapshot_without_title_field() {
         run.workflow_title, None,
         "snapshot without 'title' field must yield None workflow_title"
     );
-    let fetched = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(fetched.workflow_title, None);
 }
 
@@ -4578,6 +4617,8 @@ fn test_workflow_title_malformed_snapshot_json() {
         run.workflow_title, None,
         "malformed JSON snapshot must yield None workflow_title (not panic)"
     );
-    let fetched = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(fetched.workflow_title, None);
 }

--- a/conductor-core/src/workflow/mod.rs
+++ b/conductor-core/src/workflow/mod.rs
@@ -57,6 +57,7 @@ pub use estimation::{Confidence, Estimate, LiveEstimate, StepEstimates};
 pub use manager::definitions::{
     list_defs, list_defs_with_validation, load_def_by_name, validate_single,
 };
+pub use manager::queries::*;
 pub use manager::recovery::{ReapedStaleRun, StaleWorkflowRun};
 pub use manager::{InvalidWorkflowEntry, StepMetrics, WorkflowManager};
 pub use output::{parse_flow_output, FlowOutput};

--- a/conductor-core/src/workflow/mod.rs
+++ b/conductor-core/src/workflow/mod.rs
@@ -57,7 +57,26 @@ pub use estimation::{Confidence, Estimate, LiveEstimate, StepEstimates};
 pub use manager::definitions::{
     list_defs, list_defs_with_validation, load_def_by_name, validate_single,
 };
-pub use manager::queries::*;
+pub use manager::queries::{
+    active_run_counts_by_repo, find_step_by_name_and_iteration, find_waiting_gate,
+    find_waiting_gates_for_runs, get_active_chain_for_run, get_active_run_for_worktree,
+    get_active_steps_for_runs, get_all_pending_gates, get_completed_run_durations,
+    get_completed_step_durations, get_gate_analytics, get_plan_estimates_for_runs,
+    get_progress_steps_for_runs, get_run_metrics, get_step_by_id, get_step_failure_heatmap,
+    get_step_retry_analytics, get_step_summaries_for_runs, get_step_token_heatmap,
+    get_steps_for_runs, get_workflow_failure_rate_trend, get_workflow_percentiles,
+    get_workflow_regression_signals, get_workflow_run, get_workflow_run_ids_for_agent_runs,
+    get_workflow_spike_baseline, get_workflow_steps, get_workflow_token_aggregates,
+    get_workflow_token_trend, is_run_cancelled, is_workflow_cancelled,
+    list_active_non_worktree_workflow_runs, list_active_workflow_runs,
+    list_active_workflow_runs_for_repo, list_all_waiting_gate_steps, list_all_workflow_runs,
+    list_all_workflow_runs_filtered_paginated, list_child_workflow_runs, list_root_workflow_runs,
+    list_runs_by_status, list_waiting_gate_steps_for_repo, list_workflow_runs,
+    list_workflow_runs_by_repo_id, list_workflow_runs_by_repo_id_filtered,
+    list_workflow_runs_filtered, list_workflow_runs_filtered_paginated,
+    list_workflow_runs_for_repo, list_workflow_runs_for_scope, list_workflow_runs_paginated,
+    resolve_run_context,
+};
 pub use manager::recovery::{ReapedStaleRun, StaleWorkflowRun};
 pub use manager::{InvalidWorkflowEntry, StepMetrics, WorkflowManager};
 pub use output::{parse_flow_output, FlowOutput};

--- a/conductor-core/src/workflow/persistence_sqlite.rs
+++ b/conductor-core/src/workflow/persistence_sqlite.rs
@@ -149,7 +149,7 @@ mod tests {
         // Verify state is visible through the shared connection handle too.
         let guard = shared.lock().unwrap();
         let mgr = crate::workflow::manager::WorkflowManager::new(&guard);
-        let found = crate::workflow::get_workflow_run(mgr.conn(), &run.id).unwrap();
+        let found = crate::workflow::get_workflow_run(&guard, &run.id).unwrap();
         assert!(
             found.is_some(),
             "run written via persistence should be visible through shared conn"

--- a/conductor-core/src/workflow/persistence_sqlite.rs
+++ b/conductor-core/src/workflow/persistence_sqlite.rs
@@ -149,7 +149,7 @@ mod tests {
         // Verify state is visible through the shared connection handle too.
         let guard = shared.lock().unwrap();
         let mgr = crate::workflow::manager::WorkflowManager::new(&guard);
-        let found = mgr.get_workflow_run(&run.id).unwrap();
+        let found = crate::workflow::get_workflow_run(mgr.conn(), &run.id).unwrap();
         assert!(
             found.is_some(),
             "run written via persistence should be visible through shared conn"

--- a/conductor-core/src/workflow/runkon_bridge.rs
+++ b/conductor-core/src/workflow/runkon_bridge.rs
@@ -499,7 +499,6 @@ impl runkon_flow::engine::ChildWorkflowRunner for ConductorChildWorkflowRunner {
         workflow_name: &str,
     ) -> runkon_flow::engine_error::Result<Option<runkon_flow::types::WorkflowRun>> {
         let conn = self.conn.lock().map_err(bridge_lock_err)?;
-
         let mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         let core_run = mgr
             .find_resumable_child_run(parent_run_id, workflow_name)

--- a/conductor-core/src/workflow/tests/common.rs
+++ b/conductor-core/src/workflow/tests/common.rs
@@ -76,9 +76,9 @@ pub(super) fn make_empty_workflow() -> WorkflowDef {
 }
 
 pub(super) fn create_child_run(conn: &Connection) -> (WorkflowManager<'_>, String) {
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(conn);
     let agent_mgr = AgentManager::new(conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(conn);
     let run = wf_mgr
         .create_workflow_run("child-wf", Some("w1"), &parent.id, false, "manual", None)
         .unwrap();
@@ -260,9 +260,9 @@ pub(super) fn insert_workflow_run_with_targets(
     worktree_id: Option<&str>,
     repo_id: Option<&str>,
 ) -> String {
+    let mgr = crate::workflow::manager::WorkflowManager::new(conn);
     let agent_mgr = AgentManager::new(conn);
     let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
-    let mgr = WorkflowManager::new(conn);
     let run = mgr
         .create_workflow_run_with_targets(
             "test-wf",
@@ -330,9 +330,9 @@ pub(super) fn insert_waiting_run_with_gate(
 pub(super) fn make_workflow_run(
     conn: &Connection,
 ) -> (WorkflowManager<'_>, crate::agent::AgentRun, WorkflowRun) {
+    let mgr = crate::workflow::manager::WorkflowManager::new(conn);
     let agent_mgr = AgentManager::new(conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let mgr = WorkflowManager::new(conn);
     let run = mgr
         .create_workflow_run("test-wf", Some("w1"), &parent.id, false, "manual", None)
         .unwrap();
@@ -353,8 +353,8 @@ pub(super) fn setup_hooks_dir(config_toml: &str, workflows: &[(&str, &str)]) -> 
 
 /// Helper: create a running workflow run with a parent agent run.
 pub(super) fn make_running_wf(conn: &Connection, name: &str) -> (String, String) {
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(conn);
     let agent_mgr = AgentManager::new(conn);
-    let wf_mgr = WorkflowManager::new(conn);
     let parent = agent_mgr.create_run(Some("w1"), name, None).unwrap();
     let run = wf_mgr
         .create_workflow_run(name, Some("w1"), &parent.id, false, "manual", None)
@@ -372,7 +372,7 @@ pub(super) fn insert_terminal_step(
     status: WorkflowStepStatus,
     position: i64,
 ) {
-    let wf_mgr = WorkflowManager::new(conn);
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(conn);
     let step_id = wf_mgr
         .insert_step(wf_run_id, "step", "actor", false, position, 0)
         .unwrap();

--- a/conductor-core/src/workflow/tests/gates.rs
+++ b/conductor-core/src/workflow/tests/gates.rs
@@ -21,7 +21,7 @@ fn test_gate_approve() {
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
     // Find waiting gate
-    let waiting = mgr.find_waiting_gate(&run.id).unwrap();
+    let waiting = crate::workflow::find_waiting_gate(mgr.conn(), &run.id).unwrap();
     assert!(waiting.is_some());
     assert_eq!(waiting.unwrap().id, step_id);
 
@@ -30,7 +30,7 @@ fn test_gate_approve() {
         .unwrap();
 
     // Verify
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Completed);
     assert!(steps[0].gate_approved_at.is_some());
     assert_eq!(steps[0].gate_approved_by.as_deref(), Some("user"));
@@ -56,7 +56,7 @@ fn test_gate_reject() {
 
     mgr.reject_gate(&step_id, "user", None).unwrap();
 
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Failed);
 }
 
@@ -84,7 +84,9 @@ fn test_gate_pr_approval_approve() {
     mgr.approve_gate(&step_id, "reviewer-bot", Some("PR approved"), None, None)
         .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Completed);
     assert_eq!(step.gate_type, Some(GateType::PrApproval));
     assert_eq!(step.gate_approved_by.as_deref(), Some("reviewer-bot"));
@@ -110,7 +112,9 @@ fn test_gate_pr_approval_reject() {
     mgr.reject_gate(&step_id, "reviewer", Some("Changes requested"))
         .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Failed);
     assert_eq!(step.gate_feedback.as_deref(), Some("Changes requested"));
 }
@@ -139,7 +143,9 @@ fn test_gate_pr_checks_approve() {
     mgr.approve_gate(&step_id, "ci-bot", Some("All checks passed"), None, None)
         .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Completed);
     assert_eq!(step.gate_type, Some(GateType::PrChecks));
 }
@@ -170,7 +176,9 @@ fn test_gate_multiselect_options_and_approval() {
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
     // Verify gate_options are stored and step is waiting
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Waiting);
     assert!(step.gate_options.is_some(), "gate_options should be set");
 
@@ -181,7 +189,9 @@ fn test_gate_multiselect_options_and_approval() {
         .unwrap();
 
     // Verify post-approval state
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Completed);
     assert!(step.gate_approved_at.is_some());
     assert_eq!(step.gate_approved_by.as_deref(), Some("user"));
@@ -231,7 +241,9 @@ fn test_gate_approve_empty_selections() {
     mgr.approve_gate(&step_id, "user", None, Some(&[]), None)
         .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Completed);
     // Empty selections → no context_out injected
     assert!(

--- a/conductor-core/src/workflow/tests/gates.rs
+++ b/conductor-core/src/workflow/tests/gates.rs
@@ -21,7 +21,7 @@ fn test_gate_approve() {
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
     // Find waiting gate
-    let waiting = crate::workflow::find_waiting_gate(mgr.conn(), &run.id).unwrap();
+    let waiting = crate::workflow::find_waiting_gate(&conn, &run.id).unwrap();
     assert!(waiting.is_some());
     assert_eq!(waiting.unwrap().id, step_id);
 
@@ -30,7 +30,7 @@ fn test_gate_approve() {
         .unwrap();
 
     // Verify
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Completed);
     assert!(steps[0].gate_approved_at.is_some());
     assert_eq!(steps[0].gate_approved_by.as_deref(), Some("user"));
@@ -56,7 +56,7 @@ fn test_gate_reject() {
 
     mgr.reject_gate(&step_id, "user", None).unwrap();
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Failed);
 }
 
@@ -84,7 +84,7 @@ fn test_gate_pr_approval_approve() {
     mgr.approve_gate(&step_id, "reviewer-bot", Some("PR approved"), None, None)
         .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Completed);
@@ -112,7 +112,7 @@ fn test_gate_pr_approval_reject() {
     mgr.reject_gate(&step_id, "reviewer", Some("Changes requested"))
         .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Failed);
@@ -143,7 +143,7 @@ fn test_gate_pr_checks_approve() {
     mgr.approve_gate(&step_id, "ci-bot", Some("All checks passed"), None, None)
         .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Completed);
@@ -176,7 +176,7 @@ fn test_gate_multiselect_options_and_approval() {
     set_step_status(&mgr, &step_id, WorkflowStepStatus::Waiting);
 
     // Verify gate_options are stored and step is waiting
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Waiting);
@@ -189,7 +189,7 @@ fn test_gate_multiselect_options_and_approval() {
         .unwrap();
 
     // Verify post-approval state
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Completed);
@@ -241,7 +241,7 @@ fn test_gate_approve_empty_selections() {
     mgr.approve_gate(&step_id, "user", None, Some(&[]), None)
         .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.status, WorkflowStepStatus::Completed);

--- a/conductor-core/src/workflow/tests/manager.rs
+++ b/conductor-core/src/workflow/tests/manager.rs
@@ -46,7 +46,7 @@ fn test_create_workflow_run_with_snapshot() {
         )
         .unwrap();
 
-    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -82,7 +82,7 @@ fn test_create_workflow_run_with_repo_id_round_trip() {
     assert_eq!(run.ticket_id, None);
 
     // Read back from DB and assert columns are persisted correctly.
-    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(fetched.repo_id.as_deref(), Some("r1"));
@@ -93,7 +93,7 @@ fn test_create_workflow_run_with_repo_id_round_trip() {
 fn test_active_run_counts_by_repo_empty() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let counts = crate::workflow::active_run_counts_by_repo(mgr.conn()).unwrap();
+    let counts = crate::workflow::active_run_counts_by_repo(&conn).unwrap();
     assert!(
         counts.is_empty(),
         "expected no counts with no workflow runs"
@@ -144,7 +144,7 @@ fn test_active_run_counts_by_repo_with_runs() {
         .unwrap();
     // run2 stays at pending (default).
 
-    let counts = crate::workflow::active_run_counts_by_repo(mgr.conn()).unwrap();
+    let counts = crate::workflow::active_run_counts_by_repo(&conn).unwrap();
     let c = counts.get("r1").expect("r1 should be in map");
     assert_eq!(c.running, 1, "expected 1 running");
     assert_eq!(c.pending, 1, "expected 1 pending");
@@ -178,7 +178,7 @@ fn test_active_run_counts_by_repo_excludes_completed() {
     )
     .unwrap();
 
-    let counts = crate::workflow::active_run_counts_by_repo(mgr.conn()).unwrap();
+    let counts = crate::workflow::active_run_counts_by_repo(&conn).unwrap();
     assert!(
         !counts.contains_key("r1"),
         "completed runs must not appear in active counts"
@@ -214,7 +214,7 @@ fn test_create_workflow_run_with_ticket_id_round_trip() {
     assert_eq!(run.repo_id, None);
 
     // Read back from DB and assert columns are persisted correctly.
-    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(fetched.ticket_id.as_deref(), Some("tkt-rt-1"));
@@ -236,7 +236,7 @@ fn test_insert_step_with_iteration() {
         .insert_step(&run.id, "review", "reviewer", false, 0, 2)
         .unwrap();
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(steps.len(), 1);
     assert_eq!(steps[0].id, step_id);
     assert_eq!(steps[0].step_name, "review");
@@ -258,7 +258,7 @@ fn test_insert_step_running_is_atomic() {
         .insert_step_running(&run.id, "build", "script", false, 0, 0, 2)
         .unwrap();
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(steps.len(), 1);
     assert_eq!(steps[0].id, step_id);
     assert_eq!(steps[0].step_name, "build");
@@ -298,7 +298,7 @@ fn test_update_step_with_markers() {
     )
     .unwrap();
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(steps[0].context_out.as_deref(), Some("2 issues in lib.rs"));
     assert_eq!(
         steps[0].markers_out.as_deref(),
@@ -334,7 +334,7 @@ fn test_update_step_status_full_with_structured_output() {
     )
     .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.structured_output.as_deref(), Some(structured_json));
@@ -369,7 +369,7 @@ fn test_update_step_status_full_without_structured_output() {
     )
     .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert!(step.structured_output.is_none());
@@ -403,7 +403,7 @@ fn test_update_step_status_full_with_step_error() {
     )
     .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.step_error.as_deref(), Some(validation_error));
@@ -424,7 +424,7 @@ fn test_list_workflow_runs() {
     mgr.create_workflow_run("test-b", Some("w1"), &p2.id, true, "pr", None)
         .unwrap();
 
-    let runs = crate::workflow::list_workflow_runs(mgr.conn(), "w1").unwrap();
+    let runs = crate::workflow::list_workflow_runs(&conn, "w1").unwrap();
     assert_eq!(runs.len(), 2);
 }
 
@@ -450,7 +450,7 @@ fn test_list_all_workflow_runs_cross_worktree() {
         .unwrap();
 
     // list_all returns both runs regardless of worktree
-    let all = crate::workflow::list_all_workflow_runs(mgr.conn(), 100).unwrap();
+    let all = crate::workflow::list_all_workflow_runs(&conn, 100).unwrap();
     assert_eq!(all.len(), 2);
     let names: Vec<&str> = all.iter().map(|r| r.workflow_name.as_str()).collect();
     assert!(names.contains(&"flow-a"));
@@ -478,7 +478,7 @@ fn test_list_all_workflow_runs_respects_limit() {
         .unwrap();
     }
 
-    let limited = crate::workflow::list_all_workflow_runs(mgr.conn(), 3).unwrap();
+    let limited = crate::workflow::list_all_workflow_runs(&conn, 3).unwrap();
     assert_eq!(limited.len(), 3);
 }
 
@@ -486,7 +486,7 @@ fn test_list_all_workflow_runs_respects_limit() {
 fn test_list_all_workflow_runs_empty() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let runs = crate::workflow::list_all_workflow_runs(mgr.conn(), 50).unwrap();
+    let runs = crate::workflow::list_all_workflow_runs(&conn, 50).unwrap();
     assert!(runs.is_empty());
 }
 
@@ -509,7 +509,7 @@ fn test_list_all_workflow_runs_includes_ephemeral() {
         .create_workflow_run("ephemeral-wf", None, &parent2.id, false, "manual", None)
         .unwrap();
 
-    let all = crate::workflow::list_all_workflow_runs(mgr.conn(), 100).unwrap();
+    let all = crate::workflow::list_all_workflow_runs(&conn, 100).unwrap();
     assert_eq!(all.len(), 2);
 
     // Verify the ephemeral run has None worktree_id
@@ -538,7 +538,7 @@ fn test_list_all_workflow_runs_excludes_merged_worktree() {
     mgr.create_workflow_run("merged-run", Some("w2"), &p2.id, false, "manual", None)
         .unwrap();
 
-    let all = crate::workflow::list_all_workflow_runs(mgr.conn(), 100).unwrap();
+    let all = crate::workflow::list_all_workflow_runs(&conn, 100).unwrap();
     assert_eq!(all.len(), 1);
     assert_eq!(all[0].workflow_name, "active-run");
 }
@@ -564,7 +564,7 @@ fn test_list_all_workflow_runs_excludes_abandoned_worktree() {
     mgr.create_workflow_run("abandoned-run", Some("w2"), &p2.id, false, "manual", None)
         .unwrap();
 
-    let all = crate::workflow::list_all_workflow_runs(mgr.conn(), 100).unwrap();
+    let all = crate::workflow::list_all_workflow_runs(&conn, 100).unwrap();
     assert_eq!(all.len(), 1);
     assert_eq!(all[0].workflow_name, "active-run");
 }
@@ -585,7 +585,7 @@ fn test_list_all_workflow_runs_includes_ephemeral_and_active() {
     mgr.create_workflow_run("ephemeral-run", None, &p2.id, false, "manual", None)
         .unwrap();
 
-    let all = crate::workflow::list_all_workflow_runs(mgr.conn(), 100).unwrap();
+    let all = crate::workflow::list_all_workflow_runs(&conn, 100).unwrap();
     assert_eq!(all.len(), 2);
     let names: Vec<&str> = all.iter().map(|r| r.workflow_name.as_str()).collect();
     assert!(names.contains(&"active-run"));
@@ -612,7 +612,7 @@ fn test_list_all_workflow_runs_filtered_paginated_status_filter() {
         .unwrap();
 
     let completed = crate::workflow::list_all_workflow_runs_filtered_paginated(
-        mgr.conn(),
+        &conn,
         Some(WorkflowRunStatus::Completed),
         100,
         0,
@@ -622,7 +622,7 @@ fn test_list_all_workflow_runs_filtered_paginated_status_filter() {
     assert_eq!(completed[0].workflow_name, "done-run");
 
     let pending = crate::workflow::list_all_workflow_runs_filtered_paginated(
-        mgr.conn(),
+        &conn,
         Some(WorkflowRunStatus::Pending),
         100,
         0,
@@ -654,11 +654,11 @@ fn test_list_all_workflow_runs_filtered_paginated_offset() {
     }
 
     let page1 =
-        crate::workflow::list_all_workflow_runs_filtered_paginated(mgr.conn(), None, 2, 0).unwrap();
+        crate::workflow::list_all_workflow_runs_filtered_paginated(&conn, None, 2, 0).unwrap();
     assert_eq!(page1.len(), 2);
 
     let page2 =
-        crate::workflow::list_all_workflow_runs_filtered_paginated(mgr.conn(), None, 2, 2).unwrap();
+        crate::workflow::list_all_workflow_runs_filtered_paginated(&conn, None, 2, 2).unwrap();
     assert_eq!(page2.len(), 2);
 
     // All 4 unique
@@ -714,7 +714,7 @@ fn test_list_workflow_runs_by_repo_id_excludes_merged_worktree() {
     )
     .unwrap();
 
-    let runs = crate::workflow::list_workflow_runs_by_repo_id(mgr.conn(), "r1", 100, 0).unwrap();
+    let runs = crate::workflow::list_workflow_runs_by_repo_id(&conn, "r1", 100, 0).unwrap();
     assert_eq!(runs.len(), 1);
     assert_eq!(runs[0].workflow_name, "active-run");
 }
@@ -740,12 +740,12 @@ fn test_list_workflow_runs_for_scope_scoped() {
         .unwrap();
 
     // Scoped: only w1's run
-    let scoped = crate::workflow::list_workflow_runs_for_scope(mgr.conn(), Some("w1"), 50).unwrap();
+    let scoped = crate::workflow::list_workflow_runs_for_scope(&conn, Some("w1"), 50).unwrap();
     assert_eq!(scoped.len(), 1);
     assert_eq!(scoped[0].workflow_name, "only-w1");
 
     // Global: both runs
-    let global = crate::workflow::list_workflow_runs_for_scope(mgr.conn(), None, 50).unwrap();
+    let global = crate::workflow::list_workflow_runs_for_scope(&conn, None, 50).unwrap();
     assert_eq!(global.len(), 2);
 }
 
@@ -768,7 +768,7 @@ fn test_list_workflow_runs_for_scope_global_limit() {
         )
         .unwrap();
     }
-    let limited = crate::workflow::list_workflow_runs_for_scope(mgr.conn(), None, 2).unwrap();
+    let limited = crate::workflow::list_workflow_runs_for_scope(&conn, None, 2).unwrap();
     assert_eq!(limited.len(), 2);
 }
 
@@ -776,7 +776,7 @@ fn test_list_workflow_runs_for_scope_global_limit() {
 fn test_get_workflow_run_not_found() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = crate::workflow::get_workflow_run(mgr.conn(), "nonexistent").unwrap();
+    let result = crate::workflow::get_workflow_run(&conn, "nonexistent").unwrap();
     assert!(result.is_none());
 }
 
@@ -795,14 +795,14 @@ fn test_get_step_by_id() {
         .insert_step(&run.id, "build", "actor", false, 0, 0)
         .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id).unwrap();
+    let step = crate::workflow::get_step_by_id(&conn, &step_id).unwrap();
     assert!(step.is_some());
     let step = step.unwrap();
     assert_eq!(step.id, step_id);
     assert_eq!(step.step_name, "build");
     assert_eq!(step.role, "actor");
 
-    let missing = crate::workflow::get_step_by_id(mgr.conn(), "nonexistent").unwrap();
+    let missing = crate::workflow::get_step_by_id(&conn, "nonexistent").unwrap();
     assert!(missing.is_none());
 }
 
@@ -844,23 +844,19 @@ fn test_purge_all_terminal_statuses() {
     assert_eq!(deleted, 3);
 
     // running run must still exist
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &r_running.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &r_running.id)
         .unwrap()
         .is_some());
     // terminal runs must be gone
-    assert!(
-        crate::workflow::get_workflow_run(mgr.conn(), &r_completed.id)
-            .unwrap()
-            .is_none()
-    );
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &r_failed.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &r_completed.id)
         .unwrap()
         .is_none());
-    assert!(
-        crate::workflow::get_workflow_run(mgr.conn(), &r_cancelled.id)
-            .unwrap()
-            .is_none()
-    );
+    assert!(crate::workflow::get_workflow_run(&conn, &r_failed.id)
+        .unwrap()
+        .is_none());
+    assert!(crate::workflow::get_workflow_run(&conn, &r_cancelled.id)
+        .unwrap()
+        .is_none());
 }
 
 #[test]
@@ -887,12 +883,10 @@ fn test_purge_single_status_filter() {
     let deleted = mgr.purge(None, &["completed"]).unwrap();
     assert_eq!(deleted, 1);
 
-    assert!(
-        crate::workflow::get_workflow_run(mgr.conn(), &r_completed.id)
-            .unwrap()
-            .is_none()
-    );
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &r_failed.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &r_completed.id)
+        .unwrap()
+        .is_none());
+    assert!(crate::workflow::get_workflow_run(&conn, &r_failed.id)
         .unwrap()
         .is_some());
 }
@@ -935,10 +929,10 @@ fn test_purge_repo_scoped() {
     let deleted = mgr.purge(Some("r1"), &["completed"]).unwrap();
     assert_eq!(deleted, 1);
 
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run_r1.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &run_r1.id)
         .unwrap()
         .is_none());
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run_r2.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &run_r2.id)
         .unwrap()
         .is_some());
 }
@@ -962,7 +956,7 @@ fn test_purge_cascade_deletes_steps() {
     assert_eq!(deleted, 1);
 
     // steps must be gone (cascade)
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert!(steps.is_empty());
 }
 
@@ -1016,7 +1010,7 @@ fn test_purge_noop_when_no_matches() {
         .unwrap();
     assert_eq!(deleted, 0);
 
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .is_some());
 }
@@ -1058,13 +1052,11 @@ fn test_purge_repo_scoped_does_not_delete_global_runs() {
     assert_eq!(deleted, 1);
 
     // Global run must survive.
-    assert!(
-        crate::workflow::get_workflow_run(mgr.conn(), &run_global.id)
-            .unwrap()
-            .is_some()
-    );
+    assert!(crate::workflow::get_workflow_run(&conn, &run_global.id)
+        .unwrap()
+        .is_some());
     // w1 run must be gone.
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run_w1.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &run_w1.id)
         .unwrap()
         .is_none());
 }
@@ -1080,7 +1072,7 @@ fn test_delete_run_removes_completed_run() {
 
     mgr.delete_run(&run.id).unwrap();
 
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .is_none());
 }
@@ -1094,7 +1086,7 @@ fn test_delete_run_removes_failed_run() {
 
     mgr.delete_run(&run.id).unwrap();
 
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .is_none());
 }
@@ -1108,7 +1100,7 @@ fn test_delete_run_removes_cancelled_run() {
 
     mgr.delete_run(&run.id).unwrap();
 
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .is_none());
 }
@@ -1124,7 +1116,7 @@ fn test_delete_run_cascade_deletes_steps() {
 
     mgr.delete_run(&run.id).unwrap();
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert!(
         steps.is_empty(),
         "steps should be cascade-deleted with the run"
@@ -1161,7 +1153,7 @@ fn test_delete_run_rejects_running_run() {
         "deleting a running run should return an error"
     );
     // Run must still exist
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .is_some());
 }
@@ -1177,7 +1169,7 @@ fn test_delete_run_rejects_pending_run() {
         result.is_err(),
         "deleting a pending run should return an error"
     );
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .is_some());
 }
@@ -1226,12 +1218,10 @@ fn test_delete_run_recursive_removes_child_runs() {
     mgr.delete_run(&parent_run.id).unwrap();
 
     // Both parent and child should be gone
-    assert!(
-        crate::workflow::get_workflow_run(mgr.conn(), &parent_run.id)
-            .unwrap()
-            .is_none()
-    );
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &child_run.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &parent_run.id)
+        .unwrap()
+        .is_none());
+    assert!(crate::workflow::get_workflow_run(&conn, &child_run.id)
         .unwrap()
         .is_none());
 }
@@ -1258,11 +1248,11 @@ fn test_delete_run_does_not_affect_sibling_runs() {
 
     mgr.delete_run(&run1.id).unwrap();
 
-    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run1.id)
+    assert!(crate::workflow::get_workflow_run(&conn, &run1.id)
         .unwrap()
         .is_none());
     assert!(
-        crate::workflow::get_workflow_run(mgr.conn(), &run2.id)
+        crate::workflow::get_workflow_run(&conn, &run2.id)
             .unwrap()
             .is_some(),
         "sibling run should not be deleted"
@@ -1277,7 +1267,7 @@ fn test_cancel_run_pending() {
 
     mgr.cancel_run(&run.id, "user requested").unwrap();
 
-    let updated = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let updated = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(updated.status, WorkflowRunStatus::Cancelled);
@@ -1315,12 +1305,12 @@ fn test_cancel_run_running_with_active_steps() {
     // Cancel the run — should cancel step and child agent run
     mgr.cancel_run(&run.id, "abort").unwrap();
 
-    let updated_run = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let updated_run = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(updated_run.status, WorkflowRunStatus::Cancelled);
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Failed);
 
     let agent_run: String = conn
@@ -1357,12 +1347,12 @@ fn test_cancel_run_waiting_status() {
 
     mgr.cancel_run(&run.id, "timed out").unwrap();
 
-    let updated = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let updated = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(updated.status, WorkflowRunStatus::Cancelled);
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Failed);
 }
 
@@ -1397,7 +1387,7 @@ fn test_cancel_run_skips_terminal_steps() {
 
     mgr.cancel_run(&run.id, "stop").unwrap();
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     let done = steps.iter().find(|s| s.id == done_step).unwrap();
     let active = steps.iter().find(|s| s.id == active_step).unwrap();
 
@@ -1895,15 +1885,15 @@ fn test_list_workflow_runs_paginated_limit_and_offset() {
     }
 
     // First page: limit=2, offset=0
-    let page1 = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w1", 2, 0).unwrap();
+    let page1 = crate::workflow::list_workflow_runs_paginated(&conn, "w1", 2, 0).unwrap();
     assert_eq!(page1.len(), 2);
 
     // Second page: limit=2, offset=2
-    let page2 = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w1", 2, 2).unwrap();
+    let page2 = crate::workflow::list_workflow_runs_paginated(&conn, "w1", 2, 2).unwrap();
     assert_eq!(page2.len(), 2);
 
     // Third page: limit=2, offset=4 — only 1 remaining
-    let page3 = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w1", 2, 4).unwrap();
+    let page3 = crate::workflow::list_workflow_runs_paginated(&conn, "w1", 2, 4).unwrap();
     assert_eq!(page3.len(), 1);
 
     // Pages must not overlap
@@ -1915,7 +1905,7 @@ fn test_list_workflow_runs_paginated_limit_and_offset() {
     );
 
     // All 5 runs returned when limit exceeds count
-    let all = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w1", 100, 0).unwrap();
+    let all = crate::workflow::list_workflow_runs_paginated(&conn, "w1", 100, 0).unwrap();
     assert_eq!(all.len(), 5);
 }
 
@@ -1939,11 +1929,11 @@ fn test_list_workflow_runs_paginated_filters_by_worktree() {
     mgr.create_workflow_run("run-w2", Some("w2"), &p2.id, false, "manual", None)
         .unwrap();
 
-    let w1_runs = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w1", 100, 0).unwrap();
+    let w1_runs = crate::workflow::list_workflow_runs_paginated(&conn, "w1", 100, 0).unwrap();
     assert_eq!(w1_runs.len(), 1);
     assert_eq!(w1_runs[0].workflow_name, "run-w1");
 
-    let w2_runs = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w2", 100, 0).unwrap();
+    let w2_runs = crate::workflow::list_workflow_runs_paginated(&conn, "w2", 100, 0).unwrap();
     assert_eq!(w2_runs.len(), 1);
     assert_eq!(w2_runs[0].workflow_name, "run-w2");
 }
@@ -1975,11 +1965,11 @@ fn test_list_workflow_runs_by_repo_id_offset_pagination() {
     }
 
     // First page
-    let page1 = crate::workflow::list_workflow_runs_by_repo_id(mgr.conn(), "r1", 2, 0).unwrap();
+    let page1 = crate::workflow::list_workflow_runs_by_repo_id(&conn, "r1", 2, 0).unwrap();
     assert_eq!(page1.len(), 2);
 
     // Second page
-    let page2 = crate::workflow::list_workflow_runs_by_repo_id(mgr.conn(), "r1", 2, 2).unwrap();
+    let page2 = crate::workflow::list_workflow_runs_by_repo_id(&conn, "r1", 2, 2).unwrap();
     assert_eq!(page2.len(), 2);
 
     // Pages must not overlap
@@ -1991,7 +1981,7 @@ fn test_list_workflow_runs_by_repo_id_offset_pagination() {
     );
 
     // Beyond end returns empty
-    let beyond = crate::workflow::list_workflow_runs_by_repo_id(mgr.conn(), "r1", 2, 10).unwrap();
+    let beyond = crate::workflow::list_workflow_runs_by_repo_id(&conn, "r1", 2, 10).unwrap();
     assert!(beyond.is_empty());
 }
 
@@ -2002,7 +1992,7 @@ fn test_list_root_workflow_runs_excludes_children() {
     insert_workflow_run(&conn, "child1", "child-wf", "running", Some("root1"));
 
     let mgr = WorkflowManager::new(&conn);
-    let roots = crate::workflow::list_root_workflow_runs(mgr.conn(), 100).unwrap();
+    let roots = crate::workflow::list_root_workflow_runs(&conn, 100).unwrap();
     let ids: Vec<&str> = roots.iter().map(|r| r.id.as_str()).collect();
     assert!(ids.contains(&"root1"), "root run should appear");
     assert!(!ids.contains(&"child1"), "child run must not appear");
@@ -2012,7 +2002,7 @@ fn test_list_root_workflow_runs_excludes_children() {
 fn test_list_root_workflow_runs_empty() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let roots = crate::workflow::list_root_workflow_runs(mgr.conn(), 100).unwrap();
+    let roots = crate::workflow::list_root_workflow_runs(&conn, 100).unwrap();
     assert!(roots.is_empty());
 }
 
@@ -2022,7 +2012,7 @@ fn test_get_active_chain_no_children() {
     insert_workflow_run(&conn, "root1", "root-wf", "running", None);
 
     let mgr = WorkflowManager::new(&conn);
-    let chain = crate::workflow::get_active_chain_for_run(mgr.conn(), "root1").unwrap();
+    let chain = crate::workflow::get_active_chain_for_run(&conn, "root1").unwrap();
     assert!(chain.is_empty(), "no children → empty chain");
 }
 
@@ -2033,7 +2023,7 @@ fn test_get_active_chain_single_child() {
     insert_workflow_run(&conn, "child1", "child-wf", "running", Some("root1"));
 
     let mgr = WorkflowManager::new(&conn);
-    let chain = crate::workflow::get_active_chain_for_run(mgr.conn(), "root1").unwrap();
+    let chain = crate::workflow::get_active_chain_for_run(&conn, "root1").unwrap();
     assert_eq!(chain.len(), 1);
     assert_eq!(chain[0].0, "child1");
     assert_eq!(chain[0].1, "child-wf");
@@ -2047,7 +2037,7 @@ fn test_get_active_chain_two_deep() {
     insert_workflow_run(&conn, "grand1", "grand-wf", "running", Some("child1"));
 
     let mgr = WorkflowManager::new(&conn);
-    let chain = crate::workflow::get_active_chain_for_run(mgr.conn(), "root1").unwrap();
+    let chain = crate::workflow::get_active_chain_for_run(&conn, "root1").unwrap();
     assert_eq!(chain.len(), 2);
     assert_eq!(chain[0], ("child1".to_string(), "child-wf".to_string()));
     assert_eq!(chain[1], ("grand1".to_string(), "grand-wf".to_string()));
@@ -2061,7 +2051,7 @@ fn test_get_active_chain_ignores_terminal_children() {
     insert_workflow_run(&conn, "child1", "child-wf", "completed", Some("root1"));
 
     let mgr = WorkflowManager::new(&conn);
-    let chain = crate::workflow::get_active_chain_for_run(mgr.conn(), "root1").unwrap();
+    let chain = crate::workflow::get_active_chain_for_run(&conn, "root1").unwrap();
     assert!(chain.is_empty(), "completed child must not appear in chain");
 }
 
@@ -2072,7 +2062,7 @@ fn test_get_step_summaries_no_children() {
     insert_running_step(&conn, "step1", "root1", "my-step");
 
     let mgr = WorkflowManager::new(&conn);
-    let summaries = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &["root1"]).unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(&conn, &["root1"]).unwrap();
     let s = summaries.get("root1").expect("summary should exist");
     assert_eq!(s.step_name, "my-step");
     assert_eq!(s.iteration, 1);
@@ -2089,7 +2079,7 @@ fn test_get_step_summaries_with_child_chain() {
     insert_running_step(&conn, "step1", "child1", "leaf-step");
 
     let mgr = WorkflowManager::new(&conn);
-    let summaries = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &["root1"]).unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(&conn, &["root1"]).unwrap();
     let s = summaries.get("root1").expect("summary should exist");
     assert_eq!(s.step_name, "leaf-step");
     // workflow_chain is [root_name] because child is the leaf (excluded)
@@ -2105,7 +2095,7 @@ fn test_get_step_summaries_two_deep_chain() {
     insert_running_step(&conn, "step1", "grand1", "grand-step");
 
     let mgr = WorkflowManager::new(&conn);
-    let summaries = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &["root1"]).unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(&conn, &["root1"]).unwrap();
     let s = summaries.get("root1").expect("summary should exist");
     assert_eq!(s.step_name, "grand-step");
     // root + first child (grand is leaf, excluded)
@@ -2116,7 +2106,7 @@ fn test_get_step_summaries_two_deep_chain() {
 fn test_get_step_summaries_empty_run_ids() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let summaries = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[]).unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(&conn, &[]).unwrap();
     assert!(summaries.is_empty());
 }
 
@@ -2127,7 +2117,7 @@ fn test_get_step_summaries_no_running_step() {
     // no steps inserted
 
     let mgr = WorkflowManager::new(&conn);
-    let summaries = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &["root1"]).unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(&conn, &["root1"]).unwrap();
     assert!(
         !summaries.contains_key("root1"),
         "no running step → no entry in map"
@@ -2139,8 +2129,7 @@ fn test_resolve_run_context_run_not_found() {
     let conn = setup_db();
     let config = crate::config::Config::default();
     let mgr = WorkflowManager::new(&conn);
-    let err =
-        crate::workflow::resolve_run_context(mgr.conn(), "nonexistent-id", &config).unwrap_err();
+    let err = crate::workflow::resolve_run_context(&conn, "nonexistent-id", &config).unwrap_err();
     assert!(
         err.to_string().contains("not found"),
         "expected 'not found' error, got: {err}"
@@ -2167,7 +2156,7 @@ fn test_resolve_run_context_worktree_path_exists() {
 
     let run_id = insert_workflow_run_with_targets(&conn, Some("wt-exists"), None);
     let mgr = WorkflowManager::new(&conn);
-    let ctx = crate::workflow::resolve_run_context(mgr.conn(), &run_id, &config).unwrap();
+    let ctx = crate::workflow::resolve_run_context(&conn, &run_id, &config).unwrap();
 
     assert_eq!(ctx.working_dir, wt_path);
     assert_eq!(ctx.repo_path, "/tmp/repo"); // repo r1 from setup_db
@@ -2186,7 +2175,7 @@ fn test_resolve_run_context_worktree_path_missing() {
     // Verify the guard rejects it.
     let run_id = insert_workflow_run_with_targets(&conn, Some("w1"), None);
     let mgr = WorkflowManager::new(&conn);
-    let err = crate::workflow::resolve_run_context(mgr.conn(), &run_id, &config).unwrap_err();
+    let err = crate::workflow::resolve_run_context(&conn, &run_id, &config).unwrap_err();
     assert!(
         err.to_string().contains("no longer exists on disk"),
         "expected disk-existence error, got: {err}"
@@ -2201,7 +2190,7 @@ fn test_resolve_run_context_repo_only() {
     // Run with only repo_id (no worktree).
     let run_id = insert_workflow_run_with_targets(&conn, None, Some("r1"));
     let mgr = WorkflowManager::new(&conn);
-    let ctx = crate::workflow::resolve_run_context(mgr.conn(), &run_id, &config).unwrap();
+    let ctx = crate::workflow::resolve_run_context(&conn, &run_id, &config).unwrap();
 
     assert_eq!(ctx.working_dir, "/tmp/repo");
     assert_eq!(ctx.repo_path, "/tmp/repo");
@@ -2217,7 +2206,7 @@ fn test_resolve_run_context_no_worktree_no_repo() {
     // Run with neither worktree nor repo.
     let run_id = insert_workflow_run_with_targets(&conn, None, None);
     let mgr = WorkflowManager::new(&conn);
-    let err = crate::workflow::resolve_run_context(mgr.conn(), &run_id, &config).unwrap_err();
+    let err = crate::workflow::resolve_run_context(&conn, &run_id, &config).unwrap_err();
     assert!(
         err.to_string()
             .contains("has no associated worktree or repo"),
@@ -2242,7 +2231,7 @@ fn test_set_waiting_blocked_on_atomically_sets_status_and_blocked_on() {
 
     mgr.set_waiting_blocked_on(&run.id, &blocked).unwrap();
 
-    let updated = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let updated = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(updated.status, WorkflowRunStatus::Waiting);
@@ -2269,7 +2258,7 @@ fn test_blocked_on_cleared_when_transitioning_away_from_waiting() {
     };
     mgr.set_waiting_blocked_on(&run.id, &blocked).unwrap();
 
-    let waiting = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let waiting = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(waiting.status, WorkflowRunStatus::Waiting);
@@ -2279,7 +2268,7 @@ fn test_blocked_on_cleared_when_transitioning_away_from_waiting() {
     mgr.update_workflow_status(&run.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let running = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let running = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(running.status, WorkflowRunStatus::Running);
@@ -2302,7 +2291,7 @@ fn test_malformed_blocked_on_json_is_silently_dropped() {
     .unwrap();
 
     // Reading the run should succeed with blocked_on = None
-    let loaded = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+    let loaded = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert!(
@@ -2472,7 +2461,7 @@ fn test_set_step_output_file() {
     mgr.set_step_output_file(&step_id, "/tmp/output.txt")
         .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.output_file.as_deref(), Some("/tmp/output.txt"));
@@ -2498,7 +2487,7 @@ fn test_set_step_gate_info_with_prompt() {
     )
     .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.gate_type, Some(GateType::PrApproval));
@@ -2517,7 +2506,7 @@ fn test_set_step_gate_info_no_prompt() {
     mgr.set_step_gate_info(&step_id, GateType::PrChecks, None, "1h")
         .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.gate_type, Some(GateType::PrChecks));
@@ -2539,7 +2528,7 @@ fn test_set_step_parallel_group() {
 
     mgr.set_step_parallel_group(&step_id, "group-abc").unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(step.parallel_group_id.as_deref(), Some("group-abc"));
@@ -2553,7 +2542,7 @@ fn test_set_step_parallel_group() {
 fn test_get_steps_for_runs_empty_ids() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = crate::workflow::get_steps_for_runs(mgr.conn(), &[]).unwrap();
+    let result = crate::workflow::get_steps_for_runs(&conn, &[]).unwrap();
     assert!(result.is_empty());
 }
 
@@ -2576,7 +2565,7 @@ fn test_get_steps_for_runs_multiple_runs() {
     mgr.insert_step(&run2.id, "s3", "actor", false, 0, 0)
         .unwrap();
 
-    let result = crate::workflow::get_steps_for_runs(mgr.conn(), &[&run1.id, &run2.id]).unwrap();
+    let result = crate::workflow::get_steps_for_runs(&conn, &[&run1.id, &run2.id]).unwrap();
     assert_eq!(result.get(&run1.id).unwrap().len(), 2);
     assert_eq!(result.get(&run2.id).unwrap().len(), 1);
 }
@@ -2610,7 +2599,7 @@ fn test_get_active_steps_for_runs_filters_by_status() {
         .unwrap();
     set_step_status(&mgr, &s4, WorkflowStepStatus::Failed);
 
-    let result = crate::workflow::get_active_steps_for_runs(mgr.conn(), &[&run.id]).unwrap();
+    let result = crate::workflow::get_active_steps_for_runs(&conn, &[&run.id]).unwrap();
     let steps = result.get(&run.id).unwrap();
     // Only running and waiting should be returned
     assert_eq!(steps.len(), 2);
@@ -2622,7 +2611,7 @@ fn test_get_active_steps_for_runs_filters_by_status() {
 fn test_get_active_steps_for_runs_empty_ids() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = crate::workflow::get_active_steps_for_runs(mgr.conn(), &[]).unwrap();
+    let result = crate::workflow::get_active_steps_for_runs(&conn, &[]).unwrap();
     assert!(result.is_empty());
 }
 
@@ -3180,7 +3169,7 @@ fn test_reap_stale_reaps_dead_agent() {
     assert_eq!(reaped[0].step_name, "code-review");
 
     // Verify the workflow run is now failed.
-    let run = crate::workflow::get_workflow_run(mgr.conn(), "stale-run")
+    let run = crate::workflow::get_workflow_run(&conn, "stale-run")
         .unwrap()
         .unwrap();
     assert_eq!(run.status, WorkflowRunStatus::Failed);
@@ -3214,7 +3203,7 @@ fn test_reap_stale_skips_live_agent() {
     assert!(reaped.is_empty(), "live agent should not be reaped");
 
     // Verify the workflow run is still running.
-    let run = crate::workflow::get_workflow_run(mgr.conn(), "alive-run")
+    let run = crate::workflow::get_workflow_run(&conn, "alive-run")
         .unwrap()
         .unwrap();
     assert_eq!(run.status, WorkflowRunStatus::Running);
@@ -4064,7 +4053,7 @@ fn test_step_error_persisted_on_schema_validation_failure() {
     .unwrap();
 
     // Read the step back and assert step_error is set correctly.
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(steps.len(), 1, "expected exactly one step");
     let step = &steps[0];
     assert_eq!(step.status, WorkflowStepStatus::Failed);
@@ -4204,7 +4193,7 @@ fn test_delete_orphaned_pending_steps_removes_never_started() {
         .insert_step(&run.id, "orphan-step", "actor", false, 0, 0)
         .unwrap();
     // Confirm insert_step leaves started_at NULL and status = 'pending'.
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(steps.len(), 1);
     assert_eq!(steps[0].status, WorkflowStepStatus::Pending);
     assert!(steps[0].started_at.is_none());
@@ -4227,7 +4216,7 @@ fn test_delete_orphaned_pending_steps_removes_never_started() {
     let deleted = mgr.delete_orphaned_pending_steps(&run.id).unwrap();
     assert_eq!(deleted, 1, "exactly one orphaned row should be deleted");
 
-    let remaining = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let remaining = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(remaining.len(), 1);
     assert_eq!(remaining[0].id, completed_id, "completed step must survive");
     assert!(
@@ -4261,7 +4250,7 @@ fn test_delete_orphaned_pending_steps_ignores_started_pending() {
         "pending step with started_at must not be deleted"
     );
 
-    let remaining = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let remaining = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(remaining.len(), 1);
     assert_eq!(remaining[0].id, step_id);
 }
@@ -4290,7 +4279,7 @@ fn test_delete_orphaned_pending_steps_only_targets_pending() {
     let deleted = mgr.delete_orphaned_pending_steps(&run.id).unwrap();
     assert_eq!(deleted, 0, "non-pending rows must not be deleted");
 
-    let remaining = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let remaining = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(remaining.len(), 3, "all three rows must survive");
 }
 
@@ -4323,7 +4312,7 @@ fn test_update_step_child_run_id() {
     mgr.update_step_child_run_id(&step_id, &child_run_id)
         .unwrap();
 
-    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .expect("step must exist");
     assert_eq!(

--- a/conductor-core/src/workflow/tests/manager.rs
+++ b/conductor-core/src/workflow/tests/manager.rs
@@ -46,7 +46,9 @@ fn test_create_workflow_run_with_snapshot() {
         )
         .unwrap();
 
-    let fetched = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         fetched.definition_snapshot.as_deref(),
         Some(r#"{"name":"test"}"#)
@@ -80,7 +82,9 @@ fn test_create_workflow_run_with_repo_id_round_trip() {
     assert_eq!(run.ticket_id, None);
 
     // Read back from DB and assert columns are persisted correctly.
-    let fetched = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(fetched.repo_id.as_deref(), Some("r1"));
     assert_eq!(fetched.ticket_id, None);
 }
@@ -89,7 +93,7 @@ fn test_create_workflow_run_with_repo_id_round_trip() {
 fn test_active_run_counts_by_repo_empty() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let counts = mgr.active_run_counts_by_repo().unwrap();
+    let counts = crate::workflow::active_run_counts_by_repo(mgr.conn()).unwrap();
     assert!(
         counts.is_empty(),
         "expected no counts with no workflow runs"
@@ -140,7 +144,7 @@ fn test_active_run_counts_by_repo_with_runs() {
         .unwrap();
     // run2 stays at pending (default).
 
-    let counts = mgr.active_run_counts_by_repo().unwrap();
+    let counts = crate::workflow::active_run_counts_by_repo(mgr.conn()).unwrap();
     let c = counts.get("r1").expect("r1 should be in map");
     assert_eq!(c.running, 1, "expected 1 running");
     assert_eq!(c.pending, 1, "expected 1 pending");
@@ -174,7 +178,7 @@ fn test_active_run_counts_by_repo_excludes_completed() {
     )
     .unwrap();
 
-    let counts = mgr.active_run_counts_by_repo().unwrap();
+    let counts = crate::workflow::active_run_counts_by_repo(mgr.conn()).unwrap();
     assert!(
         !counts.contains_key("r1"),
         "completed runs must not appear in active counts"
@@ -210,7 +214,9 @@ fn test_create_workflow_run_with_ticket_id_round_trip() {
     assert_eq!(run.repo_id, None);
 
     // Read back from DB and assert columns are persisted correctly.
-    let fetched = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(fetched.ticket_id.as_deref(), Some("tkt-rt-1"));
     assert_eq!(fetched.repo_id, None);
 }
@@ -230,7 +236,7 @@ fn test_insert_step_with_iteration() {
         .insert_step(&run.id, "review", "reviewer", false, 0, 2)
         .unwrap();
 
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(steps.len(), 1);
     assert_eq!(steps[0].id, step_id);
     assert_eq!(steps[0].step_name, "review");
@@ -252,7 +258,7 @@ fn test_insert_step_running_is_atomic() {
         .insert_step_running(&run.id, "build", "script", false, 0, 0, 2)
         .unwrap();
 
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(steps.len(), 1);
     assert_eq!(steps[0].id, step_id);
     assert_eq!(steps[0].step_name, "build");
@@ -292,7 +298,7 @@ fn test_update_step_with_markers() {
     )
     .unwrap();
 
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(steps[0].context_out.as_deref(), Some("2 issues in lib.rs"));
     assert_eq!(
         steps[0].markers_out.as_deref(),
@@ -328,7 +334,9 @@ fn test_update_step_status_full_with_structured_output() {
     )
     .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.structured_output.as_deref(), Some(structured_json));
     assert_eq!(step.context_out.as_deref(), Some("All good"));
     assert_eq!(step.result_text.as_deref(), Some("result text"));
@@ -361,7 +369,9 @@ fn test_update_step_status_full_without_structured_output() {
     )
     .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert!(step.structured_output.is_none());
 }
 
@@ -393,7 +403,9 @@ fn test_update_step_status_full_with_step_error() {
     )
     .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.step_error.as_deref(), Some(validation_error));
     assert_eq!(step.result_text.as_deref(), Some("raw agent output"));
     assert!(step.structured_output.is_none());
@@ -412,7 +424,7 @@ fn test_list_workflow_runs() {
     mgr.create_workflow_run("test-b", Some("w1"), &p2.id, true, "pr", None)
         .unwrap();
 
-    let runs = mgr.list_workflow_runs("w1").unwrap();
+    let runs = crate::workflow::list_workflow_runs(mgr.conn(), "w1").unwrap();
     assert_eq!(runs.len(), 2);
 }
 
@@ -438,7 +450,7 @@ fn test_list_all_workflow_runs_cross_worktree() {
         .unwrap();
 
     // list_all returns both runs regardless of worktree
-    let all = mgr.list_all_workflow_runs(100).unwrap();
+    let all = crate::workflow::list_all_workflow_runs(mgr.conn(), 100).unwrap();
     assert_eq!(all.len(), 2);
     let names: Vec<&str> = all.iter().map(|r| r.workflow_name.as_str()).collect();
     assert!(names.contains(&"flow-a"));
@@ -466,7 +478,7 @@ fn test_list_all_workflow_runs_respects_limit() {
         .unwrap();
     }
 
-    let limited = mgr.list_all_workflow_runs(3).unwrap();
+    let limited = crate::workflow::list_all_workflow_runs(mgr.conn(), 3).unwrap();
     assert_eq!(limited.len(), 3);
 }
 
@@ -474,7 +486,7 @@ fn test_list_all_workflow_runs_respects_limit() {
 fn test_list_all_workflow_runs_empty() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let runs = mgr.list_all_workflow_runs(50).unwrap();
+    let runs = crate::workflow::list_all_workflow_runs(mgr.conn(), 50).unwrap();
     assert!(runs.is_empty());
 }
 
@@ -497,7 +509,7 @@ fn test_list_all_workflow_runs_includes_ephemeral() {
         .create_workflow_run("ephemeral-wf", None, &parent2.id, false, "manual", None)
         .unwrap();
 
-    let all = mgr.list_all_workflow_runs(100).unwrap();
+    let all = crate::workflow::list_all_workflow_runs(mgr.conn(), 100).unwrap();
     assert_eq!(all.len(), 2);
 
     // Verify the ephemeral run has None worktree_id
@@ -526,7 +538,7 @@ fn test_list_all_workflow_runs_excludes_merged_worktree() {
     mgr.create_workflow_run("merged-run", Some("w2"), &p2.id, false, "manual", None)
         .unwrap();
 
-    let all = mgr.list_all_workflow_runs(100).unwrap();
+    let all = crate::workflow::list_all_workflow_runs(mgr.conn(), 100).unwrap();
     assert_eq!(all.len(), 1);
     assert_eq!(all[0].workflow_name, "active-run");
 }
@@ -552,7 +564,7 @@ fn test_list_all_workflow_runs_excludes_abandoned_worktree() {
     mgr.create_workflow_run("abandoned-run", Some("w2"), &p2.id, false, "manual", None)
         .unwrap();
 
-    let all = mgr.list_all_workflow_runs(100).unwrap();
+    let all = crate::workflow::list_all_workflow_runs(mgr.conn(), 100).unwrap();
     assert_eq!(all.len(), 1);
     assert_eq!(all[0].workflow_name, "active-run");
 }
@@ -573,7 +585,7 @@ fn test_list_all_workflow_runs_includes_ephemeral_and_active() {
     mgr.create_workflow_run("ephemeral-run", None, &p2.id, false, "manual", None)
         .unwrap();
 
-    let all = mgr.list_all_workflow_runs(100).unwrap();
+    let all = crate::workflow::list_all_workflow_runs(mgr.conn(), 100).unwrap();
     assert_eq!(all.len(), 2);
     let names: Vec<&str> = all.iter().map(|r| r.workflow_name.as_str()).collect();
     assert!(names.contains(&"active-run"));
@@ -599,15 +611,23 @@ fn test_list_all_workflow_runs_filtered_paginated_status_filter() {
     mgr.update_workflow_status(&r2.id, WorkflowRunStatus::Completed, None, None)
         .unwrap();
 
-    let completed = mgr
-        .list_all_workflow_runs_filtered_paginated(Some(WorkflowRunStatus::Completed), 100, 0)
-        .unwrap();
+    let completed = crate::workflow::list_all_workflow_runs_filtered_paginated(
+        mgr.conn(),
+        Some(WorkflowRunStatus::Completed),
+        100,
+        0,
+    )
+    .unwrap();
     assert_eq!(completed.len(), 1);
     assert_eq!(completed[0].workflow_name, "done-run");
 
-    let pending = mgr
-        .list_all_workflow_runs_filtered_paginated(Some(WorkflowRunStatus::Pending), 100, 0)
-        .unwrap();
+    let pending = crate::workflow::list_all_workflow_runs_filtered_paginated(
+        mgr.conn(),
+        Some(WorkflowRunStatus::Pending),
+        100,
+        0,
+    )
+    .unwrap();
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].workflow_name, "pending-run");
 }
@@ -633,14 +653,12 @@ fn test_list_all_workflow_runs_filtered_paginated_offset() {
         .unwrap();
     }
 
-    let page1 = mgr
-        .list_all_workflow_runs_filtered_paginated(None, 2, 0)
-        .unwrap();
+    let page1 =
+        crate::workflow::list_all_workflow_runs_filtered_paginated(mgr.conn(), None, 2, 0).unwrap();
     assert_eq!(page1.len(), 2);
 
-    let page2 = mgr
-        .list_all_workflow_runs_filtered_paginated(None, 2, 2)
-        .unwrap();
+    let page2 =
+        crate::workflow::list_all_workflow_runs_filtered_paginated(mgr.conn(), None, 2, 2).unwrap();
     assert_eq!(page2.len(), 2);
 
     // All 4 unique
@@ -696,7 +714,7 @@ fn test_list_workflow_runs_by_repo_id_excludes_merged_worktree() {
     )
     .unwrap();
 
-    let runs = mgr.list_workflow_runs_by_repo_id("r1", 100, 0).unwrap();
+    let runs = crate::workflow::list_workflow_runs_by_repo_id(mgr.conn(), "r1", 100, 0).unwrap();
     assert_eq!(runs.len(), 1);
     assert_eq!(runs[0].workflow_name, "active-run");
 }
@@ -722,12 +740,12 @@ fn test_list_workflow_runs_for_scope_scoped() {
         .unwrap();
 
     // Scoped: only w1's run
-    let scoped = mgr.list_workflow_runs_for_scope(Some("w1"), 50).unwrap();
+    let scoped = crate::workflow::list_workflow_runs_for_scope(mgr.conn(), Some("w1"), 50).unwrap();
     assert_eq!(scoped.len(), 1);
     assert_eq!(scoped[0].workflow_name, "only-w1");
 
     // Global: both runs
-    let global = mgr.list_workflow_runs_for_scope(None, 50).unwrap();
+    let global = crate::workflow::list_workflow_runs_for_scope(mgr.conn(), None, 50).unwrap();
     assert_eq!(global.len(), 2);
 }
 
@@ -750,7 +768,7 @@ fn test_list_workflow_runs_for_scope_global_limit() {
         )
         .unwrap();
     }
-    let limited = mgr.list_workflow_runs_for_scope(None, 2).unwrap();
+    let limited = crate::workflow::list_workflow_runs_for_scope(mgr.conn(), None, 2).unwrap();
     assert_eq!(limited.len(), 2);
 }
 
@@ -758,7 +776,7 @@ fn test_list_workflow_runs_for_scope_global_limit() {
 fn test_get_workflow_run_not_found() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = mgr.get_workflow_run("nonexistent").unwrap();
+    let result = crate::workflow::get_workflow_run(mgr.conn(), "nonexistent").unwrap();
     assert!(result.is_none());
 }
 
@@ -777,14 +795,14 @@ fn test_get_step_by_id() {
         .insert_step(&run.id, "build", "actor", false, 0, 0)
         .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id).unwrap();
     assert!(step.is_some());
     let step = step.unwrap();
     assert_eq!(step.id, step_id);
     assert_eq!(step.step_name, "build");
     assert_eq!(step.role, "actor");
 
-    let missing = mgr.get_step_by_id("nonexistent").unwrap();
+    let missing = crate::workflow::get_step_by_id(mgr.conn(), "nonexistent").unwrap();
     assert!(missing.is_none());
 }
 
@@ -826,11 +844,23 @@ fn test_purge_all_terminal_statuses() {
     assert_eq!(deleted, 3);
 
     // running run must still exist
-    assert!(mgr.get_workflow_run(&r_running.id).unwrap().is_some());
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &r_running.id)
+        .unwrap()
+        .is_some());
     // terminal runs must be gone
-    assert!(mgr.get_workflow_run(&r_completed.id).unwrap().is_none());
-    assert!(mgr.get_workflow_run(&r_failed.id).unwrap().is_none());
-    assert!(mgr.get_workflow_run(&r_cancelled.id).unwrap().is_none());
+    assert!(
+        crate::workflow::get_workflow_run(mgr.conn(), &r_completed.id)
+            .unwrap()
+            .is_none()
+    );
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &r_failed.id)
+        .unwrap()
+        .is_none());
+    assert!(
+        crate::workflow::get_workflow_run(mgr.conn(), &r_cancelled.id)
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[test]
@@ -857,8 +887,14 @@ fn test_purge_single_status_filter() {
     let deleted = mgr.purge(None, &["completed"]).unwrap();
     assert_eq!(deleted, 1);
 
-    assert!(mgr.get_workflow_run(&r_completed.id).unwrap().is_none());
-    assert!(mgr.get_workflow_run(&r_failed.id).unwrap().is_some());
+    assert!(
+        crate::workflow::get_workflow_run(mgr.conn(), &r_completed.id)
+            .unwrap()
+            .is_none()
+    );
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &r_failed.id)
+        .unwrap()
+        .is_some());
 }
 
 #[test]
@@ -899,8 +935,12 @@ fn test_purge_repo_scoped() {
     let deleted = mgr.purge(Some("r1"), &["completed"]).unwrap();
     assert_eq!(deleted, 1);
 
-    assert!(mgr.get_workflow_run(&run_r1.id).unwrap().is_none());
-    assert!(mgr.get_workflow_run(&run_r2.id).unwrap().is_some());
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run_r1.id)
+        .unwrap()
+        .is_none());
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run_r2.id)
+        .unwrap()
+        .is_some());
 }
 
 #[test]
@@ -922,7 +962,7 @@ fn test_purge_cascade_deletes_steps() {
     assert_eq!(deleted, 1);
 
     // steps must be gone (cascade)
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert!(steps.is_empty());
 }
 
@@ -976,7 +1016,9 @@ fn test_purge_noop_when_no_matches() {
         .unwrap();
     assert_eq!(deleted, 0);
 
-    assert!(mgr.get_workflow_run(&run.id).unwrap().is_some());
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .is_some());
 }
 
 #[test]
@@ -1016,9 +1058,15 @@ fn test_purge_repo_scoped_does_not_delete_global_runs() {
     assert_eq!(deleted, 1);
 
     // Global run must survive.
-    assert!(mgr.get_workflow_run(&run_global.id).unwrap().is_some());
+    assert!(
+        crate::workflow::get_workflow_run(mgr.conn(), &run_global.id)
+            .unwrap()
+            .is_some()
+    );
     // w1 run must be gone.
-    assert!(mgr.get_workflow_run(&run_w1.id).unwrap().is_none());
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run_w1.id)
+        .unwrap()
+        .is_none());
 }
 
 // ---------- delete_run tests ----------
@@ -1032,7 +1080,9 @@ fn test_delete_run_removes_completed_run() {
 
     mgr.delete_run(&run.id).unwrap();
 
-    assert!(mgr.get_workflow_run(&run.id).unwrap().is_none());
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .is_none());
 }
 
 #[test]
@@ -1044,7 +1094,9 @@ fn test_delete_run_removes_failed_run() {
 
     mgr.delete_run(&run.id).unwrap();
 
-    assert!(mgr.get_workflow_run(&run.id).unwrap().is_none());
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .is_none());
 }
 
 #[test]
@@ -1056,7 +1108,9 @@ fn test_delete_run_removes_cancelled_run() {
 
     mgr.delete_run(&run.id).unwrap();
 
-    assert!(mgr.get_workflow_run(&run.id).unwrap().is_none());
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .is_none());
 }
 
 #[test]
@@ -1070,7 +1124,7 @@ fn test_delete_run_cascade_deletes_steps() {
 
     mgr.delete_run(&run.id).unwrap();
 
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert!(
         steps.is_empty(),
         "steps should be cascade-deleted with the run"
@@ -1107,7 +1161,9 @@ fn test_delete_run_rejects_running_run() {
         "deleting a running run should return an error"
     );
     // Run must still exist
-    assert!(mgr.get_workflow_run(&run.id).unwrap().is_some());
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .is_some());
 }
 
 #[test]
@@ -1121,7 +1177,9 @@ fn test_delete_run_rejects_pending_run() {
         result.is_err(),
         "deleting a pending run should return an error"
     );
-    assert!(mgr.get_workflow_run(&run.id).unwrap().is_some());
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .is_some());
 }
 
 #[test]
@@ -1168,8 +1226,14 @@ fn test_delete_run_recursive_removes_child_runs() {
     mgr.delete_run(&parent_run.id).unwrap();
 
     // Both parent and child should be gone
-    assert!(mgr.get_workflow_run(&parent_run.id).unwrap().is_none());
-    assert!(mgr.get_workflow_run(&child_run.id).unwrap().is_none());
+    assert!(
+        crate::workflow::get_workflow_run(mgr.conn(), &parent_run.id)
+            .unwrap()
+            .is_none()
+    );
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &child_run.id)
+        .unwrap()
+        .is_none());
 }
 
 #[test]
@@ -1194,9 +1258,13 @@ fn test_delete_run_does_not_affect_sibling_runs() {
 
     mgr.delete_run(&run1.id).unwrap();
 
-    assert!(mgr.get_workflow_run(&run1.id).unwrap().is_none());
+    assert!(crate::workflow::get_workflow_run(mgr.conn(), &run1.id)
+        .unwrap()
+        .is_none());
     assert!(
-        mgr.get_workflow_run(&run2.id).unwrap().is_some(),
+        crate::workflow::get_workflow_run(mgr.conn(), &run2.id)
+            .unwrap()
+            .is_some(),
         "sibling run should not be deleted"
     );
 }
@@ -1209,7 +1277,9 @@ fn test_cancel_run_pending() {
 
     mgr.cancel_run(&run.id, "user requested").unwrap();
 
-    let updated = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let updated = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(updated.status, WorkflowRunStatus::Cancelled);
 }
 
@@ -1245,10 +1315,12 @@ fn test_cancel_run_running_with_active_steps() {
     // Cancel the run — should cancel step and child agent run
     mgr.cancel_run(&run.id, "abort").unwrap();
 
-    let updated_run = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let updated_run = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(updated_run.status, WorkflowRunStatus::Cancelled);
 
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Failed);
 
     let agent_run: String = conn
@@ -1285,10 +1357,12 @@ fn test_cancel_run_waiting_status() {
 
     mgr.cancel_run(&run.id, "timed out").unwrap();
 
-    let updated = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let updated = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(updated.status, WorkflowRunStatus::Cancelled);
 
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Failed);
 }
 
@@ -1323,7 +1397,7 @@ fn test_cancel_run_skips_terminal_steps() {
 
     mgr.cancel_run(&run.id, "stop").unwrap();
 
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     let done = steps.iter().find(|s| s.id == done_step).unwrap();
     let active = steps.iter().find(|s| s.id == active_step).unwrap();
 
@@ -1821,15 +1895,15 @@ fn test_list_workflow_runs_paginated_limit_and_offset() {
     }
 
     // First page: limit=2, offset=0
-    let page1 = mgr.list_workflow_runs_paginated("w1", 2, 0).unwrap();
+    let page1 = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w1", 2, 0).unwrap();
     assert_eq!(page1.len(), 2);
 
     // Second page: limit=2, offset=2
-    let page2 = mgr.list_workflow_runs_paginated("w1", 2, 2).unwrap();
+    let page2 = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w1", 2, 2).unwrap();
     assert_eq!(page2.len(), 2);
 
     // Third page: limit=2, offset=4 — only 1 remaining
-    let page3 = mgr.list_workflow_runs_paginated("w1", 2, 4).unwrap();
+    let page3 = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w1", 2, 4).unwrap();
     assert_eq!(page3.len(), 1);
 
     // Pages must not overlap
@@ -1841,7 +1915,7 @@ fn test_list_workflow_runs_paginated_limit_and_offset() {
     );
 
     // All 5 runs returned when limit exceeds count
-    let all = mgr.list_workflow_runs_paginated("w1", 100, 0).unwrap();
+    let all = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w1", 100, 0).unwrap();
     assert_eq!(all.len(), 5);
 }
 
@@ -1865,11 +1939,11 @@ fn test_list_workflow_runs_paginated_filters_by_worktree() {
     mgr.create_workflow_run("run-w2", Some("w2"), &p2.id, false, "manual", None)
         .unwrap();
 
-    let w1_runs = mgr.list_workflow_runs_paginated("w1", 100, 0).unwrap();
+    let w1_runs = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w1", 100, 0).unwrap();
     assert_eq!(w1_runs.len(), 1);
     assert_eq!(w1_runs[0].workflow_name, "run-w1");
 
-    let w2_runs = mgr.list_workflow_runs_paginated("w2", 100, 0).unwrap();
+    let w2_runs = crate::workflow::list_workflow_runs_paginated(mgr.conn(), "w2", 100, 0).unwrap();
     assert_eq!(w2_runs.len(), 1);
     assert_eq!(w2_runs[0].workflow_name, "run-w2");
 }
@@ -1901,11 +1975,11 @@ fn test_list_workflow_runs_by_repo_id_offset_pagination() {
     }
 
     // First page
-    let page1 = mgr.list_workflow_runs_by_repo_id("r1", 2, 0).unwrap();
+    let page1 = crate::workflow::list_workflow_runs_by_repo_id(mgr.conn(), "r1", 2, 0).unwrap();
     assert_eq!(page1.len(), 2);
 
     // Second page
-    let page2 = mgr.list_workflow_runs_by_repo_id("r1", 2, 2).unwrap();
+    let page2 = crate::workflow::list_workflow_runs_by_repo_id(mgr.conn(), "r1", 2, 2).unwrap();
     assert_eq!(page2.len(), 2);
 
     // Pages must not overlap
@@ -1917,7 +1991,7 @@ fn test_list_workflow_runs_by_repo_id_offset_pagination() {
     );
 
     // Beyond end returns empty
-    let beyond = mgr.list_workflow_runs_by_repo_id("r1", 2, 10).unwrap();
+    let beyond = crate::workflow::list_workflow_runs_by_repo_id(mgr.conn(), "r1", 2, 10).unwrap();
     assert!(beyond.is_empty());
 }
 
@@ -1928,7 +2002,7 @@ fn test_list_root_workflow_runs_excludes_children() {
     insert_workflow_run(&conn, "child1", "child-wf", "running", Some("root1"));
 
     let mgr = WorkflowManager::new(&conn);
-    let roots = mgr.list_root_workflow_runs(100).unwrap();
+    let roots = crate::workflow::list_root_workflow_runs(mgr.conn(), 100).unwrap();
     let ids: Vec<&str> = roots.iter().map(|r| r.id.as_str()).collect();
     assert!(ids.contains(&"root1"), "root run should appear");
     assert!(!ids.contains(&"child1"), "child run must not appear");
@@ -1938,7 +2012,7 @@ fn test_list_root_workflow_runs_excludes_children() {
 fn test_list_root_workflow_runs_empty() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let roots = mgr.list_root_workflow_runs(100).unwrap();
+    let roots = crate::workflow::list_root_workflow_runs(mgr.conn(), 100).unwrap();
     assert!(roots.is_empty());
 }
 
@@ -1948,7 +2022,7 @@ fn test_get_active_chain_no_children() {
     insert_workflow_run(&conn, "root1", "root-wf", "running", None);
 
     let mgr = WorkflowManager::new(&conn);
-    let chain = mgr.get_active_chain_for_run("root1").unwrap();
+    let chain = crate::workflow::get_active_chain_for_run(mgr.conn(), "root1").unwrap();
     assert!(chain.is_empty(), "no children → empty chain");
 }
 
@@ -1959,7 +2033,7 @@ fn test_get_active_chain_single_child() {
     insert_workflow_run(&conn, "child1", "child-wf", "running", Some("root1"));
 
     let mgr = WorkflowManager::new(&conn);
-    let chain = mgr.get_active_chain_for_run("root1").unwrap();
+    let chain = crate::workflow::get_active_chain_for_run(mgr.conn(), "root1").unwrap();
     assert_eq!(chain.len(), 1);
     assert_eq!(chain[0].0, "child1");
     assert_eq!(chain[0].1, "child-wf");
@@ -1973,7 +2047,7 @@ fn test_get_active_chain_two_deep() {
     insert_workflow_run(&conn, "grand1", "grand-wf", "running", Some("child1"));
 
     let mgr = WorkflowManager::new(&conn);
-    let chain = mgr.get_active_chain_for_run("root1").unwrap();
+    let chain = crate::workflow::get_active_chain_for_run(mgr.conn(), "root1").unwrap();
     assert_eq!(chain.len(), 2);
     assert_eq!(chain[0], ("child1".to_string(), "child-wf".to_string()));
     assert_eq!(chain[1], ("grand1".to_string(), "grand-wf".to_string()));
@@ -1987,7 +2061,7 @@ fn test_get_active_chain_ignores_terminal_children() {
     insert_workflow_run(&conn, "child1", "child-wf", "completed", Some("root1"));
 
     let mgr = WorkflowManager::new(&conn);
-    let chain = mgr.get_active_chain_for_run("root1").unwrap();
+    let chain = crate::workflow::get_active_chain_for_run(mgr.conn(), "root1").unwrap();
     assert!(chain.is_empty(), "completed child must not appear in chain");
 }
 
@@ -1998,7 +2072,7 @@ fn test_get_step_summaries_no_children() {
     insert_running_step(&conn, "step1", "root1", "my-step");
 
     let mgr = WorkflowManager::new(&conn);
-    let summaries = mgr.get_step_summaries_for_runs(&["root1"]).unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &["root1"]).unwrap();
     let s = summaries.get("root1").expect("summary should exist");
     assert_eq!(s.step_name, "my-step");
     assert_eq!(s.iteration, 1);
@@ -2015,7 +2089,7 @@ fn test_get_step_summaries_with_child_chain() {
     insert_running_step(&conn, "step1", "child1", "leaf-step");
 
     let mgr = WorkflowManager::new(&conn);
-    let summaries = mgr.get_step_summaries_for_runs(&["root1"]).unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &["root1"]).unwrap();
     let s = summaries.get("root1").expect("summary should exist");
     assert_eq!(s.step_name, "leaf-step");
     // workflow_chain is [root_name] because child is the leaf (excluded)
@@ -2031,7 +2105,7 @@ fn test_get_step_summaries_two_deep_chain() {
     insert_running_step(&conn, "step1", "grand1", "grand-step");
 
     let mgr = WorkflowManager::new(&conn);
-    let summaries = mgr.get_step_summaries_for_runs(&["root1"]).unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &["root1"]).unwrap();
     let s = summaries.get("root1").expect("summary should exist");
     assert_eq!(s.step_name, "grand-step");
     // root + first child (grand is leaf, excluded)
@@ -2042,7 +2116,7 @@ fn test_get_step_summaries_two_deep_chain() {
 fn test_get_step_summaries_empty_run_ids() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let summaries = mgr.get_step_summaries_for_runs(&[]).unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &[]).unwrap();
     assert!(summaries.is_empty());
 }
 
@@ -2053,7 +2127,7 @@ fn test_get_step_summaries_no_running_step() {
     // no steps inserted
 
     let mgr = WorkflowManager::new(&conn);
-    let summaries = mgr.get_step_summaries_for_runs(&["root1"]).unwrap();
+    let summaries = crate::workflow::get_step_summaries_for_runs(mgr.conn(), &["root1"]).unwrap();
     assert!(
         !summaries.contains_key("root1"),
         "no running step → no entry in map"
@@ -2065,9 +2139,8 @@ fn test_resolve_run_context_run_not_found() {
     let conn = setup_db();
     let config = crate::config::Config::default();
     let mgr = WorkflowManager::new(&conn);
-    let err = mgr
-        .resolve_run_context("nonexistent-id", &config)
-        .unwrap_err();
+    let err =
+        crate::workflow::resolve_run_context(mgr.conn(), "nonexistent-id", &config).unwrap_err();
     assert!(
         err.to_string().contains("not found"),
         "expected 'not found' error, got: {err}"
@@ -2094,7 +2167,7 @@ fn test_resolve_run_context_worktree_path_exists() {
 
     let run_id = insert_workflow_run_with_targets(&conn, Some("wt-exists"), None);
     let mgr = WorkflowManager::new(&conn);
-    let ctx = mgr.resolve_run_context(&run_id, &config).unwrap();
+    let ctx = crate::workflow::resolve_run_context(mgr.conn(), &run_id, &config).unwrap();
 
     assert_eq!(ctx.working_dir, wt_path);
     assert_eq!(ctx.repo_path, "/tmp/repo"); // repo r1 from setup_db
@@ -2113,7 +2186,7 @@ fn test_resolve_run_context_worktree_path_missing() {
     // Verify the guard rejects it.
     let run_id = insert_workflow_run_with_targets(&conn, Some("w1"), None);
     let mgr = WorkflowManager::new(&conn);
-    let err = mgr.resolve_run_context(&run_id, &config).unwrap_err();
+    let err = crate::workflow::resolve_run_context(mgr.conn(), &run_id, &config).unwrap_err();
     assert!(
         err.to_string().contains("no longer exists on disk"),
         "expected disk-existence error, got: {err}"
@@ -2128,7 +2201,7 @@ fn test_resolve_run_context_repo_only() {
     // Run with only repo_id (no worktree).
     let run_id = insert_workflow_run_with_targets(&conn, None, Some("r1"));
     let mgr = WorkflowManager::new(&conn);
-    let ctx = mgr.resolve_run_context(&run_id, &config).unwrap();
+    let ctx = crate::workflow::resolve_run_context(mgr.conn(), &run_id, &config).unwrap();
 
     assert_eq!(ctx.working_dir, "/tmp/repo");
     assert_eq!(ctx.repo_path, "/tmp/repo");
@@ -2144,7 +2217,7 @@ fn test_resolve_run_context_no_worktree_no_repo() {
     // Run with neither worktree nor repo.
     let run_id = insert_workflow_run_with_targets(&conn, None, None);
     let mgr = WorkflowManager::new(&conn);
-    let err = mgr.resolve_run_context(&run_id, &config).unwrap_err();
+    let err = crate::workflow::resolve_run_context(mgr.conn(), &run_id, &config).unwrap_err();
     assert!(
         err.to_string()
             .contains("has no associated worktree or repo"),
@@ -2169,7 +2242,9 @@ fn test_set_waiting_blocked_on_atomically_sets_status_and_blocked_on() {
 
     mgr.set_waiting_blocked_on(&run.id, &blocked).unwrap();
 
-    let updated = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let updated = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(updated.status, WorkflowRunStatus::Waiting);
     assert!(updated.blocked_on.is_some());
     match updated.blocked_on.unwrap() {
@@ -2194,7 +2269,9 @@ fn test_blocked_on_cleared_when_transitioning_away_from_waiting() {
     };
     mgr.set_waiting_blocked_on(&run.id, &blocked).unwrap();
 
-    let waiting = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let waiting = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(waiting.status, WorkflowRunStatus::Waiting);
     assert!(waiting.blocked_on.is_some());
 
@@ -2202,7 +2279,9 @@ fn test_blocked_on_cleared_when_transitioning_away_from_waiting() {
     mgr.update_workflow_status(&run.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let running = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let running = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(running.status, WorkflowRunStatus::Running);
     assert!(
         running.blocked_on.is_none(),
@@ -2223,7 +2302,9 @@ fn test_malformed_blocked_on_json_is_silently_dropped() {
     .unwrap();
 
     // Reading the run should succeed with blocked_on = None
-    let loaded = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let loaded = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert!(
         loaded.blocked_on.is_none(),
         "malformed blocked_on should deserialize as None"
@@ -2391,7 +2472,9 @@ fn test_set_step_output_file() {
     mgr.set_step_output_file(&step_id, "/tmp/output.txt")
         .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.output_file.as_deref(), Some("/tmp/output.txt"));
 }
 
@@ -2415,7 +2498,9 @@ fn test_set_step_gate_info_with_prompt() {
     )
     .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.gate_type, Some(GateType::PrApproval));
     assert_eq!(step.gate_prompt.as_deref(), Some("Need 2 approvals"));
     assert_eq!(step.gate_timeout.as_deref(), Some("24h"));
@@ -2432,7 +2517,9 @@ fn test_set_step_gate_info_no_prompt() {
     mgr.set_step_gate_info(&step_id, GateType::PrChecks, None, "1h")
         .unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.gate_type, Some(GateType::PrChecks));
     assert!(step.gate_prompt.is_none());
     assert_eq!(step.gate_timeout.as_deref(), Some("1h"));
@@ -2452,7 +2539,9 @@ fn test_set_step_parallel_group() {
 
     mgr.set_step_parallel_group(&step_id, "group-abc").unwrap();
 
-    let step = mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(step.parallel_group_id.as_deref(), Some("group-abc"));
 }
 
@@ -2464,7 +2553,7 @@ fn test_set_step_parallel_group() {
 fn test_get_steps_for_runs_empty_ids() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = mgr.get_steps_for_runs(&[]).unwrap();
+    let result = crate::workflow::get_steps_for_runs(mgr.conn(), &[]).unwrap();
     assert!(result.is_empty());
 }
 
@@ -2487,7 +2576,7 @@ fn test_get_steps_for_runs_multiple_runs() {
     mgr.insert_step(&run2.id, "s3", "actor", false, 0, 0)
         .unwrap();
 
-    let result = mgr.get_steps_for_runs(&[&run1.id, &run2.id]).unwrap();
+    let result = crate::workflow::get_steps_for_runs(mgr.conn(), &[&run1.id, &run2.id]).unwrap();
     assert_eq!(result.get(&run1.id).unwrap().len(), 2);
     assert_eq!(result.get(&run2.id).unwrap().len(), 1);
 }
@@ -2521,7 +2610,7 @@ fn test_get_active_steps_for_runs_filters_by_status() {
         .unwrap();
     set_step_status(&mgr, &s4, WorkflowStepStatus::Failed);
 
-    let result = mgr.get_active_steps_for_runs(&[&run.id]).unwrap();
+    let result = crate::workflow::get_active_steps_for_runs(mgr.conn(), &[&run.id]).unwrap();
     let steps = result.get(&run.id).unwrap();
     // Only running and waiting should be returned
     assert_eq!(steps.len(), 2);
@@ -2533,7 +2622,7 @@ fn test_get_active_steps_for_runs_filters_by_status() {
 fn test_get_active_steps_for_runs_empty_ids() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let result = mgr.get_active_steps_for_runs(&[]).unwrap();
+    let result = crate::workflow::get_active_steps_for_runs(mgr.conn(), &[]).unwrap();
     assert!(result.is_empty());
 }
 
@@ -3091,7 +3180,9 @@ fn test_reap_stale_reaps_dead_agent() {
     assert_eq!(reaped[0].step_name, "code-review");
 
     // Verify the workflow run is now failed.
-    let run = mgr.get_workflow_run("stale-run").unwrap().unwrap();
+    let run = crate::workflow::get_workflow_run(mgr.conn(), "stale-run")
+        .unwrap()
+        .unwrap();
     assert_eq!(run.status, WorkflowRunStatus::Failed);
 
     // Verify the child agent run is now failed.
@@ -3123,7 +3214,9 @@ fn test_reap_stale_skips_live_agent() {
     assert!(reaped.is_empty(), "live agent should not be reaped");
 
     // Verify the workflow run is still running.
-    let run = mgr.get_workflow_run("alive-run").unwrap().unwrap();
+    let run = crate::workflow::get_workflow_run(mgr.conn(), "alive-run")
+        .unwrap()
+        .unwrap();
     assert_eq!(run.status, WorkflowRunStatus::Running);
 }
 
@@ -3971,7 +4064,7 @@ fn test_step_error_persisted_on_schema_validation_failure() {
     .unwrap();
 
     // Read the step back and assert step_error is set correctly.
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(steps.len(), 1, "expected exactly one step");
     let step = &steps[0];
     assert_eq!(step.status, WorkflowStepStatus::Failed);
@@ -4111,7 +4204,7 @@ fn test_delete_orphaned_pending_steps_removes_never_started() {
         .insert_step(&run.id, "orphan-step", "actor", false, 0, 0)
         .unwrap();
     // Confirm insert_step leaves started_at NULL and status = 'pending'.
-    let steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(steps.len(), 1);
     assert_eq!(steps[0].status, WorkflowStepStatus::Pending);
     assert!(steps[0].started_at.is_none());
@@ -4134,7 +4227,7 @@ fn test_delete_orphaned_pending_steps_removes_never_started() {
     let deleted = mgr.delete_orphaned_pending_steps(&run.id).unwrap();
     assert_eq!(deleted, 1, "exactly one orphaned row should be deleted");
 
-    let remaining = mgr.get_workflow_steps(&run.id).unwrap();
+    let remaining = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(remaining.len(), 1);
     assert_eq!(remaining[0].id, completed_id, "completed step must survive");
     assert!(
@@ -4168,7 +4261,7 @@ fn test_delete_orphaned_pending_steps_ignores_started_pending() {
         "pending step with started_at must not be deleted"
     );
 
-    let remaining = mgr.get_workflow_steps(&run.id).unwrap();
+    let remaining = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(remaining.len(), 1);
     assert_eq!(remaining[0].id, step_id);
 }
@@ -4197,7 +4290,7 @@ fn test_delete_orphaned_pending_steps_only_targets_pending() {
     let deleted = mgr.delete_orphaned_pending_steps(&run.id).unwrap();
     assert_eq!(deleted, 0, "non-pending rows must not be deleted");
 
-    let remaining = mgr.get_workflow_steps(&run.id).unwrap();
+    let remaining = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(remaining.len(), 3, "all three rows must survive");
 }
 
@@ -4230,8 +4323,7 @@ fn test_update_step_child_run_id() {
     mgr.update_step_child_run_id(&step_id, &child_run_id)
         .unwrap();
 
-    let step = mgr
-        .get_step_by_id(&step_id)
+    let step = crate::workflow::get_step_by_id(mgr.conn(), &step_id)
         .unwrap()
         .expect("step must exist");
     assert_eq!(

--- a/conductor-core/src/workflow/tests/resumption.rs
+++ b/conductor-core/src/workflow/tests/resumption.rs
@@ -9,7 +9,7 @@ use crate::agent::AgentManager;
 fn test_get_active_run_for_worktree_none_when_empty() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let active = mgr.get_active_run_for_worktree("w1").unwrap();
+    let active = crate::workflow::get_active_run_for_worktree(mgr.conn(), "w1").unwrap();
     assert!(active.is_none());
 }
 
@@ -27,7 +27,7 @@ fn test_get_active_run_for_worktree_returns_active() {
     mgr.update_workflow_status(&run.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let active = mgr.get_active_run_for_worktree("w1").unwrap();
+    let active = crate::workflow::get_active_run_for_worktree(mgr.conn(), "w1").unwrap();
     assert!(active.is_some());
     assert_eq!(active.unwrap().workflow_name, "my-flow");
 }
@@ -45,7 +45,7 @@ fn test_get_active_run_for_worktree_none_after_completion() {
     mgr.update_workflow_status(&run.id, WorkflowRunStatus::Completed, Some("done"), None)
         .unwrap();
 
-    let active = mgr.get_active_run_for_worktree("w1").unwrap();
+    let active = crate::workflow::get_active_run_for_worktree(mgr.conn(), "w1").unwrap();
     assert!(active.is_none());
 }
 
@@ -70,7 +70,7 @@ fn test_get_active_run_for_worktree_ignores_other_worktree() {
         .unwrap();
 
     // w1 should see no active runs
-    let active = mgr.get_active_run_for_worktree("w1").unwrap();
+    let active = crate::workflow::get_active_run_for_worktree(mgr.conn(), "w1").unwrap();
     assert!(active.is_none());
 }
 
@@ -83,7 +83,7 @@ fn test_reset_failed_steps() {
     // Should reset both 'failed' and 'running' steps
     assert_eq!(count, 2);
 
-    let steps = mgr.get_workflow_steps(&run_id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run_id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Completed); // unchanged
     assert_eq!(steps[1].status, WorkflowStepStatus::Pending); // was failed
     assert!(steps[1].result_text.is_none()); // cleared
@@ -98,7 +98,7 @@ fn test_reset_completed_steps() {
     let count = mgr.reset_completed_steps(&run_id).unwrap();
     assert_eq!(count, 1);
 
-    let steps = mgr.get_workflow_steps(&run_id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run_id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Pending); // was completed
     assert!(steps[0].result_text.is_none()); // cleared
     assert!(steps[0].context_out.is_none()); // cleared
@@ -113,7 +113,7 @@ fn test_reset_steps_from_position() {
     let count = mgr.reset_steps_from_position(&run_id, 1).unwrap();
     assert_eq!(count, 2); // positions 1 and 2
 
-    let steps = mgr.get_workflow_steps(&run_id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run_id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Completed); // position 0 unchanged
     assert_eq!(steps[1].status, WorkflowStepStatus::Pending);
     assert_eq!(steps[2].status, WorkflowStepStatus::Pending);
@@ -328,7 +328,9 @@ fn test_set_workflow_run_inputs_round_trip() {
         .unwrap();
 
     // Initially inputs should be empty (no inputs set yet)
-    let fetched = wf_mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert!(fetched.inputs.is_empty(), "Expected no inputs initially");
 
     // Write inputs and read back
@@ -337,7 +339,9 @@ fn test_set_workflow_run_inputs_round_trip() {
     inputs.insert("key2".to_string(), "value2".to_string());
     wf_mgr.set_workflow_run_inputs(&run.id, &inputs).unwrap();
 
-    let fetched = wf_mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         fetched.inputs.get("key1").map(String::as_str),
         Some("value1")
@@ -367,7 +371,9 @@ fn test_set_workflow_run_default_bot_name_round_trip() {
         .unwrap();
 
     // Initially default_bot_name should be None
-    let fetched = wf_mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert!(
         fetched.default_bot_name.is_none(),
         "Expected no default_bot_name initially"
@@ -378,7 +384,9 @@ fn test_set_workflow_run_default_bot_name_round_trip() {
         .set_workflow_run_default_bot_name(&run.id, "reviewer-bot")
         .unwrap();
 
-    let fetched = wf_mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         fetched.default_bot_name.as_deref(),
         Some("reviewer-bot"),
@@ -424,7 +432,9 @@ fn test_default_bot_name_persists_through_suspend_and_resume() {
         .unwrap();
 
     // Load the run as resume_workflow would — the bot name must survive the round-trip
-    let restored = wf_mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let restored = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         restored.default_bot_name.as_deref(),
         Some("deploy-bot"),
@@ -459,7 +469,9 @@ fn test_row_to_workflow_run_malformed_inputs_json_returns_empty() {
 
     // Reading back should return an empty HashMap (not panic), matching the
     // unwrap_or_else + warn fallback in row_to_workflow_run.
-    let fetched = wf_mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let fetched = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert!(
         fetched.inputs.is_empty(),
         "Expected empty inputs on malformed JSON, got: {:?}",
@@ -473,7 +485,7 @@ fn test_restart_resets_all_steps() {
     let (run_id, mgr) = setup_run_with_steps(&conn);
 
     // Verify initial state: 1 completed, 1 failed, 1 running
-    let steps = mgr.get_workflow_steps(&run_id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run_id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Completed);
     assert_eq!(steps[1].status, WorkflowStepStatus::Failed);
     assert_eq!(steps[2].status, WorkflowStepStatus::Running);
@@ -482,7 +494,7 @@ fn test_restart_resets_all_steps() {
     mgr.reset_failed_steps(&run_id).unwrap();
     mgr.reset_completed_steps(&run_id).unwrap();
 
-    let steps = mgr.get_workflow_steps(&run_id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run_id).unwrap();
     assert_eq!(
         steps[0].status,
         WorkflowStepStatus::Pending,
@@ -569,7 +581,7 @@ fn test_from_step_skip_set_and_step_map() {
     .unwrap();
 
     // Snapshot all_steps before any resets (mirrors resume_workflow: load once upfront)
-    let all_steps = mgr.get_workflow_steps(&run.id).unwrap();
+    let all_steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
 
     // Simulate the --from-step "step-b" (position 1) branch of resume_workflow
     let mut keys = completed_keys_from_steps(&all_steps);
@@ -616,7 +628,7 @@ fn test_from_step_skip_set_and_step_map() {
     );
 
     // DB state: step-a stays Completed, step-b and step-c are reset to Pending
-    let updated = mgr.get_workflow_steps(&run.id).unwrap();
+    let updated = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
     assert_eq!(
         updated[0].status,
         WorkflowStepStatus::Completed,
@@ -979,7 +991,7 @@ fn test_resume_deletes_orphaned_pending_steps() {
         .unwrap();
 
     // Confirm both rows are present before resume.
-    let steps_before = wf_mgr.get_workflow_steps(&run.id).unwrap();
+    let steps_before = crate::workflow::get_workflow_steps(wf_mgr.conn(), &run.id).unwrap();
     assert_eq!(
         steps_before.len(),
         2,
@@ -1011,7 +1023,7 @@ fn test_resume_deletes_orphaned_pending_steps() {
     );
 
     // Only the completed step should remain — the orphaned pending row is gone.
-    let steps_after = wf_mgr.get_workflow_steps(&run.id).unwrap();
+    let steps_after = crate::workflow::get_workflow_steps(wf_mgr.conn(), &run.id).unwrap();
     assert_eq!(
         steps_after.len(),
         1,
@@ -1102,7 +1114,9 @@ fn test_resume_workflow_skips_completed_steps_via_flow_engine() {
 
     // The pre-completed step must still be Completed — FlowEngine::resume() reads
     // DB post-reset and must not disturb already-completed steps.
-    let step = wf_mgr.get_step_by_id(&step_id).unwrap().unwrap();
+    let step = crate::workflow::get_step_by_id(wf_mgr.conn(), &step_id)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         step.status,
         WorkflowStepStatus::Completed,
@@ -1169,7 +1183,9 @@ fn test_spawn_heartbeat_resume_handles_failed_resume_gracefully() {
         .expect("spawn_heartbeat_resume thread panicked");
 
     // Resume failed before touching run status, so it must remain Failed.
-    let updated = wf_mgr.get_workflow_run(&run.id).unwrap().unwrap();
+    let updated = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+        .unwrap()
+        .unwrap();
     assert_eq!(
         updated.status,
         WorkflowRunStatus::Failed,

--- a/conductor-core/src/workflow/tests/resumption.rs
+++ b/conductor-core/src/workflow/tests/resumption.rs
@@ -9,7 +9,7 @@ use crate::agent::AgentManager;
 fn test_get_active_run_for_worktree_none_when_empty() {
     let conn = setup_db();
     let mgr = WorkflowManager::new(&conn);
-    let active = crate::workflow::get_active_run_for_worktree(mgr.conn(), "w1").unwrap();
+    let active = crate::workflow::get_active_run_for_worktree(&conn, "w1").unwrap();
     assert!(active.is_none());
 }
 
@@ -27,7 +27,7 @@ fn test_get_active_run_for_worktree_returns_active() {
     mgr.update_workflow_status(&run.id, WorkflowRunStatus::Running, None, None)
         .unwrap();
 
-    let active = crate::workflow::get_active_run_for_worktree(mgr.conn(), "w1").unwrap();
+    let active = crate::workflow::get_active_run_for_worktree(&conn, "w1").unwrap();
     assert!(active.is_some());
     assert_eq!(active.unwrap().workflow_name, "my-flow");
 }
@@ -45,7 +45,7 @@ fn test_get_active_run_for_worktree_none_after_completion() {
     mgr.update_workflow_status(&run.id, WorkflowRunStatus::Completed, Some("done"), None)
         .unwrap();
 
-    let active = crate::workflow::get_active_run_for_worktree(mgr.conn(), "w1").unwrap();
+    let active = crate::workflow::get_active_run_for_worktree(&conn, "w1").unwrap();
     assert!(active.is_none());
 }
 
@@ -70,7 +70,7 @@ fn test_get_active_run_for_worktree_ignores_other_worktree() {
         .unwrap();
 
     // w1 should see no active runs
-    let active = crate::workflow::get_active_run_for_worktree(mgr.conn(), "w1").unwrap();
+    let active = crate::workflow::get_active_run_for_worktree(&conn, "w1").unwrap();
     assert!(active.is_none());
 }
 
@@ -83,7 +83,7 @@ fn test_reset_failed_steps() {
     // Should reset both 'failed' and 'running' steps
     assert_eq!(count, 2);
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run_id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run_id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Completed); // unchanged
     assert_eq!(steps[1].status, WorkflowStepStatus::Pending); // was failed
     assert!(steps[1].result_text.is_none()); // cleared
@@ -98,7 +98,7 @@ fn test_reset_completed_steps() {
     let count = mgr.reset_completed_steps(&run_id).unwrap();
     assert_eq!(count, 1);
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run_id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run_id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Pending); // was completed
     assert!(steps[0].result_text.is_none()); // cleared
     assert!(steps[0].context_out.is_none()); // cleared
@@ -113,7 +113,7 @@ fn test_reset_steps_from_position() {
     let count = mgr.reset_steps_from_position(&run_id, 1).unwrap();
     assert_eq!(count, 2); // positions 1 and 2
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run_id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run_id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Completed); // position 0 unchanged
     assert_eq!(steps[1].status, WorkflowStepStatus::Pending);
     assert_eq!(steps[2].status, WorkflowStepStatus::Pending);
@@ -132,6 +132,7 @@ fn setup_standalone_run(
 ) {
     let (_tmp, db_path) = make_standalone_db();
     let conn = crate::db::open_database(&db_path).unwrap();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
@@ -241,6 +242,7 @@ fn test_resume_rejects_nonexistent_from_step() {
     let (_tmp, db_path, run_id, config) =
         setup_standalone_run(WorkflowRunStatus::Failed, Some("{}"));
     let conn = crate::db::open_database(&db_path).unwrap();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let wf_mgr = WorkflowManager::new(&conn);
 
     // Add a step so the run has steps to search through
@@ -274,6 +276,7 @@ fn test_resume_rejects_nonexistent_from_step() {
 fn test_resume_workflow_falls_back_to_repo_root_when_worktree_path_missing() {
     let (_tmp, db_path) = make_standalone_db();
     let conn = crate::db::open_database(&db_path).unwrap();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
@@ -328,7 +331,7 @@ fn test_set_workflow_run_inputs_round_trip() {
         .unwrap();
 
     // Initially inputs should be empty (no inputs set yet)
-    let fetched = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert!(fetched.inputs.is_empty(), "Expected no inputs initially");
@@ -339,7 +342,7 @@ fn test_set_workflow_run_inputs_round_trip() {
     inputs.insert("key2".to_string(), "value2".to_string());
     wf_mgr.set_workflow_run_inputs(&run.id, &inputs).unwrap();
 
-    let fetched = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -356,9 +359,9 @@ fn test_set_workflow_run_inputs_round_trip() {
 #[test]
 fn test_set_workflow_run_default_bot_name_round_trip() {
     let conn = setup_db();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
             "test-wf",
@@ -371,7 +374,7 @@ fn test_set_workflow_run_default_bot_name_round_trip() {
         .unwrap();
 
     // Initially default_bot_name should be None
-    let fetched = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert!(
@@ -384,7 +387,7 @@ fn test_set_workflow_run_default_bot_name_round_trip() {
         .set_workflow_run_default_bot_name(&run.id, "reviewer-bot")
         .unwrap();
 
-    let fetched = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -402,7 +405,7 @@ fn test_default_bot_name_persists_through_suspend_and_resume() {
     let conn = setup_db();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(&conn);
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
             "test-wf",
@@ -432,7 +435,7 @@ fn test_default_bot_name_persists_through_suspend_and_resume() {
         .unwrap();
 
     // Load the run as resume_workflow would — the bot name must survive the round-trip
-    let restored = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+    let restored = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -446,9 +449,9 @@ fn test_default_bot_name_persists_through_suspend_and_resume() {
 #[test]
 fn test_row_to_workflow_run_malformed_inputs_json_returns_empty() {
     let conn = setup_db();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
             "test-wf",
@@ -469,7 +472,7 @@ fn test_row_to_workflow_run_malformed_inputs_json_returns_empty() {
 
     // Reading back should return an empty HashMap (not panic), matching the
     // unwrap_or_else + warn fallback in row_to_workflow_run.
-    let fetched = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+    let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert!(
@@ -485,7 +488,7 @@ fn test_restart_resets_all_steps() {
     let (run_id, mgr) = setup_run_with_steps(&conn);
 
     // Verify initial state: 1 completed, 1 failed, 1 running
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run_id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run_id).unwrap();
     assert_eq!(steps[0].status, WorkflowStepStatus::Completed);
     assert_eq!(steps[1].status, WorkflowStepStatus::Failed);
     assert_eq!(steps[2].status, WorkflowStepStatus::Running);
@@ -494,7 +497,7 @@ fn test_restart_resets_all_steps() {
     mgr.reset_failed_steps(&run_id).unwrap();
     mgr.reset_completed_steps(&run_id).unwrap();
 
-    let steps = crate::workflow::get_workflow_steps(mgr.conn(), &run_id).unwrap();
+    let steps = crate::workflow::get_workflow_steps(&conn, &run_id).unwrap();
     assert_eq!(
         steps[0].status,
         WorkflowStepStatus::Pending,
@@ -581,7 +584,7 @@ fn test_from_step_skip_set_and_step_map() {
     .unwrap();
 
     // Snapshot all_steps before any resets (mirrors resume_workflow: load once upfront)
-    let all_steps = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let all_steps = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
 
     // Simulate the --from-step "step-b" (position 1) branch of resume_workflow
     let mut keys = completed_keys_from_steps(&all_steps);
@@ -628,7 +631,7 @@ fn test_from_step_skip_set_and_step_map() {
     );
 
     // DB state: step-a stays Completed, step-b and step-c are reset to Pending
-    let updated = crate::workflow::get_workflow_steps(mgr.conn(), &run.id).unwrap();
+    let updated = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(
         updated[0].status,
         WorkflowStepStatus::Completed,
@@ -675,10 +678,10 @@ fn test_from_step_skip_set_and_step_map() {
 fn test_resume_allows_restart_on_completed_run() {
     let (_tmp, db_path) = make_standalone_db();
     let conn = crate::db::open_database(&db_path).unwrap();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(&conn);
     let run = wf_mgr
         .create_workflow_run(
             "test-wf",
@@ -793,10 +796,10 @@ fn test_parallel_min_success_with_skipped_resume_agents() {
 fn test_resume_workflow_ephemeral_run_rejected() {
     let (_tmp, db_path) = make_standalone_db();
     let conn = crate::db::open_database(&db_path).unwrap();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let config = Config::default();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(&conn);
     let snapshot = serde_json::to_string(&make_empty_workflow()).unwrap();
     let run = wf_mgr
         .create_workflow_run(
@@ -840,11 +843,11 @@ fn test_resume_workflow_ephemeral_run_rejected() {
 fn test_resume_workflow_repo_target() {
     let (_tmp, db_path) = make_standalone_db();
     let conn = crate::db::open_database(&db_path).unwrap();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let config = Config::default();
 
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(&conn);
     let snapshot = serde_json::to_string(&make_empty_workflow()).unwrap();
     let run = wf_mgr
         .create_workflow_run_with_targets(
@@ -891,13 +894,13 @@ fn test_resume_workflow_repo_target() {
 fn test_resume_workflow_ticket_target() {
     let (_tmp, db_path) = make_standalone_db();
     let conn = crate::db::open_database(&db_path).unwrap();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let config = Config::default();
 
     insert_test_ticket(&conn, "tkt-1", "r1");
 
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(&conn);
     let snapshot = serde_json::to_string(&make_empty_workflow()).unwrap();
     let run = wf_mgr
         .create_workflow_run_with_targets(
@@ -950,11 +953,10 @@ fn test_resume_workflow_ticket_target() {
 fn test_resume_deletes_orphaned_pending_steps() {
     let (_tmp, db_path) = make_standalone_db();
     let conn = crate::db::open_database(&db_path).unwrap();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let config = make_resume_config();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(&conn);
-
     let snapshot = serde_json::to_string(&make_empty_workflow()).unwrap();
     let run = wf_mgr
         .create_workflow_run(
@@ -991,7 +993,7 @@ fn test_resume_deletes_orphaned_pending_steps() {
         .unwrap();
 
     // Confirm both rows are present before resume.
-    let steps_before = crate::workflow::get_workflow_steps(wf_mgr.conn(), &run.id).unwrap();
+    let steps_before = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(
         steps_before.len(),
         2,
@@ -1023,7 +1025,7 @@ fn test_resume_deletes_orphaned_pending_steps() {
     );
 
     // Only the completed step should remain — the orphaned pending row is gone.
-    let steps_after = crate::workflow::get_workflow_steps(wf_mgr.conn(), &run.id).unwrap();
+    let steps_after = crate::workflow::get_workflow_steps(&conn, &run.id).unwrap();
     assert_eq!(
         steps_after.len(),
         1,
@@ -1050,11 +1052,10 @@ fn test_resume_workflow_skips_completed_steps_via_flow_engine() {
     // Use a file-based connection so both the pre-flight phase (resume_workflow's
     // conn) and the FlowEngine execution phase share the same on-disk DB.
     let conn = crate::db::open_database(&db_path).unwrap();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let config = Config::default();
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(&conn);
-
     let snapshot = serde_json::to_string(&make_empty_workflow()).unwrap();
     let run = wf_mgr
         .create_workflow_run(
@@ -1114,7 +1115,7 @@ fn test_resume_workflow_skips_completed_steps_via_flow_engine() {
 
     // The pre-completed step must still be Completed — FlowEngine::resume() reads
     // DB post-reset and must not disturb already-completed steps.
-    let step = crate::workflow::get_step_by_id(wf_mgr.conn(), &step_id)
+    let step = crate::workflow::get_step_by_id(&conn, &step_id)
         .unwrap()
         .unwrap();
     assert_eq!(
@@ -1130,9 +1131,9 @@ fn test_resume_workflow_skips_completed_steps_via_flow_engine() {
 fn test_spawn_workflow_resume_handles_failed_resume_gracefully() {
     let (_tmp, db_path) = make_standalone_db();
     let conn = crate::db::open_database(&db_path).unwrap();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(&conn);
     // No definition_snapshot → resume will fail with "no definition snapshot"
     let run = wf_mgr
         .create_workflow_run("test-flow", Some("w1"), &parent.id, false, "manual", None)
@@ -1159,9 +1160,9 @@ fn test_spawn_heartbeat_resume_handles_failed_resume_gracefully() {
 
     let (_tmp, db_path) = make_standalone_db();
     let conn = crate::db::open_database(&db_path).unwrap();
+    let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let agent_mgr = AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let wf_mgr = WorkflowManager::new(&conn);
     // No definition_snapshot → resume will fail with "no definition snapshot"
     let run = wf_mgr
         .create_workflow_run("test-flow", Some("w1"), &parent.id, false, "manual", None)
@@ -1183,7 +1184,7 @@ fn test_spawn_heartbeat_resume_handles_failed_resume_gracefully() {
         .expect("spawn_heartbeat_resume thread panicked");
 
     // Resume failed before touching run status, so it must remain Failed.
-    let updated = crate::workflow::get_workflow_run(wf_mgr.conn(), &run.id)
+    let updated = crate::workflow::get_workflow_run(&conn, &run.id)
         .unwrap()
         .unwrap();
     assert_eq!(

--- a/conductor-core/src/workflow/tests/types.rs
+++ b/conductor-core/src/workflow/tests/types.rs
@@ -218,9 +218,9 @@ fn test_workflow_step_summary_empty_chain() {
 #[test]
 fn test_is_triggered_by_hook_true() {
     let conn = setup_db();
+    let mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let agent_mgr = crate::agent::AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let mgr = WorkflowManager::new(&conn);
     let mut run = mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "hook", None)
         .unwrap();
@@ -231,9 +231,9 @@ fn test_is_triggered_by_hook_true() {
 #[test]
 fn test_is_triggered_by_hook_false() {
     let conn = setup_db();
+    let mgr = crate::workflow::manager::WorkflowManager::new(&conn);
     let agent_mgr = crate::agent::AgentManager::new(&conn);
     let parent = agent_mgr.create_run(Some("w1"), "workflow", None).unwrap();
-    let mgr = WorkflowManager::new(&conn);
     let run = mgr
         .create_workflow_run("test", Some("w1"), &parent.id, false, "manual", None)
         .unwrap();

--- a/conductor-core/src/workflow_ephemeral.rs
+++ b/conductor-core/src/workflow_ephemeral.rs
@@ -419,7 +419,9 @@ mod tests {
         );
 
         // Fetch back from DB and confirm round-trip
-        let fetched = mgr.get_workflow_run(&run.id).unwrap().unwrap();
+        let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+            .unwrap()
+            .unwrap();
         assert!(
             fetched.worktree_id.is_none(),
             "worktree_id should remain None after DB round-trip"

--- a/conductor-core/src/workflow_ephemeral.rs
+++ b/conductor-core/src/workflow_ephemeral.rs
@@ -351,6 +351,7 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().expect("tempfile");
         let db_path = tmp.path().to_path_buf();
         let conn = crate::db::open_database(&db_path).unwrap();
+        let wf_mgr = crate::workflow::manager::WorkflowManager::new(&conn);
         crate::test_helpers::insert_test_repo(&conn, "r1", "test-repo", "/tmp/repo");
 
         let agent_mgr = AgentManager::new(&conn);
@@ -406,7 +407,6 @@ mod tests {
         let agent_mgr = AgentManager::new(&conn);
         // Ephemeral runs pass "" as worktree_id to agent_runs (stored as NULL after migration 027)
         let parent = agent_mgr.create_run(None, "workflow", None).unwrap();
-
         let mgr = WorkflowManager::new(&conn);
         let run = mgr
             .create_workflow_run("pr-flow", None, &parent.id, false, "pr", None)
@@ -419,7 +419,7 @@ mod tests {
         );
 
         // Fetch back from DB and confirm round-trip
-        let fetched = crate::workflow::get_workflow_run(mgr.conn(), &run.id)
+        let fetched = crate::workflow::get_workflow_run(&conn, &run.id)
             .unwrap()
             .unwrap();
         assert!(

--- a/conductor-tui/src/app/data_refresh.rs
+++ b/conductor-tui/src/app/data_refresh.rs
@@ -46,12 +46,12 @@ impl App {
         use conductor_core::workflow::WorkflowManager;
         if let Some(ref repo_id) = self.state.selected_repo_id.clone() {
             let wf_mgr = WorkflowManager::new(&self.conn);
-            self.state.detail_gates = wf_mgr
-                .list_waiting_gate_steps_for_repo(repo_id)
-                .unwrap_or_else(|e| {
-                    tracing::warn!("failed to load pending gates for repo {repo_id}: {e}");
-                    Vec::new()
-                });
+            self.state.detail_gates =
+                conductor_core::workflow::list_waiting_gate_steps_for_repo(wf_mgr.conn(), repo_id)
+                    .unwrap_or_else(|e| {
+                        tracing::warn!("failed to load pending gates for repo {repo_id}: {e}");
+                        Vec::new()
+                    });
         } else {
             self.state.detail_gates = Vec::new();
         }

--- a/conductor-tui/src/app/data_refresh.rs
+++ b/conductor-tui/src/app/data_refresh.rs
@@ -43,11 +43,9 @@ impl App {
     }
 
     pub(super) fn rebuild_detail_gates(&mut self) {
-        use conductor_core::workflow::WorkflowManager;
         if let Some(ref repo_id) = self.state.selected_repo_id.clone() {
-            let wf_mgr = WorkflowManager::new(&self.conn);
             self.state.detail_gates =
-                conductor_core::workflow::list_waiting_gate_steps_for_repo(wf_mgr.conn(), repo_id)
+                conductor_core::workflow::list_waiting_gate_steps_for_repo(&self.conn, repo_id)
                     .unwrap_or_else(|e| {
                         tracing::warn!("failed to load pending gates for repo {repo_id}: {e}");
                         Vec::new()

--- a/conductor-tui/src/app/workflow_management.rs
+++ b/conductor-tui/src/app/workflow_management.rs
@@ -171,26 +171,28 @@ impl App {
             self.state.data.workflow_defs.clear();
             self.state.data.workflow_def_slugs.clear();
         }
-        self.state.data.workflow_runs =
-            if let Some(ref wt_id) = self.state.selected_worktree_id.clone() {
-                wf_mgr.list_workflow_runs(wt_id).unwrap_or_else(|e| {
-                    tracing::warn!("Failed to list workflow runs for worktree '{wt_id}': {e}");
+        self.state.data.workflow_runs = if let Some(ref wt_id) =
+            self.state.selected_worktree_id.clone()
+        {
+            conductor_core::workflow::list_workflow_runs(wf_mgr.conn(), wt_id).unwrap_or_else(|e| {
+                tracing::warn!("Failed to list workflow runs for worktree '{wt_id}': {e}");
+                Default::default()
+            })
+        } else if self.state.view == View::RepoDetail {
+            let repo_id = self.state.selected_repo_id.as_deref().unwrap_or("");
+            conductor_core::workflow::list_workflow_runs_for_repo(wf_mgr.conn(), repo_id, 50)
+                .unwrap_or_else(|e| {
+                    tracing::warn!("Failed to list workflow runs for repo '{repo_id}': {e}");
                     Default::default()
                 })
-            } else if self.state.view == View::RepoDetail {
-                let repo_id = self.state.selected_repo_id.as_deref().unwrap_or("");
-                wf_mgr
-                    .list_workflow_runs_for_repo(repo_id, 50)
-                    .unwrap_or_else(|e| {
-                        tracing::warn!("Failed to list workflow runs for repo '{repo_id}': {e}");
-                        Default::default()
-                    })
-            } else {
-                wf_mgr.list_all_workflow_runs(50).unwrap_or_else(|e| {
+        } else {
+            conductor_core::workflow::list_all_workflow_runs(wf_mgr.conn(), 50).unwrap_or_else(
+                |e| {
                     tracing::warn!("Failed to list all workflow runs: {e}");
                     Default::default()
-                })
-            };
+                },
+            )
+        };
 
         // Load steps for the currently selected run
         self.state.init_collapse_state();
@@ -203,11 +205,14 @@ impl App {
 
         if let Some(ref run_id) = self.state.selected_workflow_run_id {
             let wf_mgr = WorkflowManager::new(&self.conn);
-            self.state.data.workflow_steps =
-                collapse_loop_iterations(wf_mgr.get_workflow_steps(run_id).unwrap_or_else(|e| {
-                    tracing::warn!("Failed to load steps for run '{run_id}': {e}");
-                    Default::default()
-                }));
+            self.state.data.workflow_steps = collapse_loop_iterations(
+                conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), run_id).unwrap_or_else(
+                    |e| {
+                        tracing::warn!("Failed to load steps for run '{run_id}': {e}");
+                        Default::default()
+                    },
+                ),
+            );
         } else {
             self.state.data.workflow_steps.clear();
         }
@@ -782,7 +787,8 @@ impl App {
         {
             use conductor_core::workflow::WorkflowManager;
             let wf_mgr = WorkflowManager::new(&self.conn);
-            match wf_mgr.get_active_run_for_worktree(worktree_id) {
+            match conductor_core::workflow::get_active_run_for_worktree(wf_mgr.conn(), worktree_id)
+            {
                 Ok(Some(active)) => {
                     self.state.status_message = Some(format!(
                         "Workflow '{}' is already running — cancel it before starting another",
@@ -1638,7 +1644,9 @@ impl App {
         // Otherwise, find the waiting gate and show the GateAction modal
         if let Some(ref run_id) = self.state.selected_workflow_run_id {
             let wf_mgr = WorkflowManager::new(&self.conn);
-            if let Ok(Some(step)) = wf_mgr.find_waiting_gate(run_id) {
+            if let Ok(Some(step)) =
+                conductor_core::workflow::find_waiting_gate(wf_mgr.conn(), run_id)
+            {
                 // Deserialize gate_options if present.
                 let options: Vec<String> = step
                     .gate_options
@@ -1875,7 +1883,7 @@ impl App {
     fn active_run_blocks_dispatch(&mut self, worktree_id: &str) -> bool {
         use conductor_core::workflow::WorkflowManager;
         let wf_mgr = WorkflowManager::new(&self.conn);
-        match wf_mgr.get_active_run_for_worktree(worktree_id) {
+        match conductor_core::workflow::get_active_run_for_worktree(wf_mgr.conn(), worktree_id) {
             Ok(Some(active)) => {
                 self.state.status_message = Some(format!(
                     "Workflow '{}' is already running — cancel it before starting another",

--- a/conductor-tui/src/app/workflow_management.rs
+++ b/conductor-tui/src/app/workflow_management.rs
@@ -140,10 +140,6 @@ impl App {
     }
 
     pub(super) fn reload_workflow_data(&mut self) {
-        use conductor_core::workflow::WorkflowManager;
-
-        let wf_mgr = WorkflowManager::new(&self.conn);
-
         if let Some(ref wt_id) = self.state.selected_worktree_id.clone() {
             // Worktree-scoped: load defs from FS in a background thread
             if let Some((wt_path, rp)) = self.resolve_worktree_paths(wt_id) {
@@ -174,24 +170,22 @@ impl App {
         self.state.data.workflow_runs = if let Some(ref wt_id) =
             self.state.selected_worktree_id.clone()
         {
-            conductor_core::workflow::list_workflow_runs(wf_mgr.conn(), wt_id).unwrap_or_else(|e| {
+            conductor_core::workflow::list_workflow_runs(&self.conn, wt_id).unwrap_or_else(|e| {
                 tracing::warn!("Failed to list workflow runs for worktree '{wt_id}': {e}");
                 Default::default()
             })
         } else if self.state.view == View::RepoDetail {
             let repo_id = self.state.selected_repo_id.as_deref().unwrap_or("");
-            conductor_core::workflow::list_workflow_runs_for_repo(wf_mgr.conn(), repo_id, 50)
+            conductor_core::workflow::list_workflow_runs_for_repo(&self.conn, repo_id, 50)
                 .unwrap_or_else(|e| {
                     tracing::warn!("Failed to list workflow runs for repo '{repo_id}': {e}");
                     Default::default()
                 })
         } else {
-            conductor_core::workflow::list_all_workflow_runs(wf_mgr.conn(), 50).unwrap_or_else(
-                |e| {
-                    tracing::warn!("Failed to list all workflow runs: {e}");
-                    Default::default()
-                },
-            )
+            conductor_core::workflow::list_all_workflow_runs(&self.conn, 50).unwrap_or_else(|e| {
+                tracing::warn!("Failed to list all workflow runs: {e}");
+                Default::default()
+            })
         };
 
         // Load steps for the currently selected run
@@ -201,12 +195,9 @@ impl App {
     }
 
     pub(super) fn reload_workflow_steps(&mut self) {
-        use conductor_core::workflow::WorkflowManager;
-
         if let Some(ref run_id) = self.state.selected_workflow_run_id {
-            let wf_mgr = WorkflowManager::new(&self.conn);
             self.state.data.workflow_steps = collapse_loop_iterations(
-                conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), run_id).unwrap_or_else(
+                conductor_core::workflow::get_workflow_steps(&self.conn, run_id).unwrap_or_else(
                     |e| {
                         tracing::warn!("Failed to load steps for run '{run_id}': {e}");
                         Default::default()
@@ -785,10 +776,7 @@ impl App {
             ref worktree_id, ..
         } = target
         {
-            use conductor_core::workflow::WorkflowManager;
-            let wf_mgr = WorkflowManager::new(&self.conn);
-            match conductor_core::workflow::get_active_run_for_worktree(wf_mgr.conn(), worktree_id)
-            {
+            match conductor_core::workflow::get_active_run_for_worktree(&self.conn, worktree_id) {
                 Ok(Some(active)) => {
                     self.state.status_message = Some(format!(
                         "Workflow '{}' is already running — cancel it before starting another",
@@ -1593,8 +1581,6 @@ impl App {
     }
 
     pub(super) fn handle_approve_gate(&mut self) {
-        use conductor_core::workflow::WorkflowManager;
-
         // If we're in GateAction modal, use its data
         if let Modal::GateAction {
             ref step_id,
@@ -1604,7 +1590,7 @@ impl App {
             ..
         } = self.state.modal
         {
-            let wf_mgr = WorkflowManager::new(&self.conn);
+            let wf_mgr = conductor_core::workflow::WorkflowManager::new(&self.conn);
             let fb = if feedback.is_empty() {
                 None
             } else {
@@ -1643,9 +1629,7 @@ impl App {
 
         // Otherwise, find the waiting gate and show the GateAction modal
         if let Some(ref run_id) = self.state.selected_workflow_run_id {
-            let wf_mgr = WorkflowManager::new(&self.conn);
-            if let Ok(Some(step)) =
-                conductor_core::workflow::find_waiting_gate(wf_mgr.conn(), run_id)
+            if let Ok(Some(step)) = conductor_core::workflow::find_waiting_gate(&self.conn, run_id)
             {
                 // Deserialize gate_options if present.
                 let options: Vec<String> = step
@@ -1670,10 +1654,8 @@ impl App {
     }
 
     pub(super) fn handle_reject_gate(&mut self) {
-        use conductor_core::workflow::WorkflowManager;
-
         if let Modal::GateAction { ref step_id, .. } = self.state.modal {
-            let wf_mgr = WorkflowManager::new(&self.conn);
+            let wf_mgr = conductor_core::workflow::WorkflowManager::new(&self.conn);
             match wf_mgr.reject_gate(step_id, "tui-user", None) {
                 Ok(()) => {
                     self.state.status_message = Some("Gate rejected".to_string());
@@ -1881,9 +1863,7 @@ impl App {
     /// an active run (or fails), signalling the caller to abort the dispatch.
     /// Returns `false` when no active run is found and dispatch may proceed.
     fn active_run_blocks_dispatch(&mut self, worktree_id: &str) -> bool {
-        use conductor_core::workflow::WorkflowManager;
-        let wf_mgr = WorkflowManager::new(&self.conn);
-        match conductor_core::workflow::get_active_run_for_worktree(wf_mgr.conn(), worktree_id) {
+        match conductor_core::workflow::get_active_run_for_worktree(&self.conn, worktree_id) {
             Ok(Some(active)) => {
                 self.state.status_message = Some(format!(
                     "Workflow '{}' is already running — cancel it before starting another",
@@ -2032,8 +2012,6 @@ impl App {
 
     /// Handle the `ToggleWorkflowRunDismissed` action.
     pub(super) fn handle_toggle_workflow_run_dismissed(&mut self) {
-        use conductor_core::workflow::WorkflowManager;
-
         let Some(run_id) = self.state.selected_workflow_run_id.clone() else {
             self.state.status_message = Some("No workflow run selected".to_string());
             return;
@@ -2069,7 +2047,7 @@ impl App {
                 let db_path = conductor_core::config::db_path();
                 let conn =
                     conductor_core::db::open_database(&db_path).map_err(|e| e.to_string())?;
-                WorkflowManager::new(&conn)
+                conductor_core::workflow::WorkflowManager::new(&conn)
                     .set_dismissed(&run_id_clone, new_dismissed)
                     .map_err(|e| e.to_string())
             })();
@@ -2087,8 +2065,6 @@ impl App {
     /// guards against deleting non-terminal runs, then spawns a background thread
     /// to call `WorkflowManager::delete_run`. Sends `WorkflowDeleteComplete` when done.
     pub(super) fn handle_delete_workflow_run(&mut self) {
-        use conductor_core::workflow::WorkflowManager;
-
         // Resolve the run ID: in the detail view use the selected run; in the list
         // view use the currently highlighted row.
         let run_id = if self.state.view == View::WorkflowRunDetail {
@@ -2140,7 +2116,7 @@ impl App {
                 let db_path = conductor_core::config::db_path();
                 let conn =
                     conductor_core::db::open_database(&db_path).map_err(|e| e.to_string())?;
-                WorkflowManager::new(&conn)
+                conductor_core::workflow::WorkflowManager::new(&conn)
                     .delete_run(&run_id)
                     .map_err(|e| e.to_string())
             })();

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -142,10 +142,9 @@ pub fn spawn_db_poller(
 
                             // Fire cost/duration spike notifications for completed root runs.
                             if t.succeeded && t.parent_workflow_run_id.is_none() {
-                                let wf_mgr = conductor_core::workflow::WorkflowManager::new(conn);
                                 if let Ok(Some(baseline)) =
                                     conductor_core::workflow::get_workflow_spike_baseline(
-                                        wf_mgr.conn(),
+                                        conn,
                                         &t.workflow_name,
                                         30,
                                         5,
@@ -603,16 +602,13 @@ pub fn poll_data(
         (Vec::new(), None)
     };
 
-    use conductor_core::workflow::{WorkflowManager, WorkflowRunStatus};
-    let wf_mgr = WorkflowManager::new(&conn);
+    use conductor_core::workflow::WorkflowRunStatus;
     // Build a per-worktree map of the most recent *root* run for inline indicators.
     // Using list_root_workflow_runs ensures the parent run wins the per-worktree slot
     // rather than a concurrently-active child sub-workflow run.
     // Fetch recent runs sorted DESC; the first entry per worktree_id wins.
     let mut latest_workflow_runs_by_worktree = std::collections::HashMap::new();
-    for run in
-        conductor_core::workflow::list_root_workflow_runs(wf_mgr.conn(), 100).unwrap_or_default()
-    {
+    for run in conductor_core::workflow::list_root_workflow_runs(&conn, 100).unwrap_or_default() {
         // Skip ephemeral runs (no registered worktree) — they have no worktree
         // entry to display inline indicators for.
         if let Some(ref wt_id) = run.worktree_id {
@@ -624,7 +620,7 @@ pub fn poll_data(
 
     // Fetch active non-worktree workflow runs (repo/ticket-targeted).
     let active_non_worktree_workflow_runs =
-        conductor_core::workflow::list_active_non_worktree_workflow_runs(wf_mgr.conn(), 50)
+        conductor_core::workflow::list_active_non_worktree_workflow_runs(&conn, 50)
             .unwrap_or_default();
 
     // Collect IDs of active runs to fetch current step summaries in a single batch query.
@@ -645,7 +641,7 @@ pub fn poll_data(
         .collect();
     let active_run_id_refs: Vec<&str> = active_run_ids.iter().map(|s| s.as_str()).collect();
     let workflow_step_summaries =
-        conductor_core::workflow::get_step_summaries_for_runs(wf_mgr.conn(), &active_run_id_refs)
+        conductor_core::workflow::get_step_summaries_for_runs(&conn, &active_run_id_refs)
             .unwrap_or_default();
 
     // ── Time estimation for active workflow runs ──
@@ -670,7 +666,7 @@ pub fn poll_data(
         let active_est_run_id_refs: Vec<&str> =
             active_est_run_ids.iter().map(|s| s.as_str()).collect();
         let all_steps_by_run =
-            conductor_core::workflow::get_steps_for_runs(wf_mgr.conn(), &active_est_run_id_refs)
+            conductor_core::workflow::get_steps_for_runs(&conn, &active_est_run_id_refs)
                 .unwrap_or_default();
 
         // Cache step histories per workflow name to avoid redundant queries
@@ -684,7 +680,7 @@ pub fn poll_data(
                 .entry(run.workflow_name.clone())
                 .or_insert_with(|| {
                     conductor_core::workflow::get_completed_step_durations(
-                        wf_mgr.conn(),
+                        &conn,
                         &run.workflow_name,
                         20,
                     )
@@ -694,7 +690,7 @@ pub fn poll_data(
             if step_histories.is_empty() {
                 // Fall back to workflow-level estimate
                 let hist = conductor_core::workflow::get_completed_run_durations(
-                    wf_mgr.conn(),
+                    &conn,
                     &run.workflow_name,
                     20,
                 )
@@ -739,7 +735,7 @@ pub fn poll_data(
             })
     });
     let waiting_gate_steps = query_if_enabled(config.notifications.enabled, || {
-        conductor_core::workflow::list_all_waiting_gate_steps(wf_mgr.conn()).unwrap_or_else(|e| {
+        conductor_core::workflow::list_all_waiting_gate_steps(&conn).unwrap_or_else(|e| {
             tracing::warn!("list_all_waiting_gate_steps failed: {e}");
             vec![]
         })
@@ -1022,7 +1018,7 @@ fn poll_workflow_data(
     selected_run_id: Option<&str>,
     selected_step_child_run_id: Option<&str>,
 ) -> Option<Action> {
-    use conductor_core::workflow::{WorkflowDef, WorkflowManager, WorkflowWarning};
+    use conductor_core::workflow::{WorkflowDef, WorkflowWarning};
 
     let db = db_path();
     let conn = open_database(&db).ok()?;
@@ -1169,17 +1165,16 @@ fn poll_workflow_data(
         }
         (Some(all_defs), Some(all_slugs), all_warnings)
     };
-    let wf_mgr = WorkflowManager::new(&conn);
+    let wf_mgr = conductor_core::workflow::WorkflowManager::new(&conn);
     let runs = if let Some(wt_id) = worktree_id {
-        conductor_core::workflow::list_workflow_runs(wf_mgr.conn(), wt_id).unwrap_or_default()
+        conductor_core::workflow::list_workflow_runs(&conn, wt_id).unwrap_or_default()
     } else if let Some(rid) = repo_id {
-        conductor_core::workflow::list_workflow_runs_for_repo(wf_mgr.conn(), rid, 50)
-            .unwrap_or_default()
+        conductor_core::workflow::list_workflow_runs_for_repo(&conn, rid, 50).unwrap_or_default()
     } else {
-        conductor_core::workflow::list_all_workflow_runs(wf_mgr.conn(), 50).unwrap_or_default()
+        conductor_core::workflow::list_all_workflow_runs(&conn, 50).unwrap_or_default()
     };
     let steps = if let Some(run_id) = selected_run_id {
-        conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), run_id).unwrap_or_default()
+        conductor_core::workflow::get_workflow_steps(&conn, run_id).unwrap_or_default()
     } else {
         Vec::new()
     };
@@ -1188,14 +1183,14 @@ fn poll_workflow_data(
     // 1. Direct-call steps on non-leaf parents are available for interleaving
     // 2. Step detail panel works for non-leaf parents
     let all_run_ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
-    let mut all_run_steps =
-        match conductor_core::workflow::get_steps_for_runs(wf_mgr.conn(), &all_run_ids) {
-            Ok(steps) => steps,
-            Err(e) => {
-                tracing::warn!("get_steps_for_runs failed for runs {:?}: {e}", all_run_ids);
-                Default::default()
-            }
-        };
+    let mut all_run_steps = match conductor_core::workflow::get_steps_for_runs(&conn, &all_run_ids)
+    {
+        Ok(steps) => steps,
+        Err(e) => {
+            tracing::warn!("get_steps_for_runs failed for runs {:?}: {e}", all_run_ids);
+            Default::default()
+        }
+    };
 
     // Ancestor fetch: collect parent_workflow_run_id values that aren't in the
     // current run set and fetch their steps too. This covers global/repo 50-run-limit
@@ -1211,7 +1206,7 @@ fn poll_workflow_data(
         .collect();
     if !ancestor_ids.is_empty() {
         let ancestor_refs: Vec<&str> = ancestor_ids.iter().map(|s| s.as_str()).collect();
-        match conductor_core::workflow::get_steps_for_runs(wf_mgr.conn(), &ancestor_refs) {
+        match conductor_core::workflow::get_steps_for_runs(&conn, &ancestor_refs) {
             Ok(ancestor_steps) => all_run_steps.extend(ancestor_steps),
             Err(e) => {
                 tracing::warn!(

--- a/conductor-tui/src/background.rs
+++ b/conductor-tui/src/background.rs
@@ -144,7 +144,12 @@ pub fn spawn_db_poller(
                             if t.succeeded && t.parent_workflow_run_id.is_none() {
                                 let wf_mgr = conductor_core::workflow::WorkflowManager::new(conn);
                                 if let Ok(Some(baseline)) =
-                                    wf_mgr.get_workflow_spike_baseline(&t.workflow_name, 30, 5)
+                                    conductor_core::workflow::get_workflow_spike_baseline(
+                                        wf_mgr.conn(),
+                                        &t.workflow_name,
+                                        30,
+                                        5,
+                                    )
                                 {
                                     // Cost spike detection
                                     if let Some(run) = run_by_id.get(t.run_id.as_str()) {
@@ -605,7 +610,9 @@ pub fn poll_data(
     // rather than a concurrently-active child sub-workflow run.
     // Fetch recent runs sorted DESC; the first entry per worktree_id wins.
     let mut latest_workflow_runs_by_worktree = std::collections::HashMap::new();
-    for run in wf_mgr.list_root_workflow_runs(100).unwrap_or_default() {
+    for run in
+        conductor_core::workflow::list_root_workflow_runs(wf_mgr.conn(), 100).unwrap_or_default()
+    {
         // Skip ephemeral runs (no registered worktree) — they have no worktree
         // entry to display inline indicators for.
         if let Some(ref wt_id) = run.worktree_id {
@@ -616,9 +623,9 @@ pub fn poll_data(
     }
 
     // Fetch active non-worktree workflow runs (repo/ticket-targeted).
-    let active_non_worktree_workflow_runs = wf_mgr
-        .list_active_non_worktree_workflow_runs(50)
-        .unwrap_or_default();
+    let active_non_worktree_workflow_runs =
+        conductor_core::workflow::list_active_non_worktree_workflow_runs(wf_mgr.conn(), 50)
+            .unwrap_or_default();
 
     // Collect IDs of active runs to fetch current step summaries in a single batch query.
     let active_run_ids: Vec<String> = latest_workflow_runs_by_worktree
@@ -637,9 +644,9 @@ pub fn poll_data(
         )
         .collect();
     let active_run_id_refs: Vec<&str> = active_run_ids.iter().map(|s| s.as_str()).collect();
-    let workflow_step_summaries = wf_mgr
-        .get_step_summaries_for_runs(&active_run_id_refs)
-        .unwrap_or_default();
+    let workflow_step_summaries =
+        conductor_core::workflow::get_step_summaries_for_runs(wf_mgr.conn(), &active_run_id_refs)
+            .unwrap_or_default();
 
     // ── Time estimation for active workflow runs ──
     let workflow_run_estimates = {
@@ -662,9 +669,9 @@ pub fn poll_data(
         let active_est_run_ids: Vec<String> = active_runs.iter().map(|r| r.id.clone()).collect();
         let active_est_run_id_refs: Vec<&str> =
             active_est_run_ids.iter().map(|s| s.as_str()).collect();
-        let all_steps_by_run = wf_mgr
-            .get_steps_for_runs(&active_est_run_id_refs)
-            .unwrap_or_default();
+        let all_steps_by_run =
+            conductor_core::workflow::get_steps_for_runs(wf_mgr.conn(), &active_est_run_id_refs)
+                .unwrap_or_default();
 
         // Cache step histories per workflow name to avoid redundant queries
         let mut step_history_cache: std::collections::HashMap<
@@ -676,16 +683,22 @@ pub fn poll_data(
             let step_histories = step_history_cache
                 .entry(run.workflow_name.clone())
                 .or_insert_with(|| {
-                    wf_mgr
-                        .get_completed_step_durations(&run.workflow_name, 20)
-                        .unwrap_or_default()
+                    conductor_core::workflow::get_completed_step_durations(
+                        wf_mgr.conn(),
+                        &run.workflow_name,
+                        20,
+                    )
+                    .unwrap_or_default()
                 });
 
             if step_histories.is_empty() {
                 // Fall back to workflow-level estimate
-                let hist = wf_mgr
-                    .get_completed_run_durations(&run.workflow_name, 20)
-                    .unwrap_or_default();
+                let hist = conductor_core::workflow::get_completed_run_durations(
+                    wf_mgr.conn(),
+                    &run.workflow_name,
+                    20,
+                )
+                .unwrap_or_default();
                 if let Some(est) = estimation::estimate_with_confidence(None, &hist) {
                     let remaining =
                         estimation::estimated_remaining_ms(est.point_ms, &run.started_at);
@@ -726,7 +739,7 @@ pub fn poll_data(
             })
     });
     let waiting_gate_steps = query_if_enabled(config.notifications.enabled, || {
-        wf_mgr.list_all_waiting_gate_steps().unwrap_or_else(|e| {
+        conductor_core::workflow::list_all_waiting_gate_steps(wf_mgr.conn()).unwrap_or_else(|e| {
             tracing::warn!("list_all_waiting_gate_steps failed: {e}");
             vec![]
         })
@@ -1158,16 +1171,15 @@ fn poll_workflow_data(
     };
     let wf_mgr = WorkflowManager::new(&conn);
     let runs = if let Some(wt_id) = worktree_id {
-        wf_mgr.list_workflow_runs(wt_id).unwrap_or_default()
+        conductor_core::workflow::list_workflow_runs(wf_mgr.conn(), wt_id).unwrap_or_default()
     } else if let Some(rid) = repo_id {
-        wf_mgr
-            .list_workflow_runs_for_repo(rid, 50)
+        conductor_core::workflow::list_workflow_runs_for_repo(wf_mgr.conn(), rid, 50)
             .unwrap_or_default()
     } else {
-        wf_mgr.list_all_workflow_runs(50).unwrap_or_default()
+        conductor_core::workflow::list_all_workflow_runs(wf_mgr.conn(), 50).unwrap_or_default()
     };
     let steps = if let Some(run_id) = selected_run_id {
-        wf_mgr.get_workflow_steps(run_id).unwrap_or_default()
+        conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), run_id).unwrap_or_default()
     } else {
         Vec::new()
     };
@@ -1176,13 +1188,14 @@ fn poll_workflow_data(
     // 1. Direct-call steps on non-leaf parents are available for interleaving
     // 2. Step detail panel works for non-leaf parents
     let all_run_ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
-    let mut all_run_steps = match wf_mgr.get_steps_for_runs(&all_run_ids) {
-        Ok(steps) => steps,
-        Err(e) => {
-            tracing::warn!("get_steps_for_runs failed for runs {:?}: {e}", all_run_ids);
-            Default::default()
-        }
-    };
+    let mut all_run_steps =
+        match conductor_core::workflow::get_steps_for_runs(wf_mgr.conn(), &all_run_ids) {
+            Ok(steps) => steps,
+            Err(e) => {
+                tracing::warn!("get_steps_for_runs failed for runs {:?}: {e}", all_run_ids);
+                Default::default()
+            }
+        };
 
     // Ancestor fetch: collect parent_workflow_run_id values that aren't in the
     // current run set and fetch their steps too. This covers global/repo 50-run-limit
@@ -1198,7 +1211,7 @@ fn poll_workflow_data(
         .collect();
     if !ancestor_ids.is_empty() {
         let ancestor_refs: Vec<&str> = ancestor_ids.iter().map(|s| s.as_str()).collect();
-        match wf_mgr.get_steps_for_runs(&ancestor_refs) {
+        match conductor_core::workflow::get_steps_for_runs(wf_mgr.conn(), &ancestor_refs) {
             Ok(ancestor_steps) => all_run_steps.extend(ancestor_steps),
             Err(e) => {
                 tracing::warn!(

--- a/conductor-web/src/main.rs
+++ b/conductor-web/src/main.rs
@@ -376,7 +376,8 @@ async fn main() -> Result<()> {
                 }
 
                 // Detect workflow run terminal transitions and fire notifications.
-                let workflow_runs = wf_mgr.list_all_workflow_runs(200)?;
+                let workflow_runs =
+                    conductor_core::workflow::list_all_workflow_runs(wf_mgr.conn(), 200)?;
                 let wf_transitions = conductor_web::notify::detect_workflow_terminal_transitions(
                     workflow_runs.iter(),
                     &mut wf_seen,
@@ -457,7 +458,12 @@ async fn main() -> Result<()> {
                     for t in &wf_transitions {
                         if t.succeeded && t.parent_workflow_run_id.is_none() {
                             if let Ok(Some(baseline)) =
-                                wf_mgr.get_workflow_spike_baseline(&t.workflow_name, 30, 5)
+                                conductor_core::workflow::get_workflow_spike_baseline(
+                                    wf_mgr.conn(),
+                                    &t.workflow_name,
+                                    30,
+                                    5,
+                                )
                             {
                                 if let Some(run) = run_by_id.get(t.run_id.as_str()) {
                                     if let Some(cost_usd) = run.total_cost_usd {
@@ -517,7 +523,8 @@ async fn main() -> Result<()> {
 
                 // Fire gate-pending-too-long notifications.
                 {
-                    let waiting_steps = wf_mgr.list_all_waiting_gate_steps()?;
+                    let waiting_steps =
+                        conductor_core::workflow::list_all_waiting_gate_steps(wf_mgr.conn())?;
                     let now_ms = std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap_or_default()

--- a/conductor-web/src/main.rs
+++ b/conductor-web/src/main.rs
@@ -376,8 +376,7 @@ async fn main() -> Result<()> {
                 }
 
                 // Detect workflow run terminal transitions and fire notifications.
-                let workflow_runs =
-                    conductor_core::workflow::list_all_workflow_runs(wf_mgr.conn(), 200)?;
+                let workflow_runs = conductor_core::workflow::list_all_workflow_runs(&conn, 200)?;
                 let wf_transitions = conductor_web::notify::detect_workflow_terminal_transitions(
                     workflow_runs.iter(),
                     &mut wf_seen,
@@ -459,7 +458,7 @@ async fn main() -> Result<()> {
                         if t.succeeded && t.parent_workflow_run_id.is_none() {
                             if let Ok(Some(baseline)) =
                                 conductor_core::workflow::get_workflow_spike_baseline(
-                                    wf_mgr.conn(),
+                                    &conn,
                                     &t.workflow_name,
                                     30,
                                     5,
@@ -524,7 +523,7 @@ async fn main() -> Result<()> {
                 // Fire gate-pending-too-long notifications.
                 {
                     let waiting_steps =
-                        conductor_core::workflow::list_all_waiting_gate_steps(wf_mgr.conn())?;
+                        conductor_core::workflow::list_all_waiting_gate_steps(&conn)?;
                     let now_ms = std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap_or_default()

--- a/conductor-web/src/routes/slack.rs
+++ b/conductor-web/src/routes/slack.rs
@@ -164,7 +164,7 @@ async fn handle_active(state: &AppState) -> SlackResponse {
     let db = state.db.lock().await;
     let wf_mgr = WorkflowManager::new(&db);
 
-    let runs = match wf_mgr.list_active_workflow_runs(&[]) {
+    let runs = match conductor_core::workflow::list_active_workflow_runs(wf_mgr.conn(), &[]) {
         Ok(r) => r,
         Err(e) => {
             tracing::error!(error = %e, "Failed to list active workflow runs for Slack command");

--- a/conductor-web/src/routes/slack.rs
+++ b/conductor-web/src/routes/slack.rs
@@ -6,7 +6,7 @@ use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 
-use conductor_core::workflow::{WorkflowManager, WorkflowRun, WorkflowRunStatus};
+use conductor_core::workflow::{WorkflowRun, WorkflowRunStatus};
 
 use crate::state::AppState;
 

--- a/conductor-web/src/routes/slack.rs
+++ b/conductor-web/src/routes/slack.rs
@@ -162,9 +162,7 @@ pub async fn handle_slash_command(
 
 async fn handle_active(state: &AppState) -> SlackResponse {
     let db = state.db.lock().await;
-    let wf_mgr = WorkflowManager::new(&db);
-
-    let runs = match conductor_core::workflow::list_active_workflow_runs(wf_mgr.conn(), &[]) {
+    let runs = match conductor_core::workflow::list_active_workflow_runs(&db, &[]) {
         Ok(r) => r,
         Err(e) => {
             tracing::error!(error = %e, "Failed to list active workflow runs for Slack command");

--- a/conductor-web/src/routes/workflows.rs
+++ b/conductor-web/src/routes/workflows.rs
@@ -643,8 +643,8 @@ pub async fn run_workflow(
     ))
 }
 
-fn check_no_active_run(wf_mgr: &WorkflowManager<'_>, wt_id: &str) -> Result<(), ApiError> {
-    if let Some(active) = conductor_core::workflow::get_active_run_for_worktree(&db, wt_id)? {
+fn check_no_active_run(conn: &rusqlite::Connection, wt_id: &str) -> Result<(), ApiError> {
+    if let Some(active) = conductor_core::workflow::get_active_run_for_worktree(conn, wt_id)? {
         return Err(ApiError::Core(ConductorError::WorkflowRunAlreadyActive {
             name: active.workflow_name,
         }));
@@ -690,7 +690,7 @@ pub async fn post_workflow_run(
                 let wt = wt_mgr.get_by_id_for_repo(wt_id, &repo.id)?;
 
                 // Reject if a top-level workflow run is already active on this worktree
-                check_no_active_run(&wf_mgr, wt_id)?;
+                check_no_active_run(&db, wt_id)?;
 
                 let path = wt.path.clone();
                 let slug = wt.slug.clone();
@@ -712,7 +712,7 @@ pub async fn post_workflow_run(
                     })?;
 
                 // Reject if a top-level workflow run is already active on this worktree
-                check_no_active_run(&wf_mgr, &active_wt.id)?;
+                check_no_active_run(&db, &active_wt.id)?;
 
                 let path = active_wt.path.clone();
                 let slug = active_wt.slug.clone();
@@ -973,7 +973,6 @@ pub async fn list_all_workflow_runs_handler(
 
     let db = state.db.lock().await;
     let config = state.config.read().await;
-    let mgr = WorkflowManager::new(&db);
     let runs = if let Some(ref repo_id) = params.repo {
         let repo = RepoManager::new(&db, &config).get_by_id(repo_id)?;
         conductor_core::workflow::list_active_workflow_runs_for_repo(&db, &repo.id, &statuses)?
@@ -1200,7 +1199,6 @@ pub async fn list_workflow_runs(
     Path(worktree_id): Path<String>,
 ) -> Result<Json<Vec<WorkflowRun>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let runs = conductor_core::workflow::list_workflow_runs(&db, &worktree_id)?;
     Ok(Json(runs))
 }
@@ -1223,7 +1221,6 @@ pub async fn get_workflow_run(
     Path(id): Path<String>,
 ) -> Result<Json<WorkflowRun>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let run = conductor_core::workflow::get_workflow_run(&db, &id)?
         .ok_or_else(|| ApiError::Core(ConductorError::WorkflowRunNotFound { id: id.clone() }))?;
     Ok(Json(run))
@@ -1247,7 +1244,6 @@ pub async fn get_workflow_steps(
     Path(id): Path<String>,
 ) -> Result<Json<Vec<WorkflowRunStep>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let steps = conductor_core::workflow::get_workflow_steps(&db, &id)?;
     Ok(Json(steps))
 }
@@ -1295,7 +1291,6 @@ pub async fn get_token_aggregates(
     Query(q): Query<AggregatesQuery>,
 ) -> Result<Json<Vec<WorkflowTokenAggregate>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let rows = conductor_core::workflow::get_workflow_token_aggregates(&db, q.repo_id.as_deref())?;
     Ok(Json(rows))
 }
@@ -1321,7 +1316,6 @@ pub async fn get_token_trend(
     Query(q): Query<TrendQuery>,
 ) -> Result<Json<Vec<WorkflowTokenTrendRow>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let granularity = parse_granularity(q.granularity)?;
     let rows =
         conductor_core::workflow::get_workflow_token_trend(&db, &q.workflow_name, granularity)?;
@@ -1349,7 +1343,6 @@ pub async fn get_step_heatmap(
     Query(q): Query<HeatmapQuery>,
 ) -> Result<Json<Vec<StepTokenHeatmapRow>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let limit = q.runs.unwrap_or(20);
     let rows = conductor_core::workflow::get_step_token_heatmap(&db, &q.workflow_name, limit)?;
     Ok(Json(rows))
@@ -1376,7 +1369,6 @@ pub async fn get_run_metrics(
     Query(q): Query<RunMetricsQuery>,
 ) -> Result<Json<Vec<WorkflowRunMetricsRow>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let days = q.days.unwrap_or(30);
     let rows = conductor_core::workflow::get_run_metrics(&db, &q.workflow_name, days)?;
     Ok(Json(rows))
@@ -1397,7 +1389,6 @@ pub async fn get_failure_trend(
     Query(q): Query<TrendQuery>,
 ) -> Result<Json<Vec<WorkflowFailureRateTrendRow>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let granularity = parse_granularity(q.granularity)?;
     let rows = conductor_core::workflow::get_workflow_failure_rate_trend(
         &db,
@@ -1422,7 +1413,6 @@ pub async fn get_failure_heatmap(
     Query(q): Query<HeatmapQuery>,
 ) -> Result<Json<Vec<StepFailureHeatmapRow>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let limit = q.runs.unwrap_or(20);
     let rows = conductor_core::workflow::get_step_failure_heatmap(&db, &q.workflow_name, limit)?;
     Ok(Json(rows))
@@ -1443,7 +1433,6 @@ pub async fn get_step_retry_analytics(
     Query(q): Query<HeatmapQuery>,
 ) -> Result<Json<Vec<StepRetryAnalyticsRow>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let limit = q.runs.unwrap_or(20);
     let rows = conductor_core::workflow::get_step_retry_analytics(&db, &q.workflow_name, limit)?;
     Ok(Json(rows))
@@ -1470,7 +1459,6 @@ pub async fn get_workflow_percentiles(
     Query(q): Query<PercentilesQuery>,
 ) -> Result<Json<Option<WorkflowPercentiles>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let days = q.days.unwrap_or(30);
     let result = conductor_core::workflow::get_workflow_percentiles(&db, &q.workflow_name, days)?;
     Ok(Json(result))
@@ -1498,7 +1486,6 @@ pub async fn get_workflow_regressions(
     Query(q): Query<RegressionsQuery>,
 ) -> Result<Json<Vec<WorkflowRegressionSignal>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let recent_days = q.recent_days.unwrap_or(7);
     let baseline_days = q.baseline_days.unwrap_or(30);
     let min_runs = q.min_runs.unwrap_or(REGRESSION_MIN_RECENT_RUNS);
@@ -1532,7 +1519,6 @@ pub async fn get_gate_analytics(
     Query(q): Query<GateAnalyticsQuery>,
 ) -> Result<Json<Vec<GateAnalyticsRow>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let days = q.days.unwrap_or(30);
     let rows = conductor_core::workflow::get_gate_analytics(&db, &q.workflow_name, days)?;
     Ok(Json(rows))
@@ -1551,7 +1537,6 @@ pub async fn get_pending_gates(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<PendingGateAnalyticsRow>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let rows = conductor_core::workflow::get_all_pending_gates(&db)?;
     Ok(Json(rows))
 }
@@ -1638,7 +1623,6 @@ pub async fn get_child_workflow_runs(
     Path(id): Path<String>,
 ) -> Result<Json<Vec<WorkflowRun>>, ApiError> {
     let db = state.db.lock().await;
-    let mgr = WorkflowManager::new(&db);
     let children = conductor_core::workflow::list_child_workflow_runs(&db, &id)?;
     Ok(Json(children))
 }
@@ -1708,7 +1692,6 @@ pub async fn resume_workflow_endpoint(
     // Also capture the workflow name and target label for the completion notification.
     let (workflow_name, target_label, run_repo_id, run_worktree_id) = {
         let db = state.db.lock().await;
-        let mgr = WorkflowManager::new(&db);
         let run = conductor_core::workflow::get_workflow_run(&db, &id)?.ok_or_else(|| {
             ApiError::Core(ConductorError::WorkflowRunNotFound { id: id.clone() })
         })?;
@@ -1821,10 +1804,10 @@ pub async fn resume_workflow_endpoint(
 }
 
 fn find_waiting_gate_or_err(
-    mgr: &WorkflowManager<'_>,
+    conn: &rusqlite::Connection,
     run_id: &str,
 ) -> Result<WorkflowRunStep, ApiError> {
-    conductor_core::workflow::find_waiting_gate(&db, run_id)?.ok_or_else(|| {
+    conductor_core::workflow::find_waiting_gate(conn, run_id)?.ok_or_else(|| {
         ApiError::Core(ConductorError::Workflow(
             "No waiting gate found for this workflow run".to_string(),
         ))
@@ -1861,7 +1844,7 @@ pub async fn approve_gate(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
 
-    let step = find_waiting_gate_or_err(&mgr, &id)?;
+    let step = find_waiting_gate_or_err(&db, &id)?;
 
     let approved_by = std::env::var("USER").unwrap_or_else(|_| "user".to_string());
     let context_out = req
@@ -1919,7 +1902,7 @@ pub async fn reject_gate(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
 
-    let step = find_waiting_gate_or_err(&mgr, &id)?;
+    let step = find_waiting_gate_or_err(&db, &id)?;
 
     let rejected_by = std::env::var("USER").unwrap_or_else(|_| "user".to_string());
     mgr.reject_gate(&step.id, &rejected_by, None)?;

--- a/conductor-web/src/routes/workflows.rs
+++ b/conductor-web/src/routes/workflows.rs
@@ -461,7 +461,9 @@ pub async fn run_workflow(
 
         // Reject if a top-level workflow run is already active on this worktree
         let wf_mgr = WorkflowManager::new(&db);
-        if let Some(active) = wf_mgr.get_active_run_for_worktree(&worktree_id)? {
+        if let Some(active) =
+            conductor_core::workflow::get_active_run_for_worktree(wf_mgr.conn(), &worktree_id)?
+        {
             return Err(ApiError::Core(ConductorError::WorkflowRunAlreadyActive {
                 name: active.workflow_name,
             }));
@@ -643,7 +645,9 @@ pub async fn run_workflow(
 }
 
 fn check_no_active_run(wf_mgr: &WorkflowManager<'_>, wt_id: &str) -> Result<(), ApiError> {
-    if let Some(active) = wf_mgr.get_active_run_for_worktree(wt_id)? {
+    if let Some(active) =
+        conductor_core::workflow::get_active_run_for_worktree(wf_mgr.conn(), wt_id)?
+    {
         return Err(ApiError::Core(ConductorError::WorkflowRunAlreadyActive {
             name: active.workflow_name,
         }));
@@ -976,14 +980,19 @@ pub async fn list_all_workflow_runs_handler(
     let mgr = WorkflowManager::new(&db);
     let runs = if let Some(ref repo_id) = params.repo {
         let repo = RepoManager::new(&db, &config).get_by_id(repo_id)?;
-        mgr.list_active_workflow_runs_for_repo(&repo.id, &statuses)?
+        conductor_core::workflow::list_active_workflow_runs_for_repo(
+            mgr.conn(),
+            &repo.id,
+            &statuses,
+        )?
     } else {
-        mgr.list_active_workflow_runs(&statuses)?
+        conductor_core::workflow::list_active_workflow_runs(mgr.conn(), &statuses)?
     };
 
     // Batch-fetch only running/waiting steps for all runs (filter pushed to SQL)
     let run_ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
-    let mut steps_by_run = mgr.get_active_steps_for_runs(&run_ids)?;
+    let mut steps_by_run =
+        conductor_core::workflow::get_active_steps_for_runs(mgr.conn(), &run_ids)?;
 
     // Build slug lookup maps for repo_slug / worktree_slug enrichment
     let repo_slug_map: HashMap<String, String> = RepoManager::new(&db, &config)
@@ -1012,7 +1021,8 @@ pub async fn list_all_workflow_runs_handler(
         })
         .map(|r| r.id.as_str())
         .collect();
-    let plan_estimates = mgr.get_plan_estimates_for_runs(&active_run_ids)?;
+    let plan_estimates =
+        conductor_core::workflow::get_plan_estimates_for_runs(mgr.conn(), &active_run_ids)?;
 
     // Collect unique workflow names for active runs
     let active_workflow_names: std::collections::HashSet<&str> = runs
@@ -1029,28 +1039,32 @@ pub async fn list_all_workflow_runs_handler(
     // Batch-fetch historical durations (workflow-level) and step histories
     let historical_durations: HashMap<String, Vec<i64>> = active_workflow_names
         .iter()
-        .filter_map(|name| match mgr.get_completed_run_durations(name, 15) {
-            Ok(d) => Some((name.to_string(), d)),
-            Err(e) => {
-                tracing::warn!(workflow = %name, "get_completed_run_durations failed: {e}");
-                None
+        .filter_map(|name| {
+            match conductor_core::workflow::get_completed_run_durations(mgr.conn(), name, 15) {
+                Ok(d) => Some((name.to_string(), d)),
+                Err(e) => {
+                    tracing::warn!(workflow = %name, "get_completed_run_durations failed: {e}");
+                    None
+                }
             }
         })
         .collect();
     let step_histories: HashMap<String, HashMap<String, Vec<i64>>> = active_workflow_names
         .into_iter()
-        .filter_map(|name| match mgr.get_completed_step_durations(name, 20) {
-            Ok(d) => Some((name.to_string(), d)),
-            Err(e) => {
-                tracing::warn!(workflow = %name, "get_completed_step_durations failed: {e}");
-                None
+        .filter_map(|name| {
+            match conductor_core::workflow::get_completed_step_durations(mgr.conn(), name, 20) {
+                Ok(d) => Some((name.to_string(), d)),
+                Err(e) => {
+                    tracing::warn!(workflow = %name, "get_completed_step_durations failed: {e}");
+                    None
+                }
             }
         })
         .collect();
 
     // Batch-fetch all steps for active runs (for live remaining estimation)
     let mut all_active_run_steps: HashMap<String, Vec<WorkflowRunStep>> =
-        mgr.get_steps_for_runs(&active_run_ids)?;
+        conductor_core::workflow::get_steps_for_runs(mgr.conn(), &active_run_ids)?;
     let responses: Vec<WorkflowRunResponse> = runs
         .into_iter()
         .map(|run| {
@@ -1196,7 +1210,7 @@ pub async fn list_workflow_runs(
 ) -> Result<Json<Vec<WorkflowRun>>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let runs = mgr.list_workflow_runs(&worktree_id)?;
+    let runs = conductor_core::workflow::list_workflow_runs(mgr.conn(), &worktree_id)?;
     Ok(Json(runs))
 }
 
@@ -1219,8 +1233,7 @@ pub async fn get_workflow_run(
 ) -> Result<Json<WorkflowRun>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let run = mgr
-        .get_workflow_run(&id)?
+    let run = conductor_core::workflow::get_workflow_run(mgr.conn(), &id)?
         .ok_or_else(|| ApiError::Core(ConductorError::WorkflowRunNotFound { id: id.clone() }))?;
     Ok(Json(run))
 }
@@ -1244,7 +1257,7 @@ pub async fn get_workflow_steps(
 ) -> Result<Json<Vec<WorkflowRunStep>>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let steps = mgr.get_workflow_steps(&id)?;
+    let steps = conductor_core::workflow::get_workflow_steps(mgr.conn(), &id)?;
     Ok(Json(steps))
 }
 
@@ -1292,7 +1305,8 @@ pub async fn get_token_aggregates(
 ) -> Result<Json<Vec<WorkflowTokenAggregate>>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let rows = mgr.get_workflow_token_aggregates(q.repo_id.as_deref())?;
+    let rows =
+        conductor_core::workflow::get_workflow_token_aggregates(mgr.conn(), q.repo_id.as_deref())?;
     Ok(Json(rows))
 }
 
@@ -1319,7 +1333,11 @@ pub async fn get_token_trend(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let granularity = parse_granularity(q.granularity)?;
-    let rows = mgr.get_workflow_token_trend(&q.workflow_name, granularity)?;
+    let rows = conductor_core::workflow::get_workflow_token_trend(
+        mgr.conn(),
+        &q.workflow_name,
+        granularity,
+    )?;
     Ok(Json(rows))
 }
 
@@ -1346,7 +1364,8 @@ pub async fn get_step_heatmap(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let limit = q.runs.unwrap_or(20);
-    let rows = mgr.get_step_token_heatmap(&q.workflow_name, limit)?;
+    let rows =
+        conductor_core::workflow::get_step_token_heatmap(mgr.conn(), &q.workflow_name, limit)?;
     Ok(Json(rows))
 }
 
@@ -1373,7 +1392,7 @@ pub async fn get_run_metrics(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let days = q.days.unwrap_or(30);
-    let rows = mgr.get_run_metrics(&q.workflow_name, days)?;
+    let rows = conductor_core::workflow::get_run_metrics(mgr.conn(), &q.workflow_name, days)?;
     Ok(Json(rows))
 }
 
@@ -1394,7 +1413,11 @@ pub async fn get_failure_trend(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let granularity = parse_granularity(q.granularity)?;
-    let rows = mgr.get_workflow_failure_rate_trend(&q.workflow_name, granularity)?;
+    let rows = conductor_core::workflow::get_workflow_failure_rate_trend(
+        mgr.conn(),
+        &q.workflow_name,
+        granularity,
+    )?;
     Ok(Json(rows))
 }
 
@@ -1415,7 +1438,8 @@ pub async fn get_failure_heatmap(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let limit = q.runs.unwrap_or(20);
-    let rows = mgr.get_step_failure_heatmap(&q.workflow_name, limit)?;
+    let rows =
+        conductor_core::workflow::get_step_failure_heatmap(mgr.conn(), &q.workflow_name, limit)?;
     Ok(Json(rows))
 }
 
@@ -1436,7 +1460,8 @@ pub async fn get_step_retry_analytics(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let limit = q.runs.unwrap_or(20);
-    let rows = mgr.get_step_retry_analytics(&q.workflow_name, limit)?;
+    let rows =
+        conductor_core::workflow::get_step_retry_analytics(mgr.conn(), &q.workflow_name, limit)?;
     Ok(Json(rows))
 }
 
@@ -1463,7 +1488,8 @@ pub async fn get_workflow_percentiles(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let days = q.days.unwrap_or(30);
-    let result = mgr.get_workflow_percentiles(&q.workflow_name, days)?;
+    let result =
+        conductor_core::workflow::get_workflow_percentiles(mgr.conn(), &q.workflow_name, days)?;
     Ok(Json(result))
 }
 
@@ -1493,7 +1519,12 @@ pub async fn get_workflow_regressions(
     let recent_days = q.recent_days.unwrap_or(7);
     let baseline_days = q.baseline_days.unwrap_or(30);
     let min_runs = q.min_runs.unwrap_or(REGRESSION_MIN_RECENT_RUNS);
-    let signals = mgr.get_workflow_regression_signals(min_runs, recent_days, baseline_days)?;
+    let signals = conductor_core::workflow::get_workflow_regression_signals(
+        mgr.conn(),
+        min_runs,
+        recent_days,
+        baseline_days,
+    )?;
     Ok(Json(signals))
 }
 
@@ -1520,7 +1551,7 @@ pub async fn get_gate_analytics(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let days = q.days.unwrap_or(30);
-    let rows = mgr.get_gate_analytics(&q.workflow_name, days)?;
+    let rows = conductor_core::workflow::get_gate_analytics(mgr.conn(), &q.workflow_name, days)?;
     Ok(Json(rows))
 }
 
@@ -1538,7 +1569,7 @@ pub async fn get_pending_gates(
 ) -> Result<Json<Vec<PendingGateAnalyticsRow>>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let rows = mgr.get_all_pending_gates()?;
+    let rows = conductor_core::workflow::get_all_pending_gates(mgr.conn())?;
     Ok(Json(rows))
 }
 
@@ -1568,12 +1599,12 @@ pub async fn get_workflow_step_log(
         let wf_mgr = WorkflowManager::new(&db);
 
         // Verify run exists
-        wf_mgr.get_workflow_run(&run_id)?.ok_or_else(|| {
+        conductor_core::workflow::get_workflow_run(wf_mgr.conn(), &run_id)?.ok_or_else(|| {
             ApiError::Core(ConductorError::WorkflowRunNotFound { id: run_id.clone() })
         })?;
 
         // Find matching step — last iteration wins
-        let steps = wf_mgr.get_workflow_steps(&run_id)?;
+        let steps = conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), &run_id)?;
         let step = steps
             .into_iter()
             .filter(|s| s.step_name == step_name)
@@ -1627,7 +1658,7 @@ pub async fn get_child_workflow_runs(
 ) -> Result<Json<Vec<WorkflowRun>>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let children = mgr.list_child_workflow_runs(&id)?;
+    let children = conductor_core::workflow::list_child_workflow_runs(mgr.conn(), &id)?;
     Ok(Json(children))
 }
 
@@ -1652,8 +1683,7 @@ pub async fn cancel_workflow(
     let mgr = WorkflowManager::new(&db);
 
     // Verify run exists
-    let run = mgr
-        .get_workflow_run(&id)?
+    let run = conductor_core::workflow::get_workflow_run(mgr.conn(), &id)?
         .ok_or_else(|| ApiError::Core(ConductorError::WorkflowRunNotFound { id: id.clone() }))?;
 
     mgr.cancel_run(&id, "Cancelled by user")?;
@@ -1698,9 +1728,10 @@ pub async fn resume_workflow_endpoint(
     let (workflow_name, target_label, run_repo_id, run_worktree_id) = {
         let db = state.db.lock().await;
         let mgr = WorkflowManager::new(&db);
-        let run = mgr.get_workflow_run(&id)?.ok_or_else(|| {
-            ApiError::Core(ConductorError::WorkflowRunNotFound { id: id.clone() })
-        })?;
+        let run =
+            conductor_core::workflow::get_workflow_run(mgr.conn(), &id)?.ok_or_else(|| {
+                ApiError::Core(ConductorError::WorkflowRunNotFound { id: id.clone() })
+            })?;
         validate_resume_preconditions(&run.status, restart, from_step.as_deref())
             .map_err(ApiError::Core)?;
         (
@@ -1813,7 +1844,7 @@ fn find_waiting_gate_or_err(
     mgr: &WorkflowManager<'_>,
     run_id: &str,
 ) -> Result<WorkflowRunStep, ApiError> {
-    mgr.find_waiting_gate(run_id)?.ok_or_else(|| {
+    conductor_core::workflow::find_waiting_gate(mgr.conn(), run_id)?.ok_or_else(|| {
         ApiError::Core(ConductorError::Workflow(
             "No waiting gate found for this workflow run".to_string(),
         ))

--- a/conductor-web/src/routes/workflows.rs
+++ b/conductor-web/src/routes/workflows.rs
@@ -460,9 +460,8 @@ pub async fn run_workflow(
             conductor_core::workflow::load_def_by_name(&wt.path, &repo.local_path, &req.name)?;
 
         // Reject if a top-level workflow run is already active on this worktree
-        let wf_mgr = WorkflowManager::new(&db);
         if let Some(active) =
-            conductor_core::workflow::get_active_run_for_worktree(wf_mgr.conn(), &worktree_id)?
+            conductor_core::workflow::get_active_run_for_worktree(&db, &worktree_id)?
         {
             return Err(ApiError::Core(ConductorError::WorkflowRunAlreadyActive {
                 name: active.workflow_name,
@@ -645,9 +644,7 @@ pub async fn run_workflow(
 }
 
 fn check_no_active_run(wf_mgr: &WorkflowManager<'_>, wt_id: &str) -> Result<(), ApiError> {
-    if let Some(active) =
-        conductor_core::workflow::get_active_run_for_worktree(wf_mgr.conn(), wt_id)?
-    {
+    if let Some(active) = conductor_core::workflow::get_active_run_for_worktree(&db, wt_id)? {
         return Err(ApiError::Core(ConductorError::WorkflowRunAlreadyActive {
             name: active.workflow_name,
         }));
@@ -687,7 +684,6 @@ pub async fn post_workflow_run(
         };
 
         // Route based on which target fields are present
-        let wf_mgr = WorkflowManager::new(&db);
         let (wt_path, wt_slug, wt_ticket_id, resolved_wt_id, wt_model) =
             if let Some(ref wt_id) = req.worktree {
                 // Worktree path: validate ownership
@@ -980,19 +976,14 @@ pub async fn list_all_workflow_runs_handler(
     let mgr = WorkflowManager::new(&db);
     let runs = if let Some(ref repo_id) = params.repo {
         let repo = RepoManager::new(&db, &config).get_by_id(repo_id)?;
-        conductor_core::workflow::list_active_workflow_runs_for_repo(
-            mgr.conn(),
-            &repo.id,
-            &statuses,
-        )?
+        conductor_core::workflow::list_active_workflow_runs_for_repo(&db, &repo.id, &statuses)?
     } else {
-        conductor_core::workflow::list_active_workflow_runs(mgr.conn(), &statuses)?
+        conductor_core::workflow::list_active_workflow_runs(&db, &statuses)?
     };
 
     // Batch-fetch only running/waiting steps for all runs (filter pushed to SQL)
     let run_ids: Vec<&str> = runs.iter().map(|r| r.id.as_str()).collect();
-    let mut steps_by_run =
-        conductor_core::workflow::get_active_steps_for_runs(mgr.conn(), &run_ids)?;
+    let mut steps_by_run = conductor_core::workflow::get_active_steps_for_runs(&db, &run_ids)?;
 
     // Build slug lookup maps for repo_slug / worktree_slug enrichment
     let repo_slug_map: HashMap<String, String> = RepoManager::new(&db, &config)
@@ -1022,7 +1013,7 @@ pub async fn list_all_workflow_runs_handler(
         .map(|r| r.id.as_str())
         .collect();
     let plan_estimates =
-        conductor_core::workflow::get_plan_estimates_for_runs(mgr.conn(), &active_run_ids)?;
+        conductor_core::workflow::get_plan_estimates_for_runs(&db, &active_run_ids)?;
 
     // Collect unique workflow names for active runs
     let active_workflow_names: std::collections::HashSet<&str> = runs
@@ -1040,7 +1031,7 @@ pub async fn list_all_workflow_runs_handler(
     let historical_durations: HashMap<String, Vec<i64>> = active_workflow_names
         .iter()
         .filter_map(|name| {
-            match conductor_core::workflow::get_completed_run_durations(mgr.conn(), name, 15) {
+            match conductor_core::workflow::get_completed_run_durations(&db, name, 15) {
                 Ok(d) => Some((name.to_string(), d)),
                 Err(e) => {
                     tracing::warn!(workflow = %name, "get_completed_run_durations failed: {e}");
@@ -1052,7 +1043,7 @@ pub async fn list_all_workflow_runs_handler(
     let step_histories: HashMap<String, HashMap<String, Vec<i64>>> = active_workflow_names
         .into_iter()
         .filter_map(|name| {
-            match conductor_core::workflow::get_completed_step_durations(mgr.conn(), name, 20) {
+            match conductor_core::workflow::get_completed_step_durations(&db, name, 20) {
                 Ok(d) => Some((name.to_string(), d)),
                 Err(e) => {
                     tracing::warn!(workflow = %name, "get_completed_step_durations failed: {e}");
@@ -1064,7 +1055,7 @@ pub async fn list_all_workflow_runs_handler(
 
     // Batch-fetch all steps for active runs (for live remaining estimation)
     let mut all_active_run_steps: HashMap<String, Vec<WorkflowRunStep>> =
-        conductor_core::workflow::get_steps_for_runs(mgr.conn(), &active_run_ids)?;
+        conductor_core::workflow::get_steps_for_runs(&db, &active_run_ids)?;
     let responses: Vec<WorkflowRunResponse> = runs
         .into_iter()
         .map(|run| {
@@ -1210,7 +1201,7 @@ pub async fn list_workflow_runs(
 ) -> Result<Json<Vec<WorkflowRun>>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let runs = conductor_core::workflow::list_workflow_runs(mgr.conn(), &worktree_id)?;
+    let runs = conductor_core::workflow::list_workflow_runs(&db, &worktree_id)?;
     Ok(Json(runs))
 }
 
@@ -1233,7 +1224,7 @@ pub async fn get_workflow_run(
 ) -> Result<Json<WorkflowRun>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let run = conductor_core::workflow::get_workflow_run(mgr.conn(), &id)?
+    let run = conductor_core::workflow::get_workflow_run(&db, &id)?
         .ok_or_else(|| ApiError::Core(ConductorError::WorkflowRunNotFound { id: id.clone() }))?;
     Ok(Json(run))
 }
@@ -1257,7 +1248,7 @@ pub async fn get_workflow_steps(
 ) -> Result<Json<Vec<WorkflowRunStep>>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let steps = conductor_core::workflow::get_workflow_steps(mgr.conn(), &id)?;
+    let steps = conductor_core::workflow::get_workflow_steps(&db, &id)?;
     Ok(Json(steps))
 }
 
@@ -1305,8 +1296,7 @@ pub async fn get_token_aggregates(
 ) -> Result<Json<Vec<WorkflowTokenAggregate>>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let rows =
-        conductor_core::workflow::get_workflow_token_aggregates(mgr.conn(), q.repo_id.as_deref())?;
+    let rows = conductor_core::workflow::get_workflow_token_aggregates(&db, q.repo_id.as_deref())?;
     Ok(Json(rows))
 }
 
@@ -1333,11 +1323,8 @@ pub async fn get_token_trend(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let granularity = parse_granularity(q.granularity)?;
-    let rows = conductor_core::workflow::get_workflow_token_trend(
-        mgr.conn(),
-        &q.workflow_name,
-        granularity,
-    )?;
+    let rows =
+        conductor_core::workflow::get_workflow_token_trend(&db, &q.workflow_name, granularity)?;
     Ok(Json(rows))
 }
 
@@ -1364,8 +1351,7 @@ pub async fn get_step_heatmap(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let limit = q.runs.unwrap_or(20);
-    let rows =
-        conductor_core::workflow::get_step_token_heatmap(mgr.conn(), &q.workflow_name, limit)?;
+    let rows = conductor_core::workflow::get_step_token_heatmap(&db, &q.workflow_name, limit)?;
     Ok(Json(rows))
 }
 
@@ -1392,7 +1378,7 @@ pub async fn get_run_metrics(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let days = q.days.unwrap_or(30);
-    let rows = conductor_core::workflow::get_run_metrics(mgr.conn(), &q.workflow_name, days)?;
+    let rows = conductor_core::workflow::get_run_metrics(&db, &q.workflow_name, days)?;
     Ok(Json(rows))
 }
 
@@ -1414,7 +1400,7 @@ pub async fn get_failure_trend(
     let mgr = WorkflowManager::new(&db);
     let granularity = parse_granularity(q.granularity)?;
     let rows = conductor_core::workflow::get_workflow_failure_rate_trend(
-        mgr.conn(),
+        &db,
         &q.workflow_name,
         granularity,
     )?;
@@ -1438,8 +1424,7 @@ pub async fn get_failure_heatmap(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let limit = q.runs.unwrap_or(20);
-    let rows =
-        conductor_core::workflow::get_step_failure_heatmap(mgr.conn(), &q.workflow_name, limit)?;
+    let rows = conductor_core::workflow::get_step_failure_heatmap(&db, &q.workflow_name, limit)?;
     Ok(Json(rows))
 }
 
@@ -1460,8 +1445,7 @@ pub async fn get_step_retry_analytics(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let limit = q.runs.unwrap_or(20);
-    let rows =
-        conductor_core::workflow::get_step_retry_analytics(mgr.conn(), &q.workflow_name, limit)?;
+    let rows = conductor_core::workflow::get_step_retry_analytics(&db, &q.workflow_name, limit)?;
     Ok(Json(rows))
 }
 
@@ -1488,8 +1472,7 @@ pub async fn get_workflow_percentiles(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let days = q.days.unwrap_or(30);
-    let result =
-        conductor_core::workflow::get_workflow_percentiles(mgr.conn(), &q.workflow_name, days)?;
+    let result = conductor_core::workflow::get_workflow_percentiles(&db, &q.workflow_name, days)?;
     Ok(Json(result))
 }
 
@@ -1520,7 +1503,7 @@ pub async fn get_workflow_regressions(
     let baseline_days = q.baseline_days.unwrap_or(30);
     let min_runs = q.min_runs.unwrap_or(REGRESSION_MIN_RECENT_RUNS);
     let signals = conductor_core::workflow::get_workflow_regression_signals(
-        mgr.conn(),
+        &db,
         min_runs,
         recent_days,
         baseline_days,
@@ -1551,7 +1534,7 @@ pub async fn get_gate_analytics(
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
     let days = q.days.unwrap_or(30);
-    let rows = conductor_core::workflow::get_gate_analytics(mgr.conn(), &q.workflow_name, days)?;
+    let rows = conductor_core::workflow::get_gate_analytics(&db, &q.workflow_name, days)?;
     Ok(Json(rows))
 }
 
@@ -1569,7 +1552,7 @@ pub async fn get_pending_gates(
 ) -> Result<Json<Vec<PendingGateAnalyticsRow>>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let rows = conductor_core::workflow::get_all_pending_gates(mgr.conn())?;
+    let rows = conductor_core::workflow::get_all_pending_gates(&db)?;
     Ok(Json(rows))
 }
 
@@ -1596,15 +1579,13 @@ pub async fn get_workflow_step_log(
     // Hold the DB lock only for the DB queries, then drop it before the file read.
     let log_path = {
         let db = state.db.lock().await;
-        let wf_mgr = WorkflowManager::new(&db);
-
         // Verify run exists
-        conductor_core::workflow::get_workflow_run(wf_mgr.conn(), &run_id)?.ok_or_else(|| {
+        conductor_core::workflow::get_workflow_run(&db, &run_id)?.ok_or_else(|| {
             ApiError::Core(ConductorError::WorkflowRunNotFound { id: run_id.clone() })
         })?;
 
         // Find matching step — last iteration wins
-        let steps = conductor_core::workflow::get_workflow_steps(wf_mgr.conn(), &run_id)?;
+        let steps = conductor_core::workflow::get_workflow_steps(&db, &run_id)?;
         let step = steps
             .into_iter()
             .filter(|s| s.step_name == step_name)
@@ -1658,7 +1639,7 @@ pub async fn get_child_workflow_runs(
 ) -> Result<Json<Vec<WorkflowRun>>, ApiError> {
     let db = state.db.lock().await;
     let mgr = WorkflowManager::new(&db);
-    let children = conductor_core::workflow::list_child_workflow_runs(mgr.conn(), &id)?;
+    let children = conductor_core::workflow::list_child_workflow_runs(&db, &id)?;
     Ok(Json(children))
 }
 
@@ -1683,7 +1664,7 @@ pub async fn cancel_workflow(
     let mgr = WorkflowManager::new(&db);
 
     // Verify run exists
-    let run = conductor_core::workflow::get_workflow_run(mgr.conn(), &id)?
+    let run = conductor_core::workflow::get_workflow_run(&db, &id)?
         .ok_or_else(|| ApiError::Core(ConductorError::WorkflowRunNotFound { id: id.clone() }))?;
 
     mgr.cancel_run(&id, "Cancelled by user")?;
@@ -1728,10 +1709,9 @@ pub async fn resume_workflow_endpoint(
     let (workflow_name, target_label, run_repo_id, run_worktree_id) = {
         let db = state.db.lock().await;
         let mgr = WorkflowManager::new(&db);
-        let run =
-            conductor_core::workflow::get_workflow_run(mgr.conn(), &id)?.ok_or_else(|| {
-                ApiError::Core(ConductorError::WorkflowRunNotFound { id: id.clone() })
-            })?;
+        let run = conductor_core::workflow::get_workflow_run(&db, &id)?.ok_or_else(|| {
+            ApiError::Core(ConductorError::WorkflowRunNotFound { id: id.clone() })
+        })?;
         validate_resume_preconditions(&run.status, restart, from_step.as_deref())
             .map_err(ApiError::Core)?;
         (
@@ -1844,7 +1824,7 @@ fn find_waiting_gate_or_err(
     mgr: &WorkflowManager<'_>,
     run_id: &str,
 ) -> Result<WorkflowRunStep, ApiError> {
-    conductor_core::workflow::find_waiting_gate(mgr.conn(), run_id)?.ok_or_else(|| {
+    conductor_core::workflow::find_waiting_gate(&db, run_id)?.ok_or_else(|| {
         ApiError::Core(ConductorError::Workflow(
             "No waiting gate found for this workflow run".to_string(),
         ))


### PR DESCRIPTION
## Summary

Second step in the WorkflowManager free-function migration (#2590). All 50 read-only query methods in `conductor-core/src/workflow/manager/queries.rs` move from `impl WorkflowManager<'a>` methods to module-level free functions taking `conn: &Connection`. Three associated constants (`STEP_SELECT_WITH_TOKENS`, `N_RECENT_COMPLETED_RUNS_SUBQUERY`, `N_RECENT_TERMINAL_RUNS_SUBQUERY`) move to module level alongside them.

## What's in this PR

- **queries.rs**: 50 methods → free functions; 3 associated constants → module-level constants; internal `self.method()` calls become direct free-function calls
- **Sibling manager modules** (`recovery.rs`, `lifecycle.rs`, `fan_out.rs`, `steps.rs`): `self.<query_method>()` calls converted to `super::queries::method(self.conn, ...)`. Module visibility bumped to `pub(crate)` so siblings can address it.
- **`WorkflowManager::conn()` accessor added**: external callers (TUI, CLI, web, internal coordinator/item_provider code) can forward the connection to free functions without leaking the `pub(super) conn` field.
- **All 50 free functions re-exported from `conductor_core::workflow`**: callers say `workflow::get_workflow_run(&conn, &id)` rather than the deeper `workflow::manager::queries::...` path.
- **All call sites updated** across conductor-cli, conductor-tui, conductor-web, and conductor-core (including 1900+ lines of test code in `tests/manager.rs` and the in-file `queries.rs` tests).

## Caller migration patterns

| Before | After |
|---|---|
| `WorkflowManager::new(&conn).method(args)` | `conductor_core::workflow::method(&conn, args)` |
| `wf_mgr.method(args)` | `conductor_core::workflow::method(wf_mgr.conn(), args)` |
| `mgr.method(args)` (where `mgr: WorkflowManager`) | `conductor_core::workflow::method(mgr.conn(), args)` |
| `self.method(args)` (cross-module within `manager/`) | `super::queries::method(self.conn, args)` |

The `wf_mgr.conn()` indirection is a transient migration artifact — the final cleanup PR will simplify these to direct `&conn` references where the local connection is available, and delete the accessor when the struct itself is removed.

## Migration roadmap

1. ✅ `definitions.rs` — PR #2765 (merged)
2. ✅ **`queries.rs`** — this PR
3. `steps.rs` + `fan_out.rs`
4. `lifecycle.rs`
5. `recovery.rs`
6. (Final cleanup) — delete `WorkflowManager` struct + `mod.rs` wrapper + `conn()` accessor

See #2590 for the full plan.

## Test plan

- [x] `cargo build` — passes for `conductor-core`, `conductor-cli`, `conductor-tui`
- [x] `cargo clippy -p conductor-core -p conductor-cli -p conductor-tui -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test -p conductor-core` — 1963 tests pass, 0 failures
- [x] `cargo test -p conductor-cli -p conductor-tui` — 963 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)