### PR TITLE
chore: add trace.sh helper for TUI tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ script-*.out
 conductor.db
 conductor.db-wal
 conductor.db-shm
+conductor.log

--- a/trace.sh
+++ b/trace.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Launch the TUI with debug tracing for the workflow engine, sending logs to conductor.log.
+# Useful for diagnosing workflow stalls (e.g. step transitions that never advance).
+# Tail the log in another terminal: `tail -f conductor.log`.
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$HOME/.conductor/cargo-target}"
+
+LOG_FILE="${CONDUCTOR_LOG_FILE:-$REPO_ROOT/conductor.log}"
+RUST_LOG="${RUST_LOG:-runkon_flow=debug,conductor_core::workflow=debug}"
+export RUST_LOG
+
+echo "==> RUST_LOG=$RUST_LOG"
+echo "==> Logging stderr to $LOG_FILE"
+exec "${CARGO_TARGET_DIR:-$REPO_ROOT/target}/debug/conductor-tui" 2>"$LOG_FILE"


### PR DESCRIPTION
## Summary
- New \`trace.sh\` launches \`target/debug/conductor-tui\` with \`RUST_LOG=runkon_flow=debug,conductor_core::workflow=debug\` and redirects stderr to \`conductor.log\`.
- Useful for diagnosing workflow stalls (e.g. step transitions that never advance — see #2805 for the kind of issue this is meant to help debug).
- Both \`RUST_LOG\` and the log path (\`CONDUCTOR_LOG_FILE\`) are overridable via env.
- Adds \`conductor.log\` to \`.gitignore\`.

## Test plan
- [ ] \`./trace.sh\` boots the TUI and writes log lines to \`conductor.log\` while a workflow runs
- [ ] Custom \`RUST_LOG=\"...\" ./trace.sh\` honors the override
- [ ] Custom \`CONDUCTOR_LOG_FILE=/tmp/foo.log ./trace.sh\` writes to the custom path

🤖 Generated with [Claude Code](https://claude.com/claude-code)