### PR TITLE
feat(workflow): acquire lease at FlowEngine::run/resume entry, fail-f…

### DIFF
--- a/conductor-core/src/notify/tests.rs
+++ b/conductor-core/src/notify/tests.rs
@@ -1319,6 +1319,9 @@ fn make_workflow_run(id: &str, name: &str, status: WorkflowRunStatus) -> Workflo
         total_duration_ms: None,
         model: None,
         dismissed: false,
+        owner_token: None,
+        lease_until: None,
+        generation: 0,
     }
 }
 

--- a/conductor-core/src/workflow/coordinator.rs
+++ b/conductor-core/src/workflow/coordinator.rs
@@ -310,6 +310,8 @@ fn build_rk_execution_state(args: RkStateArgs) -> runkon_flow::engine::Execution
         event_sinks: args.event_sinks,
         cancellation: runkon_flow::CancellationToken::new(),
         current_execution_id: Arc::new(std::sync::Mutex::new(None)),
+        owner_token: None,
+        lease_generation: None,
     }
 }
 

--- a/conductor-core/src/workflow/manager/helpers.rs
+++ b/conductor-core/src/workflow/manager/helpers.rs
@@ -97,6 +97,9 @@ pub(in crate::workflow) fn row_to_workflow_run(
         total_duration_ms,
         model,
         dismissed: dismissed_int != 0,
+        owner_token: row.get("owner_token")?,
+        lease_until: row.get("lease_until")?,
+        generation: row.get("generation")?,
     })
 }
 

--- a/conductor-core/src/workflow/manager/lifecycle.rs
+++ b/conductor-core/src/workflow/manager/lifecycle.rs
@@ -107,6 +107,9 @@ pub fn create_workflow_run_with_targets(
         total_duration_ms: None,
         model: None,
         dismissed: false,
+        owner_token: None,
+        lease_until: None,
+        generation: 0,
     })
 }
 

--- a/conductor-tui/src/state/app_state.rs
+++ b/conductor-tui/src/state/app_state.rs
@@ -1132,6 +1132,9 @@ mod tests {
             total_duration_ms: None,
             model: None,
             dismissed,
+            owner_token: None,
+            lease_until: None,
+            generation: 0,
         }
     }
 

--- a/conductor-tui/src/state/tests/mod.rs
+++ b/conductor-tui/src/state/tests/mod.rs
@@ -114,6 +114,9 @@ pub(crate) fn make_wf_run_full(
         total_duration_ms: None,
         model: None,
         dismissed: false,
+        owner_token: None,
+        lease_until: None,
+        generation: 0,
     }
 }
 

--- a/conductor-tui/tests/tui_snapshots.rs
+++ b/conductor-tui/tests/tui_snapshots.rs
@@ -334,6 +334,9 @@ fn snap_workflow_run_detail_with_steps() {
         total_duration_ms: None,
         model: None,
         dismissed: false,
+        owner_token: None,
+        lease_until: None,
+        generation: 0,
     };
 
     let steps = vec![

--- a/conductor-web/src/routes/slack.rs
+++ b/conductor-web/src/routes/slack.rs
@@ -359,6 +359,9 @@ mod tests {
             total_duration_ms: None,
             model: None,
             dismissed: false,
+            owner_token: None,
+            lease_until: None,
+            generation: 0,
         }];
         let output = format_active_runs_for_slack(&runs);
         assert!(output.contains("Active workflow runs (1)"));

--- a/runkon-flow/src/constants.rs
+++ b/runkon-flow/src/constants.rs
@@ -12,7 +12,7 @@ pub const RUN_COLUMNS: &str =
      parent_workflow_run_id, target_label, default_bot_name, iteration, blocked_on, \
      total_input_tokens, total_output_tokens, total_cache_read_input_tokens, \
      total_cache_creation_input_tokens, total_turns, total_cost_usd, total_duration_ms, model, \
-     error, dismissed, workflow_title";
+     error, dismissed, workflow_title, owner_token, lease_until, generation";
 
 pub const FLOW_OUTPUT_INSTRUCTION: &str = r#"
 When you have finished your work, output the following block exactly as the

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -85,6 +85,10 @@ pub struct ExecutionState {
     /// Written by execute_call before dispatch; read by FlowEngine::cancel_run()
     /// to fire-and-forget executor.cancel().
     pub current_execution_id: Arc<Mutex<Option<(String, String)>>>,
+    /// Lease token held by this engine instance after a successful acquire_lease().
+    /// Used by PRs 3–5 for refresh and generation checks.
+    pub owner_token: Option<String>,
+    pub lease_generation: Option<i64>,
 }
 
 /// Input parameters for child workflow execution.
