### PR TITLE
fix(reviewers): forbid cd-elsewhere in shared diff-scope prompt

### DIFF
--- a/.conductor/prompts/review-diff-scope.md
+++ b/.conductor/prompts/review-diff-scope.md
@@ -1,5 +1,17 @@
 ## Diff scope rules
 
+### Working directory — do not `cd`
+
+Run every `git` command from your current working directory. Do **NOT**
+`cd` to any other path (including paths you may know from prior sessions
+or memory like `/Users/.../Personal/conductor-ai`). The harness has
+already placed you in the worktree that holds this PR's branch — any
+other checkout will have a different `HEAD`, producing a fabricated
+diff that contaminates the entire review (this is the same class of bug
+that `resolve-pr-base.sh` was added to prevent — see #2736).
+
+### Diff command
+
 Get the diff for this PR using the appropriate command for the review scope:
 
 - If the scope is **full** (default): the PR's base branch has already been
@@ -16,6 +28,15 @@ Get the diff for this PR using the appropriate command for the review scope:
 **Review scope: {{scope}}**
 
 If the diff exceeds ~50KB, focus on files most relevant to your review area.
+
+If an **incremental** diff comes back surprisingly large (hundreds of
+KB, or contains files unrelated to the ticket), do **not** try to filter
+it down by reading individual files — re-run the diff against
+`origin/{{base_branch}}...HEAD` instead. A bloated incremental diff
+almost always means `HEAD` is not where you expect it (e.g. you are in
+the wrong working directory, or the worktree has just been rebased over
+many upstream commits). Switch commands and proceed; do not waste
+turns picking through a fabricated diff.
 
 **In scope — review carefully:**
 - Lines starting with `+` (added code)


### PR DESCRIPTION
## Summary

- Fixes a contamination bug in PR-review reviewer agents where the model `cd`'d out of the harness-set worktree into another clone before running `git diff`, producing a fabricated diff against an unrelated branch.
- Adds two rules to the shared `.conductor/prompts/review-diff-scope.md` fragment (loaded into every reviewer prompt via `with =`):
  1. **Working directory — do not `cd`**: explicit instruction to stay in the harness cwd, naming the same #2736 failure mode that `resolve-pr-base.sh` was added to prevent.
  2. **Recovery hint**: if an incremental diff comes back surprisingly large, re-run against `origin/{{base_branch}}...HEAD` instead of trying to filter the noise.

## Repro

Workflow run `01KQNBBA097MJJTDKGE9Y152S7`, step `review-db-migrations` (haiku):

1. Reviewer correctly chose `git diff HEAD~1` per the incremental-scope rule.
2. But ran it as `cd /Users/devin/Personal/conductor-ai && git diff HEAD~1` — that clone's HEAD was the just-merged 0.11.0 release commit.
3. Diff came back at 971.9 KB (essentially all of the WorkflowManager refactor).
4. Reviewer spent 32 turns / \$0.24 picking through the fabricated context before producing a (correct) approval.
5. Peer reviewers in the same parallel block, which stayed in the worktree, used 2–18 turns at \$0.04–\$0.16.

## Test plan

- [ ] Run `iterate-pr` (incremental scope) on a small PR; confirm reviewers stay in the worktree and the diff is accurate.
- [ ] Run `review-pr` (full scope) on a PR; confirm `git diff origin/<base>...HEAD` is still used and works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)