### PR TITLE
fix(workflow): reaper skips parents with in-flight actor cleanup (closes #2787)

### DIFF
--- a/conductor-core/src/workflow/manager/recovery.rs
+++ b/conductor-core/src/workflow/manager/recovery.rs
@@ -655,6 +655,15 @@ pub fn reap_finalization_stuck_workflow_runs(
 ) -> crate::error::Result<usize> {
     // Find root running workflow runs where all steps are terminal and
     // the last step (or the run itself) ended more than threshold_secs ago.
+    //
+    // Actor steps mark their step record terminal as soon as the agent
+    // emits FLOW_OUTPUT, but the agent subprocess continues for cleanup
+    // (final SDK message, log flush, prompt-file removal, child wait) and
+    // the workflow engine waits for the actual process exit before
+    // scheduling the next step. For long actors, that gap can exceed
+    // `threshold_secs` and trip the false-positive branch of this reaper.
+    // Skip parents whose latest actor step still has a `running`
+    // `agent_run` — see issue #2787.
     let stuck: Vec<(String, String, bool)> = query_collect(
         conn,
         "SELECT id, parent_run_id, has_failure FROM ( \
@@ -676,6 +685,12 @@ pub fn reap_finalization_stuck_workflow_runs(
                    SELECT 1 FROM workflow_run_steps wrs \
                    WHERE wrs.workflow_run_id = wr.id \
                      AND wrs.status IN ('running', 'pending', 'waiting') \
+                 ) \
+                 AND NOT EXISTS ( \
+                   SELECT 1 FROM workflow_run_steps wrs_act \
+                   JOIN agent_runs ar ON ar.id = wrs_act.child_run_id \
+                   WHERE wrs_act.workflow_run_id = wr.id \
+                     AND ar.status = 'running' \
                  ) \
              ) \
              WHERE age_ref IS NOT NULL \

--- a/conductor-core/src/workflow/tests/manager.rs
+++ b/conductor-core/src/workflow/tests/manager.rs
@@ -4816,3 +4816,100 @@ fn test_active_step_exists_false_for_timed_out() {
         !crate::workflow::active_step_exists(&conn, &run.id, 2, 0, "workflow:lint-fix").unwrap()
     );
 }