@@ -251,6 +255,8 @@ impl ExecutionState {
         child.last_heartbeat_at = Self::new_heartbeat();
         child.cancellation = cancellation;
         child.current_execution_id = Arc::new(std::sync::Mutex::new(None));
+        child.owner_token = None;
+        child.lease_generation = None;
         child
     }
 
@@ -1111,6 +1117,8 @@ mod tests {
             event_sinks: Arc::from(vec![]),
             cancellation: CancellationToken::new(),
             current_execution_id: Arc::new(std::sync::Mutex::new(None)),
+            owner_token: None,
+            lease_generation: None,
         };
 
         let child_cancellation = CancellationToken::new();
@@ -1236,6 +1244,8 @@ mod tests {
             event_sinks: Arc::clone(&sinks),
             cancellation: CancellationToken::new(),
             current_execution_id: Arc::new(std::sync::Mutex::new(None)),
+            owner_token: None,
+            lease_generation: None,
         };
 
         let ctx = parent.child_workflow_context();

--- a/runkon-flow/src/engine_error.rs
+++ b/runkon-flow/src/engine_error.rs
@@ -14,4 +14,6 @@ pub enum EngineError {
     Workflow(String),
     #[error("workflow not found: {0}")]
     WorkflowNotFound(String),
+    #[error("workflow run already owned by another engine: {0}")]
+    AlreadyOwned(String),
 }

--- a/runkon-flow/src/executors/control_flow.rs
+++ b/runkon-flow/src/executors/control_flow.rs
@@ -304,6 +304,8 @@ mod tests {
             event_sinks: Arc::from(vec![]),
             cancellation: crate::cancellation::CancellationToken::new(),
             current_execution_id: Arc::new(std::sync::Mutex::new(None)),
+            owner_token: None,
+            lease_generation: None,
         }
     }
 

--- a/runkon-flow/src/executors/foreach.rs
+++ b/runkon-flow/src/executors/foreach.rs
@@ -914,6 +914,8 @@ mod tests {
             event_sinks: Arc::from(vec![]),
             cancellation: CancellationToken::new(),
             current_execution_id: Arc::new(Mutex::new(None)),
+            owner_token: None,
+            lease_generation: None,
         };
 
         let ctx = super::ForeachParentCtx::from_state(&parent, Arc::new(DummyChildRunner));

--- a/runkon-flow/src/executors/parallel.rs
+++ b/runkon-flow/src/executors/parallel.rs
@@ -503,6 +503,8 @@ mod tests {
             event_sinks: Arc::from(vec![]),
             cancellation: crate::cancellation::CancellationToken::new(),
             current_execution_id: Arc::new(std::sync::Mutex::new(None)),
+            owner_token: None,
+            lease_generation: None,
         }
     }
 

--- a/runkon-flow/src/executors/script.rs
+++ b/runkon-flow/src/executors/script.rs
@@ -502,6 +502,8 @@ mod tests {
             event_sinks: Arc::from(vec![]),
             cancellation: crate::cancellation::CancellationToken::new(),
             current_execution_id: Arc::new(std::sync::Mutex::new(None)),
+            owner_token: None,
+            lease_generation: None,
         }
     }
 

--- a/runkon-flow/src/flow_engine.rs
+++ b/runkon-flow/src/flow_engine.rs
@@ -18,6 +18,8 @@ use crate::traits::workflow_resolver::WorkflowResolver;
 use crate::types::{WorkflowResult, WorkflowRunStep};
 use crate::workflow_resolver_directory::DirectoryWorkflowResolver;
 
+const LEASE_TTL_SECONDS: i64 = 30; // refreshed in PR 3/5
+
 // ---------------------------------------------------------------------------
 // FlowEngine
 // ---------------------------------------------------------------------------
@@ -111,6 +113,22 @@ impl FlowEngine {
         }
         state.event_sinks = Arc::from(self.event_sinks.clone());
 
+        // Acquire or re-claim lease (idempotent when token already set by resume()).
+        let token = state
+            .owner_token
+            .get_or_insert_with(|| ulid::Ulid::new().to_string())
+            .clone();
+        match state
+            .persistence
+            .acquire_lease(&state.workflow_run_id, &token, LEASE_TTL_SECONDS)
+        {
+            Ok(Some(gen)) => {
+                state.lease_generation = Some(gen);
+            }
+            Ok(None) => return Err(EngineError::AlreadyOwned(state.workflow_run_id.clone())),
+            Err(e) => return Err(e),
+        }
+
         // Ensure the exec_config.shutdown arc exists so cancel_run() can set it.
         let shutdown_arc = state
             .exec_config
