### PR TITLE
fix(workflow): guard terminal-branch UPDATE against overwriting already-completed steps (#2805)

### DIFF
--- a/conductor-core/src/workflow/constants.rs
+++ b/conductor-core/src/workflow/constants.rs
@@ -1,5 +1,5 @@
 pub(super) use runkon_flow::constants::RUN_COLUMNS;
-pub use runkon_flow::constants::{STEP_ROLE_FOREACH, STEP_ROLE_WORKFLOW};
+pub use runkon_flow::constants::{STEP_ROLE_FOREACH, STEP_ROLE_WORKFLOW, TERMINAL_STATUSES_SQL};
 
 /// Minimum number of recent runs required to emit a regression signal.
 pub const REGRESSION_MIN_RECENT_RUNS: i64 = 5;

--- a/conductor-core/src/workflow/manager/recovery.rs
+++ b/conductor-core/src/workflow/manager/recovery.rs
@@ -10,7 +10,7 @@ use crate::error::Result;
 
 use super::helpers::row_to_workflow_run;
 
-use crate::workflow::constants::RUN_COLUMNS;
+use crate::workflow::constants::{RUN_COLUMNS, TERMINAL_STATUSES_SQL};
 use crate::workflow::types::StepKey;
 use crate::workflow::WorkflowRun;
 use crate::workflow::{WorkflowRunStatus, WorkflowStepStatus};
@@ -203,7 +203,7 @@ fn bulk_recover_steps(
                      structured_output = NULL, \
                      step_error  = NULL \
                  WHERE id IN ({in_placeholders}) \
-                 AND status NOT IN ('completed','failed','skipped','timed_out')"
+                 AND status NOT IN ({TERMINAL_STATUSES_SQL})"
         );
 
         let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::with_capacity(5 * n + 1);

--- a/conductor-core/src/workflow/manager/recovery.rs
+++ b/conductor-core/src/workflow/manager/recovery.rs
@@ -202,7 +202,8 @@ fn bulk_recover_steps(
                      markers_out = NULL, \
                      structured_output = NULL, \
                      step_error  = NULL \
-                 WHERE id IN ({in_placeholders})"
+                 WHERE id IN ({in_placeholders}) \
+                 AND status NOT IN ('completed','failed','skipped','timed_out')"
         );
 
         let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::with_capacity(5 * n + 1);

--- a/conductor-core/src/workflow/manager/tests.rs
+++ b/conductor-core/src/workflow/manager/tests.rs
@@ -4897,3 +4897,48 @@ fn test_workflow_title_malformed_snapshot_json() {
         .unwrap();
     assert_eq!(fetched.workflow_title, None);
 }
+
+// ── cancel_run step-status preservation ─────────────────────────────────────
+
+#[test]
+fn test_cancel_run_does_not_overwrite_completed_step() {
+    let conn = setup_db();
+    let run = create_worktree_run(&conn, "w1");
+
+    // Insert a step that is already completed with a known ended_at.
+    let step_id = "test-step-completed-01";
+    let original_ended_at = "2024-01-01T13:23:44Z";
+    conn.execute(
+        "INSERT INTO workflow_run_steps \
+         (id, workflow_run_id, step_name, role, position, status, ended_at) \
+         VALUES (:id, :run_id, 'implement', 'actor', 0, 'completed', :ended_at)",
+        rusqlite::named_params! {
+            ":id": step_id,
+            ":run_id": run.id,
+            ":ended_at": original_ended_at,
+        },
+    )
+    .unwrap();
+
+    // Cancel the run (run is in pending state, which is cancellable).
+    crate::workflow::cancel_run(&conn, &run.id, "workflow cancelled: UserRequested(None)")
+        .expect("cancel_run must succeed");
+
+    // The completed step row must be unchanged.
+    let (status, ended_at): (String, String) = conn
+        .query_row(
+            "SELECT status, ended_at FROM workflow_run_steps WHERE id = ?",
+            rusqlite::params![step_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("step row must exist after cancel");
+
+    assert_eq!(
+        status, "completed",
+        "cancel_run must not regress a completed step to failed"
+    );
+    assert_eq!(
+        ended_at, original_ended_at,
+        "cancel_run must not overwrite ended_at of a completed step"
+    );
+}

--- a/runkon-flow/src/constants.rs
+++ b/runkon-flow/src/constants.rs
@@ -14,6 +14,9 @@ pub const RUN_COLUMNS: &str =
      total_cache_creation_input_tokens, total_turns, total_cost_usd, total_duration_ms, model, \
      error, dismissed, workflow_title, owner_token, lease_until, generation";
 
+/// SQL fragment listing every terminal step status, for use in `IN`/`NOT IN` clauses.
+pub const TERMINAL_STATUSES_SQL: &str = "'completed','failed','skipped','timed_out'";
+
 pub const FLOW_OUTPUT_INSTRUCTION: &str = r#"
 When you have finished your work, output the following block exactly as the
 last thing in your response. Do not include this block in code examples or

--- a/runkon-flow/src/persistence_sqlite.rs
+++ b/runkon-flow/src/persistence_sqlite.rs
@@ -475,8 +475,9 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
             .map_err(db_err)?
         } else if update.status.is_terminal() {
             let now = Utc::now().to_rfc3339();
-            conn.execute(
-                "UPDATE workflow_run_steps SET status = :status, \
+            let n = conn
+                .execute(
+                    "UPDATE workflow_run_steps SET status = :status, \
                  child_run_id = COALESCE(:child_run_id, child_run_id), \
                  ended_at = :ended_at, result_text = :result_text, context_out = :context_out, \
                  markers_out = :markers_out, \
@@ -484,22 +485,49 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
                  structured_output = :structured_output, step_error = :step_error \
                  WHERE id = :id \
                  AND (SELECT generation FROM workflow_runs \
-                      WHERE id = workflow_run_steps.workflow_run_id) = :generation",
-                named_params![
-                    ":status": update.status,
-                    ":child_run_id": update.child_run_id,
-                    ":ended_at": now,
-                    ":result_text": update.result_text,
-                    ":context_out": update.context_out,
-                    ":markers_out": update.markers_out,
-                    ":retry_count": update.retry_count,
-                    ":structured_output": update.structured_output,
-                    ":step_error": update.step_error,
-                    ":id": step_id,
-                    ":generation": update.generation,
-                ],
-            )
-            .map_err(db_err)?
+                      WHERE id = workflow_run_steps.workflow_run_id) = :generation \
+                 AND status NOT IN ('completed','failed','skipped','timed_out')",
+                    named_params![
+                        ":status": update.status,
+                        ":child_run_id": update.child_run_id,
+                        ":ended_at": now,
+                        ":result_text": update.result_text,
+                        ":context_out": update.context_out,
+                        ":markers_out": update.markers_out,
+                        ":retry_count": update.retry_count,
+                        ":structured_output": update.structured_output,
+                        ":step_error": update.step_error,
+                        ":id": step_id,
+                        ":generation": update.generation,
+                    ],
+                )
+                .map_err(db_err)?;
+            if n == 0 {
+                // Disambiguate: already terminal with correct generation (benign no-op) vs
+                // generation truly mismatched (caller lost the lease).
+                let already_terminal = conn
+                    .query_row(
+                        "SELECT 1 FROM workflow_run_steps \
+                         WHERE id = :id \
+                         AND (SELECT generation FROM workflow_runs \
+                              WHERE id = workflow_run_steps.workflow_run_id) = :generation \
+                         AND status IN ('completed','failed','skipped','timed_out')",
+                        named_params![":id": step_id, ":generation": update.generation],
+                        |_| Ok(()),
+                    )
+                    .optional()
+                    .map_err(db_err)?
+                    .is_some();
+                if already_terminal {
+                    tracing::debug!(
+                        step_id = %step_id,
+                        "update_step: step already terminal, skipping overwrite"
+                    );
+                    return Ok(());
+                }
+                return Err(EngineError::Cancelled(CancellationReason::LeaseLost));
+            }
+            n
         } else {
             conn.execute(
                 "UPDATE workflow_run_steps SET status = :status WHERE id = :id \
@@ -1049,6 +1077,82 @@ mod tests {
             ),
             "terminal branch should return LeaseLost on stale generation; got {result:?}"
         );
+    }
+
+    #[test]
+    fn update_step_terminal_branch_noop_when_already_completed() {
+        use crate::status::WorkflowStepStatus;
+        use crate::traits::persistence::StepUpdate;
+
+        let (p, run_id, step_id) = make_step_db();
+
+        // Mark the step as completed (generation=1 matches the DB seed).
+        p.update_step(
+            &step_id,
+            StepUpdate {
+                generation: 1,
+                status: WorkflowStepStatus::Completed,
+                child_run_id: None,
+                result_text: Some("success".to_string()),
+                context_out: None,
+                markers_out: None,
+                retry_count: None,
+                structured_output: None,
+                step_error: None,
+            },
+        )
+        .expect("first update to completed must succeed");
+
+        // Capture the ended_at written by the first update.
+        let (status_after_first, ended_at_after_first): (String, String) = p
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT status, ended_at FROM workflow_run_steps WHERE id = ?",
+                rusqlite::params![step_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("row must exist");
+        assert_eq!(status_after_first, "completed");
+
+        // Try to overwrite with Failed — must be a no-op.
+        let result = p.update_step(
+            &step_id,
+            StepUpdate {
+                generation: 1,
+                status: WorkflowStepStatus::Failed,
+                child_run_id: None,
+                result_text: Some("overwrite attempt".to_string()),
+                context_out: None,
+                markers_out: None,
+                retry_count: None,
+                structured_output: None,
+                step_error: Some("cancelled".to_string()),
+            },
+        );
+        assert!(
+            result.is_ok(),
+            "update_step on already-completed step must return Ok; got {result:?}"
+        );
+
+        // Row must be unchanged.
+        let (status_final, ended_at_final): (String, String) = p
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT status, ended_at FROM workflow_run_steps WHERE id = ?",
+                rusqlite::params![step_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("row must still exist");
+        assert_eq!(status_final, "completed", "status must remain completed");
+        assert_eq!(
+            ended_at_final, ended_at_after_first,
+            "ended_at must be unchanged after no-op"
+        );
+
+        // run_id is read by other tests; suppress the unused warning.
+        let _ = run_id;
     }
 
     #[test]

--- a/runkon-flow/src/persistence_sqlite.rs
+++ b/runkon-flow/src/persistence_sqlite.rs
@@ -43,6 +43,34 @@ static STEP_COLUMNS_WITH_PREFIX: std::sync::LazyLock<String> = std::sync::LazyLo
         .join(", ")
 });
 
