### PR TITLE
fix(workflow): drop two pre-existing clippy errors in test files (closes #2776)

### DIFF
--- a/conductor-core/src/workflow/manager/tests.rs
+++ b/conductor-core/src/workflow/manager/tests.rs
@@ -1,4 +1,3 @@
-use super::*;
 use crate::agent::AgentManager;
 use crate::db::sql_placeholders;
 use crate::workflow::types::TimeGranularity;

--- a/conductor-core/src/workflow/tests/common.rs
+++ b/conductor-core/src/workflow/tests/common.rs
@@ -136,7 +136,7 @@ pub(super) fn setup_run_with_steps(conn: &Connection) -> String {
 
     // Step 2: running (stalled)
     let s2 = crate::workflow::insert_step(conn, &run.id, "step-c", "actor", false, 2, 0).unwrap();
-    set_step_status(&conn, &s2, WorkflowStepStatus::Running);
+    set_step_status(conn, &s2, WorkflowStepStatus::Running);
 
     run.id
 }


### PR DESCRIPTION
## Summary

Two trivial clippy errors in conductor-core test files that only show up under \`cargo clippy --workspace --all-targets -- -D warnings\` — one unused import, one needless borrow:

\`\`\`diff
- use super::*;                                                    // manager/tests.rs:1
- set_step_status(&conn, &s2, WorkflowStepStatus::Running);        // tests/common.rs:139
+ set_step_status(conn,  &s2, WorkflowStepStatus::Running);
\`\`\`

## Closes

- #2776 — Two pre-existing test-clippy errors on release/0.11.0

## Why now

These were introduced (or surfaced) by PR #2772 and not caught because that PR's test plan ran \`cargo clippy --lib\` rather than \`--all-targets\`. CI doesn't run on release branches, so they slipped in.

They actively block the \`lint-fix\` workflow from reaching a clean state when run on top of \`release/0.11.0\` (workflow run \`01KQJ3K1Q855DT6NEAK6DB4HRG\` failed for exactly this reason).

## Diff

| | |
|---|---:|
| Files changed | 2 |
| Insertions | +1 |
| Deletions | -2 |

## Test plan

- [x] \`cargo clippy -p conductor-core --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [x] \`cargo test -p conductor-core --lib\` — 1946 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)