### PR TITLE
perf(runkon-flow): batch fan-out item DB writes in foreach (#2684)

### DIFF
--- a/runkon-flow/src/executors/foreach.rs
+++ b/runkon-flow/src/executors/foreach.rs
@@ -345,7 +345,7 @@ pub fn execute_foreach(
             });
 
             batch.push((
-                item_db_id.clone(),
+                item_db_id,
                 FanOutItemUpdate::Terminal {
                     status: if succeeded {
                         FanOutItemStatus::Completed

--- a/runkon-flow/src/executors/foreach.rs
+++ b/runkon-flow/src/executors/foreach.rs
@@ -325,6 +325,7 @@ pub fn execute_foreach(
             completed.push(m);
         }
 
+        let mut batch: Vec<(String, FanOutItemUpdate)> = Vec::new();
         for (item_db_id, succeeded) in completed {
             in_flight -= 1;
 
@@ -343,19 +344,16 @@ pub fn execute_foreach(
                 String::new()
             });
 
-            state
-                .persistence
-                .update_fan_out_item(
-                    &item_db_id,
-                    FanOutItemUpdate::Terminal {
-                        status: if succeeded {
-                            FanOutItemStatus::Completed
-                        } else {
-                            FanOutItemStatus::Failed
-                        },
+            batch.push((
+                item_db_id.clone(),
+                FanOutItemUpdate::Terminal {
+                    status: if succeeded {
+                        FanOutItemStatus::Completed
+                    } else {
+                        FanOutItemStatus::Failed
                     },
-                )
-                .map_err(p_err)?;
+                },
+            ));
 
             emit_event(
                 state,
@@ -391,15 +389,12 @@ pub fn execute_foreach(
                         skipped_count += to_skip.len();
                         for skip_id in &to_skip {
                             if let Some(skip_db_id) = item_id_to_db_id.get(skip_id) {
-                                state
-                                    .persistence
-                                    .update_fan_out_item(
-                                        skip_db_id,
-                                        FanOutItemUpdate::Terminal {
-                                            status: FanOutItemStatus::Skipped,
-                                        },
-                                    )
-                                    .map_err(p_err)?;
+                                batch.push((
+                                    skip_db_id.clone(),
+                                    FanOutItemUpdate::Terminal {
+                                        status: FanOutItemStatus::Skipped,
+                                    },
+                                ));
                             }
                             terminal_ids.insert(skip_id.clone());
                             newly_terminal.push(skip_id.clone());
@@ -442,6 +437,12 @@ pub fn execute_foreach(
                     });
                 }
             }
+        }
+        if !batch.is_empty() {
+            state
+                .persistence
+                .batch_update_fan_out_items(&batch)
+                .map_err(p_err)?;
         }
 
         // 2. Check parent cancellation.

--- a/runkon-flow/src/persistence_memory.rs
+++ b/runkon-flow/src/persistence_memory.rs
@@ -1153,6 +1153,53 @@ mod tests {
     }
 
     #[test]
+    fn batch_update_fan_out_items_running_variant() {
+        use crate::traits::persistence::FanOutItemUpdate;
+
+        let p = InMemoryWorkflowPersistence::new();
+        let run = p.create_run(make_new_run("test")).unwrap();
+        let step_id = p.insert_step(make_new_step(&run.id, "foreach")).unwrap();
+        let id1 = p
+            .insert_fan_out_item(&step_id, "ticket", "t-1", "ref-1")
+            .unwrap();
+
+        let updates = vec![(
+            id1.clone(),
+            FanOutItemUpdate::Running {
+                child_run_id: "run-child-abc".to_string(),
+            },
+        )];
+        p.batch_update_fan_out_items(&updates).unwrap();
+
+        let items = p.get_fan_out_items(&step_id, None).unwrap();
+        let item = items.iter().find(|i| i.id == id1).unwrap();
+        assert_eq!(item.status, "running");
+        assert_eq!(item.child_run_id.as_deref(), Some("run-child-abc"));
+        assert!(item.dispatched_at.is_some(), "dispatched_at must be set");
+        assert!(item.completed_at.is_none(), "completed_at must not be set");
+    }
+
+    #[test]
+    fn batch_update_fan_out_items_missing_item_returns_error() {
+        use crate::traits::persistence::{FanOutItemStatus, FanOutItemUpdate};
+
+        let p = InMemoryWorkflowPersistence::new();
+        let run = p.create_run(make_new_run("test")).unwrap();
+        let _step_id = p.insert_step(make_new_step(&run.id, "foreach")).unwrap();
+
+        let updates = vec![(
+            "does-not-exist".to_string(),
+            FanOutItemUpdate::Terminal {
+                status: FanOutItemStatus::Completed,
+            },
+        )];
+        assert!(
+            p.batch_update_fan_out_items(&updates).is_err(),
+            "should error for non-existent item"
+        );
+    }
+
+    #[test]
     fn test_acquire_lease_nonexistent_run_returns_none() {
         let p = InMemoryWorkflowPersistence::new();
         let result = p.acquire_lease("does-not-exist", "token-abc", 30);

--- a/runkon-flow/src/persistence_memory.rs
+++ b/runkon-flow/src/persistence_memory.rs
@@ -474,6 +474,34 @@ impl WorkflowPersistence for InMemoryWorkflowPersistence {
         Ok(())
     }
 
+    fn batch_update_fan_out_items(
+        &self,
+        updates: &[(String, FanOutItemUpdate)],
+    ) -> Result<(), EngineError> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+        let mut store = self.lock()?;
+        let now = Utc::now().to_rfc3339();
+        for (item_id, update) in updates {
+            let item = store.fan_out_items.get_mut(item_id).ok_or_else(|| {
+                EngineError::Persistence(format!("fan-out item {item_id} not found"))
+            })?;
+            match update {
+                FanOutItemUpdate::Running { child_run_id } => {
+                    item.status = "running".to_string();
+                    item.child_run_id = Some(child_run_id.clone());
+                    item.dispatched_at = Some(now.clone());
+                }
+                FanOutItemUpdate::Terminal { status } => {
+                    item.status = status.as_str().to_string();
+                    item.completed_at = Some(now.clone());
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn get_fan_out_items(
         &self,
         step_run_id: &str,
@@ -1047,6 +1075,81 @@ mod tests {
         assert!(p
             .persist_metrics(&run.id, 100, 200, 50, 25, 0.01, 3, 5000)
             .is_ok());
+    }
+
+    #[test]
+    fn batch_update_fan_out_items_mixed_terminal_statuses() {
+        use crate::traits::persistence::{FanOutItemStatus, FanOutItemUpdate};
+
+        let p = InMemoryWorkflowPersistence::new();
+        let run = p.create_run(make_new_run("test")).unwrap();
+        let step_id = p.insert_step(make_new_step(&run.id, "foreach")).unwrap();
+
+        let id1 = p
+            .insert_fan_out_item(&step_id, "ticket", "t-1", "ref-1")
+            .unwrap();
+        let id2 = p
+            .insert_fan_out_item(&step_id, "ticket", "t-2", "ref-2")
+            .unwrap();
+        let id3 = p
+            .insert_fan_out_item(&step_id, "ticket", "t-3", "ref-3")
+            .unwrap();
+
+        let updates = vec![
+            (
+                id1.clone(),
+                FanOutItemUpdate::Terminal {
+                    status: FanOutItemStatus::Completed,
+                },
+            ),
+            (
+                id2.clone(),
+                FanOutItemUpdate::Terminal {
+                    status: FanOutItemStatus::Failed,
+                },
+            ),
+            (
+                id3.clone(),
+                FanOutItemUpdate::Terminal {
+                    status: FanOutItemStatus::Skipped,
+                },
+            ),
+        ];
+
+        p.batch_update_fan_out_items(&updates).unwrap();
+
+        let items = p.get_fan_out_items(&step_id, None).unwrap();
+        let get = |id: &str| items.iter().find(|i| i.id == id).unwrap().clone();
+
+        let item1 = get(&id1);
+        assert_eq!(item1.status, "completed");
+        assert!(item1.completed_at.is_some(), "completed_at must be set");
+
+        let item2 = get(&id2);
+        assert_eq!(item2.status, "failed");
+        assert!(item2.completed_at.is_some());
+
+        let item3 = get(&id3);
+        assert_eq!(item3.status, "skipped");
+        assert!(item3.completed_at.is_some());
+    }
+
+    #[test]
+    fn batch_update_fan_out_items_empty_is_noop() {
+        use crate::traits::persistence::FanOutItemUpdate;
+
+        let p = InMemoryWorkflowPersistence::new();
+        let run = p.create_run(make_new_run("test")).unwrap();
+        let step_id = p.insert_step(make_new_step(&run.id, "foreach")).unwrap();
+        let _id = p
+            .insert_fan_out_item(&step_id, "ticket", "t-1", "ref-1")
+            .unwrap();
+
+        p.batch_update_fan_out_items(&[] as &[(String, FanOutItemUpdate)])
+            .unwrap();
+
+        let items = p.get_fan_out_items(&step_id, None).unwrap();
+        assert_eq!(items[0].status, "pending", "empty batch must be a no-op");
     }
 
     #[test]

--- a/runkon-flow/src/persistence_sqlite.rs
+++ b/runkon-flow/src/persistence_sqlite.rs
@@ -641,6 +641,50 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
         Ok(())
     }
 
+    fn batch_update_fan_out_items(
+        &self,
+        updates: &[(String, FanOutItemUpdate)],
+    ) -> Result<(), EngineError> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+        let conn = self.lock()?;
+        let tx = conn.unchecked_transaction().map_err(db_err)?;
+        let now = Utc::now().to_rfc3339();
+        for (item_id, update) in updates {
+            match update {
+                FanOutItemUpdate::Running { child_run_id } => {
+                    tx.execute(
+                        "UPDATE workflow_run_step_fan_out_items \
+                         SET status = 'running', child_run_id = :child_run_id, dispatched_at = :now \
+                         WHERE id = :id",
+                        named_params![
+                            ":child_run_id": child_run_id,
+                            ":now": now,
+                            ":id": item_id,
+                        ],
+                    )
+                    .map_err(db_err)?;
+                }
+                FanOutItemUpdate::Terminal { status } => {
+                    tx.execute(
+                        "UPDATE workflow_run_step_fan_out_items \
+                         SET status = :status, completed_at = :now \
+                         WHERE id = :id",
+                        named_params![
+                            ":status": status.as_str(),
+                            ":now": now,
+                            ":id": item_id,
+                        ],
+                    )
+                    .map_err(db_err)?;
+                }
+            }
+        }
+        tx.commit().map_err(db_err)?;
+        Ok(())
+    }
+
     fn get_fan_out_items(
         &self,
         step_run_id: &str,
@@ -1219,6 +1263,97 @@ mod tests {
             result, None,
             "different-token acquire on held lease should return None"
         );
+    }
+
+    fn make_fan_out_db() -> (SqliteWorkflowPersistence, String) {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE workflow_run_step_fan_out_items (
+                id TEXT PRIMARY KEY,
+                step_run_id TEXT NOT NULL,
+                item_type TEXT NOT NULL,
+                item_id TEXT NOT NULL,
+                item_ref TEXT NOT NULL DEFAULT '',
+                child_run_id TEXT,
+                status TEXT NOT NULL DEFAULT 'pending',
+                dispatched_at TEXT,
+                completed_at TEXT
+            );",
+        )
+        .unwrap();
+        let p = SqliteWorkflowPersistence::from_shared_connection(Arc::new(Mutex::new(conn)));
+        (p, "step-1".to_string())
+    }
+
+    #[test]
+    fn batch_update_fan_out_items_mixed_terminal_statuses() {
+        use crate::traits::persistence::{FanOutItemStatus, FanOutItemUpdate};
+
+        let (p, step_id) = make_fan_out_db();
+
+        let id1 = p
+            .insert_fan_out_item(&step_id, "ticket", "t-1", "ref-1")
+            .unwrap();
+        let id2 = p
+            .insert_fan_out_item(&step_id, "ticket", "t-2", "ref-2")
+            .unwrap();
+        let id3 = p
+            .insert_fan_out_item(&step_id, "ticket", "t-3", "ref-3")
+            .unwrap();
+
+        let updates = vec![
+            (
+                id1.clone(),
+                FanOutItemUpdate::Terminal {
+                    status: FanOutItemStatus::Completed,
+                },
+            ),
+            (
+                id2.clone(),
+                FanOutItemUpdate::Terminal {
+                    status: FanOutItemStatus::Failed,
+                },
+            ),
+            (
+                id3.clone(),
+                FanOutItemUpdate::Terminal {
+                    status: FanOutItemStatus::Skipped,
+                },
+            ),
+        ];
+
+        p.batch_update_fan_out_items(&updates).unwrap();
+
+        let items = p.get_fan_out_items(&step_id, None).unwrap();
+        let get = |id: &str| items.iter().find(|i| i.id == id).unwrap().clone();
+
+        let item1 = get(&id1);
+        assert_eq!(item1.status, "completed");
+        assert!(item1.completed_at.is_some(), "completed_at must be set");
+
+        let item2 = get(&id2);
+        assert_eq!(item2.status, "failed");
+        assert!(item2.completed_at.is_some());
+
+        let item3 = get(&id3);
+        assert_eq!(item3.status, "skipped");
+        assert!(item3.completed_at.is_some());
+    }
+
+    #[test]
+    fn batch_update_fan_out_items_empty_is_noop() {
+        use crate::traits::persistence::FanOutItemUpdate;
+
+        let (p, step_id) = make_fan_out_db();
+        let _id = p
+            .insert_fan_out_item(&step_id, "ticket", "t-1", "ref-1")
+            .unwrap();
+
+        p.batch_update_fan_out_items(&[] as &[(String, FanOutItemUpdate)])
+            .unwrap();
+
+        let items = p.get_fan_out_items(&step_id, None).unwrap();
+        assert_eq!(items[0].status, "pending", "empty batch must be a no-op");
     }
 
     #[test]

--- a/runkon-flow/src/persistence_sqlite.rs
+++ b/runkon-flow/src/persistence_sqlite.rs
@@ -652,9 +652,9 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
         let tx = conn.unchecked_transaction().map_err(db_err)?;
         let now = Utc::now().to_rfc3339();
         for (item_id, update) in updates {
-            match update {
-                FanOutItemUpdate::Running { child_run_id } => {
-                    tx.execute(
+            let rows_changed = match update {
+                FanOutItemUpdate::Running { child_run_id } => tx
+                    .execute(
                         "UPDATE workflow_run_step_fan_out_items \
                          SET status = 'running', child_run_id = :child_run_id, dispatched_at = :now \
                          WHERE id = :id",
@@ -664,10 +664,9 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
                             ":id": item_id,
                         ],
                     )
-                    .map_err(db_err)?;
-                }
-                FanOutItemUpdate::Terminal { status } => {
-                    tx.execute(
+                    .map_err(db_err)?,
+                FanOutItemUpdate::Terminal { status } => tx
+                    .execute(
                         "UPDATE workflow_run_step_fan_out_items \
                          SET status = :status, completed_at = :now \
                          WHERE id = :id",
@@ -677,8 +676,12 @@ impl WorkflowPersistence for SqliteWorkflowPersistence {
                             ":id": item_id,
                         ],
                     )
-                    .map_err(db_err)?;
-                }
+                    .map_err(db_err)?,
+            };
+            if rows_changed == 0 {
+                return Err(EngineError::Persistence(format!(
+                    "fan-out item {item_id} not found"
+                )));
             }
         }
         tx.commit().map_err(db_err)?;
@@ -1354,6 +1357,49 @@ mod tests {
 
         let items = p.get_fan_out_items(&step_id, None).unwrap();
         assert_eq!(items[0].status, "pending", "empty batch must be a no-op");
+    }
+
+    #[test]
+    fn batch_update_fan_out_items_running_variant() {
+        use crate::traits::persistence::FanOutItemUpdate;
+
+        let (p, step_id) = make_fan_out_db();
+        let id1 = p
+            .insert_fan_out_item(&step_id, "ticket", "t-1", "ref-1")
+            .unwrap();
+
+        let updates = vec![(
+            id1.clone(),
+            FanOutItemUpdate::Running {
+                child_run_id: "run-child-abc".to_string(),
+            },
+        )];
+        p.batch_update_fan_out_items(&updates).unwrap();
+
+        let items = p.get_fan_out_items(&step_id, None).unwrap();
+        let item = items.iter().find(|i| i.id == id1).unwrap();
+        assert_eq!(item.status, "running");
+        assert_eq!(item.child_run_id.as_deref(), Some("run-child-abc"));
+        assert!(item.dispatched_at.is_some(), "dispatched_at must be set");
+        assert!(item.completed_at.is_none(), "completed_at must not be set");
+    }
+
+    #[test]
+    fn batch_update_fan_out_items_missing_item_returns_error() {
+        use crate::traits::persistence::{FanOutItemStatus, FanOutItemUpdate};
+
+        let (p, _step_id) = make_fan_out_db();
+
+        let updates = vec![(
+            "does-not-exist".to_string(),
+            FanOutItemUpdate::Terminal {
+                status: FanOutItemStatus::Completed,
+            },
+        )];
+        assert!(
+            p.batch_update_fan_out_items(&updates).is_err(),
+            "should error for non-existent item"
+        );
     }
 
     #[test]

--- a/runkon-flow/src/test_helpers.rs
+++ b/runkon-flow/src/test_helpers.rs
@@ -284,6 +284,12 @@ impl crate::traits::persistence::WorkflowPersistence for CountingPersistence {
     ) -> Result<(), crate::engine_error::EngineError> {
         self.inner.update_fan_out_item(id, u)
     }
+    fn batch_update_fan_out_items(
+        &self,
+        updates: &[(String, crate::traits::persistence::FanOutItemUpdate)],
+    ) -> Result<(), crate::engine_error::EngineError> {
+        self.inner.batch_update_fan_out_items(updates)
+    }
     fn get_fan_out_items(
         &self,
         step_run_id: &str,

--- a/runkon-flow/src/traits/persistence.rs
+++ b/runkon-flow/src/traits/persistence.rs
@@ -140,6 +140,7 @@ impl TryFrom<&str> for FanOutItemStatus {
 }
 
 /// Update payload for a fan-out item, mapping the two existing update variants.
+#[derive(Clone)]
 pub enum FanOutItemUpdate {
     Running { child_run_id: String },
     Terminal { status: FanOutItemStatus },
@@ -221,6 +222,19 @@ pub trait WorkflowPersistence: Send + Sync {
         item_id: &str,
         update: FanOutItemUpdate,
     ) -> Result<(), EngineError>;
+    /// Flush a batch of fan-out item updates in a single operation.
+    ///
+    /// The default impl loops over `update_fan_out_item` for backwards compatibility.
+    /// Production backends override this with a transactional bulk-write.
+    fn batch_update_fan_out_items(
+        &self,
+        updates: &[(String, FanOutItemUpdate)],
+    ) -> Result<(), EngineError> {
+        for (id, update) in updates {
+            self.update_fan_out_item(id, update.clone())?;
+        }
+        Ok(())
+    }
     fn get_fan_out_items(
         &self,
         step_run_id: &str,


### PR DESCRIPTION
Add `batch_update_fan_out_items` to `WorkflowPersistence` with a default looping impl (backwards compat) and efficient overrides in SQLite (single transaction via `unchecked_transaction`) and in-memory (single lock pass).

Replace the two N+1 call sites in the foreach executor:
- completion-drain loop: buffer all terminal updates across the drain, flush once after the loop
- SkipDependents branch: accumulate skip updates into the same batch

A 1,000-item foreach now issues 1 UPDATE transaction instead of 1,000+ individual round-trips for the terminal-items phase.