@@ -161,6 +179,21 @@ impl FlowEngine {
                 "resume() requires resume_ctx to be None on entry".to_string(),
             ));
         }
+
+        // Acquire before any DB reads so concurrent resume() calls race exactly once.
+        let token = ulid::Ulid::new().to_string();
+        match state
+            .persistence
+            .acquire_lease(&state.workflow_run_id, &token, LEASE_TTL_SECONDS)
+        {
+            Ok(Some(gen)) => {
+                state.owner_token = Some(token);
+                state.lease_generation = Some(gen);
+            }
+            Ok(None) => return Err(EngineError::AlreadyOwned(state.workflow_run_id.clone())),
+            Err(e) => return Err(e),
+        }
+
         let steps = state
             .persistence
             .get_steps(&state.workflow_run_id)
@@ -1141,6 +1174,8 @@ mod tests {
             event_sinks: Arc::from(vec![]),
             cancellation: CancellationToken::new(),
             current_execution_id: Arc::new(std::sync::Mutex::new(None)),
+            owner_token: None,
+            lease_generation: None,
         }
     }
 
@@ -2048,6 +2083,186 @@ mod tests {
         assert!(
             err.to_string().contains("resume_ctx"),
             "error should mention resume_ctx; got: {err}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Lease acquisition tests
+    // ---------------------------------------------------------------------------
+
+    // AC: run() sets owner_token and lease_generation after a successful acquire.
+    #[test]
+    fn run_sets_lease_fields_on_success() {
+        use crate::persistence_memory::InMemoryWorkflowPersistence;
+
+        let persistence = Arc::new(InMemoryWorkflowPersistence::new());
+        let run = make_test_run(&persistence);
+
+        let engine = FlowEngineBuilder::new()
+            .action(Box::new(AlphaExecutor))
+            .build()
+            .unwrap();
+        let def = make_def("wf", vec![call_node("alpha")]);
+
+        let mut state = make_bare_state("wf");
+        state.persistence =
+            Arc::clone(&persistence) as Arc<dyn crate::traits::persistence::WorkflowPersistence>;
+        state.action_registry = Arc::new(ActionRegistry::new(
+            {
+                let mut m = HashMap::new();
+                m.insert(
+                    "alpha".to_string(),
+                    Box::new(AlphaExecutor)
+                        as Box<dyn crate::traits::action_executor::ActionExecutor>,
+                );
+                m
+            },
+            None,
+        ));
+        state.workflow_run_id = run.id.clone();
+
+        engine.run(&def, &mut state).unwrap();
+
+        assert!(
+            state.owner_token.is_some(),
+            "owner_token should be set after run()"
+        );
+        assert_eq!(
+            state.lease_generation,
+            Some(1),
+            "lease_generation should be 1 after first acquire"
+        );
+    }
+
+    // AC: two concurrent FlowEngine::run calls on same run_id → exactly one succeeds.
+    #[test]
+    fn two_concurrent_runs_exactly_one_succeeds() {
+        use crate::persistence_memory::InMemoryWorkflowPersistence;
+        use crate::traits::persistence::WorkflowPersistence;
+        use std::thread;
+
+        let persistence = Arc::new(InMemoryWorkflowPersistence::new());
+        let run = make_test_run(&persistence);
+        let run_id = run.id.clone();
+
+        let persistence: Arc<dyn WorkflowPersistence> = persistence;
+
+        // Build a state factory
+        let make_state_for_run = |run_id: String, p: Arc<dyn WorkflowPersistence>| {
+            let mut s = make_bare_state("wf");
+            s.persistence = p;
+            s.action_registry = Arc::new(ActionRegistry::new(
+                {
+                    let mut m = HashMap::new();
+                    m.insert(
+                        "alpha".to_string(),
+                        Box::new(AlphaExecutor)
+                            as Box<dyn crate::traits::action_executor::ActionExecutor>,
+                    );
+                    m
+                },
+                None,
+            ));
+            s.workflow_run_id = run_id;
+            s
+        };
+
+        let def = make_def("wf", vec![call_node("alpha")]);
+
+        // Use a barrier so both threads start run() at the same time.
+        let barrier = Arc::new(std::sync::Barrier::new(2));
+
+        let p1 = Arc::clone(&persistence);
+        let run_id1 = run_id.clone();
+        let barrier1 = Arc::clone(&barrier);
+        let def1 = def.clone();
+        let t1 = thread::spawn(move || {
+            let engine = FlowEngineBuilder::new()
+                .action(Box::new(AlphaExecutor))
+                .build()
+                .unwrap();
+            let mut state = make_state_for_run(run_id1, p1);
+            barrier1.wait();
+            engine.run(&def1, &mut state)
+        });
+
+        let p2 = Arc::clone(&persistence);
+        let run_id2 = run_id.clone();
+        let barrier2 = Arc::clone(&barrier);
+        let def2 = def.clone();
+        let t2 = thread::spawn(move || {
+            let engine = FlowEngineBuilder::new()
+                .action(Box::new(AlphaExecutor))
+                .build()
+                .unwrap();
+            let mut state = make_state_for_run(run_id2, p2);
+            barrier2.wait();
+            engine.run(&def2, &mut state)
+        });
+
+        let r1 = t1.join().unwrap();
+        let r2 = t2.join().unwrap();
+
+        let successes = [&r1, &r2].iter().filter(|r| r.is_ok()).count();
+        let already_owned = [&r1, &r2]
+            .iter()
+            .filter(|r| matches!(r, Err(EngineError::AlreadyOwned(_))))
+            .count();
+
+        assert_eq!(
+            successes, 1,
+            "exactly one run should succeed; got r1={r1:?}, r2={r2:?}"
+        );
+        assert_eq!(
+            already_owned, 1,
+            "exactly one run should fail with AlreadyOwned; got r1={r1:?}, r2={r2:?}"
+        );
+    }
+
+    // AC: resume() acquires lease before get_steps() — a pre-held lease blocks resume().
+    #[test]
+    fn resume_acquires_before_get_steps() {
+        use crate::persistence_memory::InMemoryWorkflowPersistence;
+        use crate::traits::persistence::WorkflowPersistence;
+
+        let persistence = Arc::new(InMemoryWorkflowPersistence::new());
+        let run = make_test_run(&persistence);
+
+        // Manually acquire the lease for another token (TTL = 1 hour, won't expire).
+        persistence
+            .acquire_lease(&run.id, "other-engine-token", 3600)
+            .unwrap();
+
+        let engine = FlowEngineBuilder::new()
+            .action(Box::new(AlphaExecutor))
+            .build()
+            .unwrap();
+        let def = make_def("wf", vec![call_node("alpha")]);
+
+        let mut state = make_bare_state("wf");
+        state.persistence = Arc::clone(&persistence) as Arc<dyn WorkflowPersistence>;
+        state.workflow_run_id = run.id.clone();
+
+        let err = engine.resume(&def, &mut state).unwrap_err();
+        assert!(
+            matches!(err, EngineError::AlreadyOwned(_)),
+            "resume() with a pre-held lease should fail with AlreadyOwned; got {err:?}"
+        );
+    }
+
+    // AC: existing single-engine workflow still completes normally.
+    #[test]
+    fn single_engine_workflow_still_completes() {
+        let engine = FlowEngineBuilder::new()
+            .action(Box::new(AlphaExecutor))
+            .build()
+            .unwrap();
+        let def = make_single_step_def();
+        let mut state = make_state_with_persistence("wf");
+        let result = engine.run(&def, &mut state).unwrap();
+        assert!(
+            result.all_succeeded,
+            "single-engine workflow should complete successfully"
         );
     }
 

--- a/runkon-flow/src/flow_engine.rs
+++ b/runkon-flow/src/flow_engine.rs
@@ -117,10 +117,10 @@ impl FlowEngine {
         let token = state
             .owner_token
             .get_or_insert_with(|| ulid::Ulid::new().to_string())
-            .clone();
+            .as_str();
         match state
             .persistence
-            .acquire_lease(&state.workflow_run_id, &token, LEASE_TTL_SECONDS)
+            .acquire_lease(&state.workflow_run_id, token, LEASE_TTL_SECONDS)
         {
             Ok(Some(gen)) => {
                 state.lease_generation = Some(gen);
@@ -1130,8 +1130,10 @@ mod tests {
         use crate::persistence_memory::InMemoryWorkflowPersistence;
         use crate::traits::script_env_provider::NoOpScriptEnvProvider;
         use crate::types::WorkflowExecConfig;
+        let persistence = InMemoryWorkflowPersistence::new();
+        persistence.seed_run("test-run");
         ExecutionState {
-            persistence: Arc::new(InMemoryWorkflowPersistence::new()),
+            persistence: Arc::new(persistence),
             action_registry: Arc::new(ActionRegistry::new(HashMap::new(), None)),
             script_env_provider: Arc::new(NoOpScriptEnvProvider),
             workflow_run_id: "test-run".to_string(),
@@ -2045,6 +2047,7 @@ mod tests {
         use crate::persistence_memory::InMemoryWorkflowPersistence;
 
         let persistence = Arc::new(InMemoryWorkflowPersistence::new());
+        persistence.seed_run("run-123");
         persistence.set_fail_get_steps(true);
 
         let engine = FlowEngineBuilder::new().build().unwrap();

--- a/runkon-flow/src/persistence_memory.rs
+++ b/runkon-flow/src/persistence_memory.rs
@@ -947,4 +947,37 @@ mod tests {
             .persist_metrics(&run.id, 100, 200, 50, 25, 0.01, 3, 5000)
             .is_ok());
     }
+
+    #[test]
+    fn test_acquire_lease_nonexistent_run_returns_none() {
+        let p = InMemoryWorkflowPersistence::new();
+        let result = p.acquire_lease("does-not-exist", "token-abc", 30);
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_acquire_lease_existing_run_returns_generation() {
+        let p = InMemoryWorkflowPersistence::new();
+        let run = p.create_run(make_new_run("test")).unwrap();
+        let result = p.acquire_lease(&run.id, "token-abc", 30).unwrap();
+        assert_eq!(result, Some(1));
+    }
+
+    #[test]
+    fn test_acquire_lease_same_token_is_idempotent() {
+        let p = InMemoryWorkflowPersistence::new();
+        let run = p.create_run(make_new_run("test")).unwrap();
+        p.acquire_lease(&run.id, "token-abc", 30).unwrap();
+        let result = p.acquire_lease(&run.id, "token-abc", 30).unwrap();
+        assert_eq!(result, Some(2));
+    }
+
+    #[test]
+    fn test_acquire_lease_conflict_returns_none() {
+        let p = InMemoryWorkflowPersistence::new();
+        let run = p.create_run(make_new_run("test")).unwrap();
+        p.acquire_lease(&run.id, "token-first", 3600).unwrap();
+        let result = p.acquire_lease(&run.id, "token-second", 30).unwrap();
+        assert_eq!(result, None);
+    }
 }

--- a/runkon-flow/src/persistence_memory.rs
+++ b/runkon-flow/src/persistence_memory.rs
@@ -75,6 +75,51 @@ impl InMemoryWorkflowPersistence {
             .store(fail, std::sync::atomic::Ordering::Relaxed);
     }
 
+    /// Test helper: insert a minimal `WorkflowRun` with the given `id` so that
+    /// `acquire_lease` can find it. Use this in tests that call `FlowEngine::run`
+    /// or `FlowEngine::resume` against an `InMemoryWorkflowPersistence` without
+    /// going through `create_run` (which generates its own id).
+    #[cfg(test)]
+    pub fn seed_run(&self, id: &str) {
+        let now = chrono::Utc::now().to_rfc3339();
+        let run = crate::types::WorkflowRun {
+            id: id.to_string(),
+            workflow_name: String::new(),
+            worktree_id: None,
+            parent_run_id: String::new(),
+            status: crate::status::WorkflowRunStatus::Pending,
+            dry_run: false,
+            trigger: "test".to_string(),
+            started_at: now,
+            ended_at: None,
+            result_summary: None,
+            error: None,
+            definition_snapshot: None,
+            inputs: std::collections::HashMap::new(),
+            ticket_id: None,
+            repo_id: None,
+            parent_workflow_run_id: None,
+            target_label: None,
+            default_bot_name: None,
+            iteration: 0,
+            blocked_on: None,
+            workflow_title: None,
+            total_input_tokens: None,
+            total_output_tokens: None,
+            total_cache_read_input_tokens: None,
+            total_cache_creation_input_tokens: None,
+            total_turns: None,
+            total_cost_usd: None,
+            total_duration_ms: None,
+            model: None,
+            dismissed: false,
+            owner_token: None,
+            lease_until: None,
+            generation: 0,
+        };
+        self.store.lock().unwrap().runs.insert(id.to_string(), run);
+    }
+
     /// Test helper: directly set the metric fields on a step so that
     /// `restore_completed_step` can be tested with non-None metric values.
     #[cfg(test)]
@@ -508,11 +553,10 @@ impl WorkflowPersistence for InMemoryWorkflowPersistence {
         let mut store = self.store.lock().map_err(|_| lock_err())?;
         let now = chrono::Utc::now();
 
-        // If the run doesn't exist in the store (common in unit tests that only set up
-        // persistence to inject specific failures), treat it as unclaimed and grant the
-        // lease without modifying the store.
+        // If the run doesn't exist, return None (no rows updated) — consistent with the SQLite
+        // implementation which returns None when the UPDATE matches 0 rows.
         let Some(run) = store.runs.get_mut(run_id) else {
-            return Ok(Some(1));
+            return Ok(None);
         };
 
         let can_claim = match &run.owner_token {

--- a/runkon-flow/src/persistence_memory.rs
+++ b/runkon-flow/src/persistence_memory.rs
@@ -159,6 +159,9 @@ impl WorkflowPersistence for InMemoryWorkflowPersistence {
             total_duration_ms: None,
             model: None,
             dismissed: false,
+            owner_token: None,
+            lease_until: None,
+            generation: 0,
         };
         let mut store = self.lock()?;
         store.runs.insert(id, run.clone());
@@ -494,6 +497,42 @@ impl WorkflowPersistence for InMemoryWorkflowPersistence {
                 )
             })
             .unwrap_or(false))
+    }
+
+    fn acquire_lease(
+        &self,
+        run_id: &str,
+        token: &str,
+        ttl_seconds: i64,
+    ) -> Result<Option<i64>, EngineError> {
+        let mut store = self.store.lock().map_err(|_| lock_err())?;
+        let now = chrono::Utc::now();
+
+        // If the run doesn't exist in the store (common in unit tests that only set up
+        // persistence to inject specific failures), treat it as unclaimed and grant the
+        // lease without modifying the store.
+        let Some(run) = store.runs.get_mut(run_id) else {
+            return Ok(Some(1));
+        };
+
+        let can_claim = match &run.owner_token {
+            None => true,
+            Some(t) if t == token => true,
+            Some(_) => run.lease_until.as_deref().is_some_and(|until| {
+                chrono::DateTime::parse_from_rfc3339(until)
+                    .map(|exp| exp < now)
+                    .unwrap_or(false)
+            }),
+        };
+
+        if !can_claim {
+            return Ok(None);
+        }
+
+        run.owner_token = Some(token.to_string());
+        run.lease_until = Some((now + chrono::Duration::seconds(ttl_seconds)).to_rfc3339());
+        run.generation += 1;
+        Ok(Some(run.generation))
     }
 
     fn tick_heartbeat(&self, _run_id: &str) -> Result<(), EngineError> {

--- a/runkon-flow/src/persistence_memory.rs
+++ b/runkon-flow/src/persistence_memory.rs
@@ -980,4 +980,16 @@ mod tests {
         let result = p.acquire_lease(&run.id, "token-second", 30).unwrap();
         assert_eq!(result, None);
     }
+
+    #[test]
+    fn test_acquire_lease_expired_lease_allows_new_token() {
+        let p = InMemoryWorkflowPersistence::new();
+        let run = p.create_run(make_new_run("test")).unwrap();
+        // Acquire with a negative TTL so the lease is already in the past.
+        let gen1 = p.acquire_lease(&run.id, "token-first", -1).unwrap();
+        assert_eq!(gen1, Some(1));
+        // A different token should be able to claim the expired lease.
+        let gen2 = p.acquire_lease(&run.id, "token-second", 30).unwrap();
+        assert_eq!(gen2, Some(2));
+    }
 }

--- a/runkon-flow/src/persistence_sqlite.rs
+++ b/runkon-flow/src/persistence_sqlite.rs
@@ -766,7 +766,7 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
                     OR owner_token = :token)",
             named_params! { ":token": token, ":ttl": ttl_seconds, ":run_id": run_id },
         )
-        .map_err(|e| EngineError::Persistence(e.to_string()))?;
+        .map_err(|e| EngineError::Persistence(format!("acquire_lease UPDATE: {e}")))?;
 
         if conn.changes() == 0u64 {
             return Ok(None);
@@ -777,7 +777,7 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
                 [run_id],
                 |r| r.get(0),
             )
-            .map_err(|e| EngineError::Persistence(e.to_string()))?;
+            .map_err(|e| EngineError::Persistence(format!("acquire_lease read generation: {e}")))?;
         Ok(Some(gen))
     }
 

--- a/runkon-flow/src/persistence_sqlite.rs
+++ b/runkon-flow/src/persistence_sqlite.rs
@@ -104,6 +104,9 @@ fn row_to_run(row: &rusqlite::Row) -> rusqlite::Result<WorkflowRun> {
         total_duration_ms: row.get("total_duration_ms")?,
         model: row.get("model")?,
         dismissed: dismissed_int != 0,
+        owner_token: row.get("owner_token")?,
+        lease_until: row.get("lease_until")?,
+        generation: row.get("generation")?,
     })
 }
 
