### PR TITLE
fix(lint-fix): use merge-base diff so committed changes stay in scope (closes #2777)

### DIFF
--- a/.conductor/scripts/analyze-lint.sh
+++ b/.conductor/scripts/analyze-lint.sh
@@ -10,8 +10,21 @@ if [ ! -d conductor-web/frontend/dist ]; then
   fi
 fi
 
-# Detect which conductor-* crates have changed files
-CHANGED_CRATES=$(git diff --name-only HEAD | grep '^conductor-' | cut -d/ -f1 | sort -u)
+# Detect which conductor-* crates have changed files.
+# If FEATURE_BASE_BRANCH is set (passed by the workflow), diff against the
+# merge-base with that branch so committed changes within the worktree are
+# included. Falling back to HEAD only sees uncommitted edits, which means
+# scope shrinks the moment the worktree commits — see issue #2777.
+BASE="${FEATURE_BASE_BRANCH:-}"
+if [ -n "$BASE" ]; then
+  DIFF_TARGET=$(git merge-base HEAD "origin/$BASE" 2>/dev/null \
+              || git merge-base HEAD "$BASE" 2>/dev/null \
+              || echo HEAD)
+else
+  DIFF_TARGET=HEAD
+fi
+
+CHANGED_CRATES=$(git diff --name-only "$DIFF_TARGET" | grep '^conductor-' | cut -d/ -f1 | sort -u)
 
 if [ -z "$CHANGED_CRATES" ]; then
   # No crate-level changes detected — fall back to full workspace (matches CI)
@@ -34,7 +47,7 @@ fi
 cargo fmt --all --check 2>&1 || ERRORS=1
 
 # Validate changed or new .wf files
-for f in $(git diff --name-only HEAD -- '*.wf') $(git ls-files --others --exclude-standard -- '*.wf'); do
+for f in $(git diff --name-only "$DIFF_TARGET" -- '*.wf') $(git ls-files --others --exclude-standard -- '*.wf'); do
   [ -f "$f" ] || continue
   name=$(basename "$f" .wf)
   conductor workflow validate "$name" --path . 2>&1 \

--- a/.conductor/workflows/lint-fix.wf
+++ b/.conductor/workflows/lint-fix.wf
@@ -13,6 +13,7 @@ workflow lint-fix {
 
     script analyze-lint {
       run = ".conductor/scripts/analyze-lint.sh"
+      env = { FEATURE_BASE_BRANCH = "{{feature_base_branch}}" }
     }
 
     if analyze-lint.has_lint_errors {


### PR DESCRIPTION
## Summary

\`.conductor/scripts/analyze-lint.sh\` scoped clippy via \`git diff --name-only HEAD\`, which only catches **uncommitted** changes. As soon as the agent inside the \`lint-fix\` workflow committed its work, the diff went empty and the script fell through to a workspace-wide clippy run — strictly broader than the agent's actual scope and prone to attributing unrelated pre-existing errors to the agent.

This caused workflow run \`01KQJ3K1Q855DT6NEAK6DB4HRG\` to loop until \`max_iterations\` even though the agent's commit was correct (see PR #2775).

## Fix

When \`FEATURE_BASE_BRANCH\` is set (now passed by the workflow via the \`env\` block, matching the existing pattern in \`rebase-worktree.wf\` etc.), diff against the merge-base with that branch so committed changes within the worktree remain in scope. Falls back to HEAD-only diff for ad-hoc invocations without the env var.

\`\`\`bash
BASE="\${FEATURE_BASE_BRANCH:-}"
if [ -n "\$BASE" ]; then
  DIFF_TARGET=\$(git merge-base HEAD "origin/\$BASE" 2>/dev/null \
              || git merge-base HEAD "\$BASE" 2>/dev/null \
              || echo HEAD)
else
  DIFF_TARGET=HEAD
fi
CHANGED_CRATES=\$(git diff --name-only "\$DIFF_TARGET" | grep '^conductor-' | cut -d/ -f1 | sort -u)
\`\`\`

The \`.wf\`-file scan further down was updated to use the same \`\$DIFF_TARGET\`.

## Closes

- #2777 — \`analyze-lint.sh\` changed-crate detection breaks after a commit

## Test plan

- [x] \`cargo run --bin conductor -- workflow validate lint-fix --path .\` — passes
- [x] Smoke test with \`FEATURE_BASE_BRANCH=release/0.11.0 bash .conductor/scripts/analyze-lint.sh\` — script picks up the .wf file change and runs workflow validate on it (validates clean), then falls through to workspace clippy as expected

## Notes

- The remaining workspace-wide clippy errors hit during the smoke test are the **pre-existing** test-clippy errors tracked in #2776 / fixed in PR #2778. After both PRs land, a clean \`lint-fix\` run on \`release/0.11.0\` worktrees should reach max-iterations only when there are real, in-scope errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)