### PR TITLE
feat(tui): install tracing subscriber when RUST_LOG is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "tempfile",
  "toml 0.8.23",
  "tracing",
+ "tracing-subscriber",
  "tui-textarea",
 ]
 

--- a/conductor-tui/Cargo.toml
+++ b/conductor-tui/Cargo.toml
@@ -28,6 +28,7 @@ tui-textarea = "0.7"
 toml = "0.8"
 serde_yml = "0.0"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 conductor-core = { path = "../conductor-core", features = ["test-helpers"] }

--- a/conductor-tui/src/main.rs
+++ b/conductor-tui/src/main.rs
@@ -22,6 +22,16 @@ fn main() -> Result<()> {
         original_hook(info);
     }));
 
+    // Tracing is opt-in: only install a subscriber when RUST_LOG is set, since
+    // unredirected stderr output would corrupt the ratatui display. Pair with
+    // `2>conductor.log` (see trace.sh) to capture engine traces while using the TUI.
+    if std::env::var("RUST_LOG").is_ok() {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_target(false)
+            .init();
+    }
+
     let config = load_config()?;
     ensure_dirs(&config)?;
 


### PR DESCRIPTION
## Summary
- The TUI binary never installed a tracing subscriber, so every \`tracing::info!\`/\`debug!\`/\`warn!\` call inside the workflow engine silently no-opped when run from the TUI. This made \`trace.sh\` (#2807) appear broken — \`conductor.log\` stayed at zero bytes.
- Mirrors the CLI's setup (\`conductor-cli/src/main.rs:20-26\`) but gates on \`RUST_LOG\` being set so the default TUI run stays silent — unredirected stderr would otherwise corrupt the ratatui display.

## Test plan
- [ ] \`./trace.sh\` produces non-empty \`conductor.log\` lines while a workflow runs
- [ ] Plain \`cargo run --bin conductor-tui\` (no \`RUST_LOG\`) still shows a clean TUI with no stderr output
- [ ] \`RUST_LOG=runkon_flow=info cargo run --bin conductor-tui 2>/tmp/foo.log\` writes to /tmp/foo.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)