@@ -318,6 +321,9 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
             total_duration_ms: None,
             model: None,
             dismissed: false,
+            owner_token: None,
+            lease_until: None,
+            generation: 0,
         })
     }
 
@@ -742,6 +748,39 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
     }
 
     #[allow(clippy::too_many_arguments)]
+    fn acquire_lease(
+        &self,
+        run_id: &str,
+        token: &str,
+        ttl_seconds: i64,
+    ) -> Result<Option<i64>, EngineError> {
+        let conn = self.lock()?;
+        conn.execute(
+            "UPDATE workflow_runs \
+             SET owner_token = :token, \
+                 lease_until = datetime('now', '+' || :ttl || ' seconds'), \
+                 generation  = generation + 1 \
+             WHERE id = :run_id \
+               AND (owner_token IS NULL \
+                    OR lease_until < datetime('now') \
+                    OR owner_token = :token)",
+            named_params! { ":token": token, ":ttl": ttl_seconds, ":run_id": run_id },
+        )
+        .map_err(|e| EngineError::Persistence(e.to_string()))?;
+
+        if conn.changes() == 0u64 {
+            return Ok(None);
+        }
+        let gen: i64 = conn
+            .query_row(
+                "SELECT generation FROM workflow_runs WHERE id = ?1",
+                [run_id],
+                |r| r.get(0),
+            )
+            .map_err(|e| EngineError::Persistence(e.to_string()))?;
+        Ok(Some(gen))
+    }
+
     fn persist_metrics(
         &self,
         run_id: &str,
@@ -848,4 +887,85 @@ fn validate_gate_selections(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::SqliteWorkflowPersistence;
+    use crate::traits::persistence::WorkflowPersistence;
+
+    /// Create an in-memory SQLite DB with the minimal schema for acquire_lease tests.
+    fn make_lease_db() -> (SqliteWorkflowPersistence, String) {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE workflow_runs (
+                id TEXT PRIMARY KEY,
+                owner_token TEXT,
+                lease_until TEXT,
+                generation INTEGER NOT NULL DEFAULT 0
+            );
+            INSERT INTO workflow_runs (id) VALUES ('run-1');",
+        )
+        .unwrap();
+        let p = SqliteWorkflowPersistence::from_shared_connection(Arc::new(Mutex::new(conn)));
+        (p, "run-1".to_string())
+    }
+
+    #[test]
+    fn acquire_lease_increments_generation() {
+        let (p, run_id) = make_lease_db();
+
+        let gen1 = p.acquire_lease(&run_id, "tok", 60).unwrap();
+        assert_eq!(gen1, Some(1), "first acquire should return generation 1");
+
+        let gen2 = p.acquire_lease(&run_id, "tok", 60).unwrap();
+        assert_eq!(gen2, Some(2), "same-token re-acquire should increment to 2");
+    }
+
+    #[test]
+    fn acquire_lease_returns_none_when_held_by_other() {
+        let (p, run_id) = make_lease_db();
+
+        // Acquire with token 'x' and a 1-hour TTL.
+        let gen = p.acquire_lease(&run_id, "x", 3600).unwrap();
+        assert_eq!(gen, Some(1));
+
+        // Attempt to acquire with a different token 'y' — lease is still held.
+        let result = p.acquire_lease(&run_id, "y", 3600).unwrap();
+        assert_eq!(
+            result, None,
+            "different-token acquire on held lease should return None"
+        );
+    }
+
+    #[test]
+    fn acquire_lease_succeeds_when_expired() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE workflow_runs (
+                id TEXT PRIMARY KEY,
+                owner_token TEXT,
+                lease_until TEXT,
+                generation INTEGER NOT NULL DEFAULT 0
+            );
+            -- Insert a row with an already-expired lease held by 'old-engine'.
+            INSERT INTO workflow_runs (id, owner_token, lease_until, generation)
+            VALUES ('run-exp', 'old-engine', datetime('now', '-1 second'), 5);",
+        )
+        .unwrap();
+        let p = SqliteWorkflowPersistence::from_shared_connection(Arc::new(Mutex::new(conn)));
+
+        let result = p.acquire_lease("run-exp", "new-engine", 60).unwrap();
+        assert!(
+            result.is_some(),
+            "acquire on expired lease should succeed; got None"
+        );
+        assert_eq!(
+            result,
+            Some(6),
+            "generation should be incremented from 5 to 6"
+        );
+    }
 }

