### PR TITLE
feat(workflow): add owner_token / lease_until / generation columns to workflow_runs

### DIFF
--- a/conductor-core/src/db/migrations.rs
+++ b/conductor-core/src/db/migrations.rs
@@ -5,7 +5,7 @@ use crate::error::{ConductorError, Result};
 
 /// The highest migration version this binary knows about.
 /// **When adding a new migration, update this constant to match the new version.**
-pub const LATEST_SCHEMA_VERSION: u32 = 83;
+pub const LATEST_SCHEMA_VERSION: u32 = 84;
 
 /// Legacy plan step shape used only for migrating JSON data from agent_runs.plan.
 #[derive(Deserialize)]
@@ -1294,6 +1294,17 @@ pub fn run(conn: &Connection) -> Result<()> {
             }
         }
         bump_version(conn, 83)?;
+    }
+
+    // Migration 084: add lease-based ownership columns to workflow_runs.
+    if version < 84 {
+        let has_col: bool = conn
+            .prepare("SELECT owner_token FROM workflow_runs LIMIT 0")
+            .is_ok();
+        if !has_col {
+            conn.execute_batch(include_str!("migrations/084_workflow_run_lease.sql"))?;
+        }
+        bump_version(conn, 84)?;
     }
 
     Ok(())

--- a/conductor-core/src/db/migrations/084_workflow_run_lease.sql
+++ b/conductor-core/src/db/migrations/084_workflow_run_lease.sql
@@ -1,0 +1,11 @@
+-- Migration 084: add lease-based ownership columns to workflow_runs.
+--
+-- owner_token TEXT (nullable) — identifies the current lease holder; NULL means unowned.
+-- lease_until TEXT (nullable, ISO 8601) — expiry timestamp of the current lease; NULL means no expiry.
+-- generation INTEGER NOT NULL DEFAULT 0 — monotonic counter used by generation-check predicates
+--   to detect stale ownership claims.  DEFAULT 0 ensures all existing rows start at generation 0
+--   without any Rust-side backfill.
+
+ALTER TABLE workflow_runs ADD COLUMN owner_token TEXT;
+ALTER TABLE workflow_runs ADD COLUMN lease_until TEXT;
+ALTER TABLE workflow_runs ADD COLUMN generation  INTEGER NOT NULL DEFAULT 0;

--- a/docs/diagrams/database-schema.mmd
+++ b/docs/diagrams/database-schema.mmd
@@ -1,4 +1,4 @@
-%% Updated 2026-04-30 — Entity-relationship diagram for conductor.db (86 migrations)
+%% Updated 2026-05-01 — Entity-relationship diagram for conductor.db (87 migrations)
 erDiagram
 
     _conductor_meta {
@@ -237,6 +237,9 @@ erDiagram
         text last_heartbeat
         int dismissed
         text workflow_title
+        text owner_token
+        text lease_until
+        int generation
     }
 
     worktrees {


### PR DESCRIPTION
Migration 084 — pure schema change, no code reads or writes the new columns yet. Idempotent column-existence probe matches the pattern established in migrations 82/83. Closes #2792.