+/// Precomputed SQL for the terminal-status UPDATE in `update_step`. Allocated once so
+/// the hot-path call site carries no per-invocation heap cost.
+static SQL_UPDATE_TERMINAL: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+    format!(
+        "UPDATE workflow_run_steps SET status = :status, \
+         child_run_id = COALESCE(:child_run_id, child_run_id), \
+         ended_at = :ended_at, result_text = :result_text, context_out = :context_out, \
+         markers_out = :markers_out, \
+         retry_count = COALESCE(:retry_count, retry_count), \
+         structured_output = :structured_output, step_error = :step_error \
+         WHERE id = :id \
+         AND (SELECT generation FROM workflow_runs \
+              WHERE id = workflow_run_steps.workflow_run_id) = :generation \
+         AND status NOT IN ({TERMINAL_STATUSES_SQL})"
+    )
+});
+
+/// Precomputed SQL for the already-terminal disambiguation check in `update_step`.
+static SQL_CHECK_TERMINAL: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+    format!(
+        "SELECT 1 FROM workflow_run_steps \
+         WHERE id = :id \
+         AND (SELECT generation FROM workflow_runs \
+              WHERE id = workflow_run_steps.workflow_run_id) = :generation \
+         AND status IN ({TERMINAL_STATUSES_SQL})"
+    )
+});
+
 // ---------------------------------------------------------------------------
 // Row mappers (rusqlite::Row → runkon-flow type)
 // ---------------------------------------------------------------------------