--- a/runkon-flow/src/test_helpers.rs
+++ b/runkon-flow/src/test_helpers.rs
@@ -158,6 +158,8 @@ pub fn make_test_execution_state(
         event_sinks: Arc::from(vec![]),
         cancellation: CancellationToken::new(),
         current_execution_id: Arc::new(Mutex::new(None)),
+        owner_token: None,
+        lease_generation: None,
     }
 }
 
@@ -198,6 +200,14 @@ impl CountingPersistence {
 }
 
 impl crate::traits::persistence::WorkflowPersistence for CountingPersistence {
+    fn acquire_lease(
+        &self,
+        run_id: &str,
+        token: &str,
+        ttl_seconds: i64,
+    ) -> Result<Option<i64>, crate::engine_error::EngineError> {
+        self.inner.acquire_lease(run_id, token, ttl_seconds)
+    }
     fn is_run_cancelled(&self, run_id: &str) -> Result<bool, crate::engine_error::EngineError> {
         if self.cancelled.load(std::sync::atomic::Ordering::Relaxed) {
             return Ok(true);

--- a/runkon-flow/src/traits/persistence.rs
+++ b/runkon-flow/src/traits/persistence.rs
@@ -236,6 +236,15 @@ pub trait WorkflowPersistence: Send + Sync {
 
     // --- Engine lifecycle hooks ---
 
+    /// Atomically claim ownership of a workflow run. Returns the new generation on
+    /// success, or `None` if another engine already holds the lease.
+    fn acquire_lease(
+        &self,
+        run_id: &str,
+        token: &str,
+        ttl_seconds: i64,
+    ) -> Result<Option<i64>, EngineError>;
+
     /// Returns true if the run has been cancelled (e.g. via external request).
     fn is_run_cancelled(&self, run_id: &str) -> Result<bool, EngineError>;
 

--- a/runkon-flow/src/types.rs
+++ b/runkon-flow/src/types.rs
@@ -71,6 +71,11 @@ pub struct WorkflowRun {
     pub total_duration_ms: Option<i64>,
     pub model: Option<String>,
     pub dismissed: bool,
+    #[serde(skip)]
+    pub owner_token: Option<String>,
+    #[serde(skip)]
+    pub lease_until: Option<String>,
+    pub generation: i64,
 }
 
 /// Extract the human-readable title from a workflow definition snapshot JSON string.

--- a/runkon-flow/src/types.rs
+++ b/runkon-flow/src/types.rs
@@ -75,6 +75,7 @@ pub struct WorkflowRun {
     pub owner_token: Option<String>,
     #[serde(skip)]
     pub lease_until: Option<String>,
+    #[serde(skip)]
     pub generation: i64,
 }
 

--- a/runkon-flow/tests/common/mod.rs
+++ b/runkon-flow/tests/common/mod.rs
@@ -169,6 +169,8 @@ pub fn make_state(
         event_sinks: Arc::from(vec![]),
         cancellation: CancellationToken::new(),
         current_execution_id: Arc::new(Mutex::new(None)),
+        owner_token: None,
+        lease_generation: None,
     }
 }
 


### PR DESCRIPTION
…ast on conflict (#2793)

Wires atomic lease acquisition into FlowEngine::run() and FlowEngine::resume() so two concurrent engines racing on the same workflow run result in exactly one success and one clean EngineError::AlreadyOwned failure.

- Add EngineError::AlreadyOwned(String) variant
- Add WorkflowPersistence::acquire_lease trait method (returns Option<i64> generation)
- Add owner_token / lease_generation fields to ExecutionState
- Implement acquire_lease in SQLiteWorkflowPersistence (atomic UPDATE+changes())
- Implement acquire_lease in InMemoryWorkflowPersistence (for tests)
- Wire acquire_lease into FlowEngine::run() (idempotent re-claim via same token)
- Wire acquire_lease into FlowEngine::resume() (fresh token per resume)
- Update RUN_COLUMNS constant and row_to_run() for new DB columns
- Propagate new WorkflowRun fields through conductor-core, conductor-tui, conductor-web
- Add 7 new tests covering lease acquisition, concurrency, and resume ordering