### PR TITLE
refactor(tui): log warn when cache-miss label resolution falls through (closes #2774)

### DIFF
--- a/conductor-tui/src/app/workflow_management.rs
+++ b/conductor-tui/src/app/workflow_management.rs
@@ -981,6 +981,12 @@ impl App {
                                 .ok()?;
                             Some((Some(format!("{}/{}", repo.slug, wt.slug)), wt.ticket_id))
                         })();
+                        if label.is_none() {
+                            tracing::warn!(
+                                worktree_id = %worktree_id,
+                                "label resolution fell through on cache-miss DB lookup; dispatching workflow with empty target_label"
+                            );
+                        }
                         label.unwrap_or((None, None))
                     });
                 // Fall back to inputs["ticket_id"] when the worktree's in-memory state


### PR DESCRIPTION
## Summary

Adds a `tracing::warn!` boundary log at the cache-miss closure inside `do_dispatch_workflow` (\`conductor-tui/src/app/workflow_management.rs:984-989\`) so silent \`.ok()?\` swallows in the DB lookup become observable in logs.

Behavior is unchanged: the closure still returns \`(None, None)\` on any failure (DB row missing, transient error, etc.) and dispatch still proceeds. The only change is that the operator now sees a structured warn entry with the offending \`worktree_id\`.

\`\`\`rust
let label = (|| -> Option<WorktreeLabelParts> { ... })();
if label.is_none() {
    tracing::warn!(
        worktree_id = %worktree_id,
        "label resolution fell through on cache-miss DB lookup; dispatching workflow with empty target_label"
    );
}
label.unwrap_or((None, None))
\`\`\`

## Closes

- #2774 — TUI cache-miss label resolution swallows errors silently

## Diff

| | |
|---|---:|
| Files changed | 1 |
| Insertions | +6 |
| Deletions | 0 |

## Test plan

- [x] \`cargo build -p conductor-tui --lib\` — passes
- [x] \`cargo clippy -p conductor-tui -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo test -p conductor-tui --lib\` — 195 tests pass

## Notes

- The lint-fix workflow run that produced this commit (\`01KQJ3K1Q855DT6NEAK6DB4HRG\`) failed at \`max_iterations\`, but the failure was unrelated to this fix — the script's changed-crate detection misbehaves once changes are committed (uses \`git diff HEAD\`, only sees uncommitted diffs) and falls through to a workspace-wide clippy that trips two pre-existing test-clippy errors on \`release/0.11.0\`. Both are tracked as separate cleanup PRs. The fix in this PR is correct and verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)