@@ -475,21 +503,9 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
             .map_err(db_err)?
         } else if update.status.is_terminal() {
             let now = Utc::now().to_rfc3339();
-            let update_sql = format!(
-                "UPDATE workflow_run_steps SET status = :status, \
-                 child_run_id = COALESCE(:child_run_id, child_run_id), \
-                 ended_at = :ended_at, result_text = :result_text, context_out = :context_out, \
-                 markers_out = :markers_out, \
-                 retry_count = COALESCE(:retry_count, retry_count), \
-                 structured_output = :structured_output, step_error = :step_error \
-                 WHERE id = :id \
-                 AND (SELECT generation FROM workflow_runs \
-                      WHERE id = workflow_run_steps.workflow_run_id) = :generation \
-                 AND status NOT IN ({TERMINAL_STATUSES_SQL})"
-            );
             let n = conn
                 .execute(
-                    &update_sql,
+                    &SQL_UPDATE_TERMINAL,
                     named_params![
                         ":status": update.status,
                         ":child_run_id": update.child_run_id,
@@ -508,16 +524,9 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
             if n == 0 {
                 // Disambiguate: already terminal with correct generation (benign no-op) vs
                 // generation truly mismatched (caller lost the lease).
-                let check_sql = format!(
-                    "SELECT 1 FROM workflow_run_steps \
-                     WHERE id = :id \
-                     AND (SELECT generation FROM workflow_runs \
-                          WHERE id = workflow_run_steps.workflow_run_id) = :generation \
-                     AND status IN ({TERMINAL_STATUSES_SQL})"
-                );
                 let already_terminal = conn
                     .query_row(
-                        &check_sql,
+                        &SQL_CHECK_TERMINAL,
                         named_params![":id": step_id, ":generation": update.generation],
                         |_| Ok(()),
                     )

--- a/runkon-flow/src/persistence_sqlite.rs
+++ b/runkon-flow/src/persistence_sqlite.rs
@@ -12,7 +12,7 @@ use chrono::Utc;
 use rusqlite::{named_params, Connection, OptionalExtension};
 
 use crate::cancellation_reason::CancellationReason;
-use crate::constants::RUN_COLUMNS;
+use crate::constants::{RUN_COLUMNS, TERMINAL_STATUSES_SQL};
 use crate::engine_error::EngineError;
 use crate::status::{WorkflowRunStatus, WorkflowStepStatus};
 use crate::traits::persistence::{
@@ -475,9 +475,8 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
             .map_err(db_err)?
         } else if update.status.is_terminal() {
             let now = Utc::now().to_rfc3339();
-            let n = conn
-                .execute(
-                    "UPDATE workflow_run_steps SET status = :status, \
+            let update_sql = format!(
+                "UPDATE workflow_run_steps SET status = :status, \
                  child_run_id = COALESCE(:child_run_id, child_run_id), \
                  ended_at = :ended_at, result_text = :result_text, context_out = :context_out, \
                  markers_out = :markers_out, \
@@ -486,7 +485,11 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
                  WHERE id = :id \
                  AND (SELECT generation FROM workflow_runs \
                       WHERE id = workflow_run_steps.workflow_run_id) = :generation \
-                 AND status NOT IN ('completed','failed','skipped','timed_out')",
+                 AND status NOT IN ({TERMINAL_STATUSES_SQL})"
+            );
+            let n = conn
+                .execute(
+                    &update_sql,
                     named_params![
                         ":status": update.status,
                         ":child_run_id": update.child_run_id,
@@ -505,13 +508,16 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
             if n == 0 {
                 // Disambiguate: already terminal with correct generation (benign no-op) vs
                 // generation truly mismatched (caller lost the lease).
+                let check_sql = format!(
+                    "SELECT 1 FROM workflow_run_steps \
+                     WHERE id = :id \
+                     AND (SELECT generation FROM workflow_runs \
+                          WHERE id = workflow_run_steps.workflow_run_id) = :generation \
+                     AND status IN ({TERMINAL_STATUSES_SQL})"
+                );
                 let already_terminal = conn
                     .query_row(
-                        "SELECT 1 FROM workflow_run_steps \
-                         WHERE id = :id \
-                         AND (SELECT generation FROM workflow_runs \
-                              WHERE id = workflow_run_steps.workflow_run_id) = :generation \
-                         AND status IN ('completed','failed','skipped','timed_out')",
+                        &check_sql,
                         named_params![":id": step_id, ":generation": update.generation],
                         |_| Ok(()),
                     )


### PR DESCRIPTION
## Summary

Fixes #2805 — workflow cancellation was silently overwriting already-completed/failed/skipped/timed_out step rows, regressing their status and `ended_at` timestamp.

**Root cause:** Two SQL `UPDATE` statements lacked a `status NOT IN (terminal)` guard:
1. `runkon-flow/src/persistence_sqlite.rs` — `update_step` terminal branch overwrites rows regardless of current status
2. `conductor-core/src/workflow/manager/recovery.rs` — `bulk_recover_steps` bulk UPDATE has no status guard

**Likely production path (run `01KQMCVMW4VQC79M1CC2G6S8T2`):** The runkon-flow call executor's `Err(Cancelled)` branch (in `call.rs:281-294`) reached `update_step(Failed)` against the already-completed `implement` step — either from the watchdog-reclaim path (#2796) or from the cancel signal racing the result-collection thread. The terminal-branch UPDATE had no status guard and silently overwrote the completed row. The `tracing::debug!` added here will identify the exact code path next time.

## Changes

- **`runkon-flow/src/persistence_sqlite.rs`** — `update_step` terminal branch:
  - Adds `AND status NOT IN ('completed','failed','skipped','timed_out')` to the WHERE clause
  - When `affected == 0`, disambiguates via a follow-up SELECT: if the step is already terminal with the correct generation, returns `Ok(())` (benign no-op) + emits `tracing::debug!`; if generation mismatches, returns `Cancelled(LeaseLost)` (existing behavior)

- **`conductor-core/src/workflow/manager/recovery.rs`** — `bulk_recover_steps`:
  - Adds the same `AND status NOT IN (…)` guard to the bulk UPDATE

## Tests

- `update_step_terminal_branch_noop_when_already_completed` — unit test seeding a completed step and verifying `update_step(Failed)` returns `Ok(())` with the row unchanged
- `test_cancel_run_does_not_overwrite_completed_step` — regression test verifying `cancel_run` does not regress a pre-completed step

## Test plan

- [ ] `cargo nextest run -p runkon-flow --features rusqlite` → all 268 tests pass including new test
- [ ] `cargo nextest run -p conductor-core --features test-helpers` → all tests pass including new regression test
- [ ] `cargo clippy --workspace -- -D warnings` → clean
- [ ] `cargo fmt --all --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)