### PR TITLE
fix(tui): route tracing writer to stderr, not stdout

### DIFF
--- a/conductor-tui/src/main.rs
+++ b/conductor-tui/src/main.rs
@@ -22,12 +22,15 @@ fn main() -> Result<()> {
         original_hook(info);
     }));
 
-    // Tracing is opt-in: only install a subscriber when RUST_LOG is set, since
-    // unredirected stderr output would corrupt the ratatui display. Pair with
-    // `2>conductor.log` (see trace.sh) to capture engine traces while using the TUI.
+    // Tracing is opt-in: only install a subscriber when RUST_LOG is set. Writes
+    // to stderr — not stdout, the tracing_subscriber default — so ratatui's
+    // stdout-based rendering stays intact and `2>conductor.log` (see trace.sh)
+    // captures the traces. Without `with_writer(stderr)`, log lines bleed
+    // through the TUI display.
     if std::env::var("RUST_LOG").is_ok() {
         tracing_subscriber::fmt()
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_writer(std::io::stderr)
             .with_target(false)
             .init();
     }


### PR DESCRIPTION
## Summary
Follow-up to #2808. \`tracing_subscriber::fmt()\` defaults to stdout, which ratatui also owns for alternate-screen rendering. With \`RUST_LOG\` set, log lines bled through the TUI display and \`2>conductor.log\` (in \`trace.sh\`) redirected nothing useful. Adding \`.with_writer(std::io::stderr)\` sends the traces where the redirection expects them.

## Test plan
- [ ] \`./trace.sh\` shows a clean TUI with no bleed-through; traces appear in \`conductor.log\`
- [ ] Plain \`cargo run --bin conductor-tui\` (no \`RUST_LOG\`) still shows a clean TUI
- [ ] \`RUST_LOG=runkon_flow=info cargo run --bin conductor-tui 2>/tmp/foo.log\` writes to /tmp/foo.log without TUI corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)