+
+// ---------------------------------------------------------------------------
+// reap_finalization_stuck_workflow_runs — false-positive guard for in-flight
+// actor cleanup (issue #2787)
+// ---------------------------------------------------------------------------
+
+/// Insert a workflow run in 'running' status with an actor step whose record
+/// is already terminal but whose linked agent_run is in `agent_status`. The
+/// step's ended_at is stamped at `step_ended_at` so callers can put it well
+/// past the reaper threshold.
+fn insert_root_run_with_actor_step(
+    conn: &Connection,
+    run_id: &str,
+    step_id: &str,
+    agent_status: &str,
+    step_ended_at: &str,
+) {
+    insert_running_root_run(conn, run_id);
+
+    let agent_mgr = AgentManager::new(conn);
+    let agent_run = agent_mgr.create_run(None, "actor", None).unwrap();
+
+    // Override the agent_run status (create_run defaults to 'running').
+    conn.execute(
+        "UPDATE agent_runs SET status = :status WHERE id = :id",
+        named_params! { ":status": agent_status, ":id": agent_run.id },
+    )
+    .unwrap();
+
+    // Insert a terminal step record that links to the agent_run.
+    conn.execute(
+        "INSERT INTO workflow_run_steps \
+         (id, workflow_run_id, step_name, role, position, status, iteration, \
+          ended_at, child_run_id) \
+         VALUES (:step_id, :run_id, 'implement', 'actor', 0, 'completed', 0, \
+                 :ended_at, :child_run_id)",
+        named_params! {
+            ":step_id": step_id,
+            ":run_id": run_id,
+            ":ended_at": step_ended_at,
+            ":child_run_id": agent_run.id,
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+fn test_reap_finalization_skips_run_with_in_flight_actor_cleanup() {
+    // The scenario from issue #2787: an actor step's record is already
+    // terminal but the agent subprocess is still cleaning up. The reaper
+    // must not finalize the parent in this window.
+    let conn = setup_db();
+    insert_root_run_with_actor_step(
+        &conn,
+        "run-actor-cleanup",
+        "step-impl",
+        "running",              // agent process not yet exited
+        "2020-01-01T00:00:00Z", // step "ended" well past any threshold
+    );
+
+    let reaped = crate::workflow::reap_finalization_stuck_workflow_runs(&conn, 60).unwrap();
+    assert_eq!(
+        reaped, 0,
+        "must not finalize a run whose actor agent is still running"
+    );
+    assert_eq!(
+        get_run_status(&conn, "run-actor-cleanup"),
+        "running",
+        "parent must remain running while actor cleanup is in flight"
+    );
+}
+
+#[test]
+fn test_reap_finalization_finalizes_run_after_actor_completes() {
+    // Regression for the legitimate case from #1777: all steps did finish
+    // (agent_run flipped to 'completed') but the parent's status update
+    // failed. The reaper must still finalize this case.
+    let conn = setup_db();
+    insert_root_run_with_actor_step(
+        &conn,
+        "run-finalization-failed",
+        "step-impl",
+        "completed",            // agent fully done
+        "2020-01-01T00:00:00Z", // step "ended" well past any threshold
+    );
+
+    let reaped = crate::workflow::reap_finalization_stuck_workflow_runs(&conn, 60).unwrap();
+    assert_eq!(
+        reaped, 1,
+        "must finalize a run whose actor agent is fully done"
+    );
+    assert_eq!(
+        get_run_status(&conn, "run-finalization-failed"),
+        "completed",
+        "parent must transition to completed"
+    );
+}


### PR DESCRIPTION
## Summary

\`reap_finalization_stuck_workflow_runs\` was falsely finalizing parent workflow runs during the (sometimes \>60 s) gap between an actor step's record flipping terminal and the agent subprocess actually exiting. This narrows its predicate with a \`NOT EXISTS\` join on \`agent_runs.status = 'running'\` so the reaper waits for the agent process to actually be done before declaring the parent stuck.

## Closes

- #2787 — Reaper prematurely finalizes parent workflow during gap between actor step's FLOW_OUTPUT and agent process exit

## Why this is the right scope

(Per the investigation thread on #2787):

- **Actor steps are the only step type that races.** Step records flip terminal on FLOW_OUTPUT, but the agent process keeps cleaning up. \`script\` is synchronous, \`gate\` stays in \`waiting\` until approved, and \`call_workflow\` keeps the step in \`running\` until the child finishes. No gap → no false positive.
- **The legitimate #1777 case is preserved.** The reaper exists to recover workflow runs left in \`running\` when the engine completes successfully but the finalization-DB-write fails transiently. In that case the \`agent_run\` is genuinely \`completed\`, so the new \`agent_runs.status = 'running'\` filter doesn't block reaper finalization.
- **Engine self-correction is unchanged.** \`update_workflow_status\` is a plain \`UPDATE\` with no guard, so when the engine eventually completes naturally it still overwrites whatever the reaper set.

## SQL change

\`\`\`sql
-- Added inside the existing inner WHERE clause
AND NOT EXISTS (
  SELECT 1 FROM workflow_run_steps wrs_act
  JOIN agent_runs ar ON ar.id = wrs_act.child_run_id
  WHERE wrs_act.workflow_run_id = wr.id
    AND ar.status = 'running'
)
\`\`\`

## Test plan

- [x] \`cargo test -p conductor-core workflow::tests::manager::test_reap_finalization\` — both new tests pass
- [x] \`cargo test -p conductor-core --lib\` — 1957 tests pass (was 1955; +2 new)
- [x] \`cargo test -p conductor-tui --lib\` — 195 tests pass
- [x] \`cargo test -p conductor-web --lib\` — 126 tests pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean

### New tests

- **\`test_reap_finalization_skips_run_with_in_flight_actor_cleanup\`** — the #2787 scenario: actor step record is \`completed\` with stale \`ended_at\` but \`agent_runs.status = 'running'\`. Reaper must leave the parent alone.
- **\`test_reap_finalization_finalizes_run_after_actor_completes\`** — the #1777 regression: actor step record is \`completed\`, agent_run is \`completed\`, parent stuck in \`running\`. Reaper must finalize.

## Diff

| | |
|---|---:|
| Files changed | 2 |
| Insertions | +112 |
| Deletions | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)