### PR TITLE
fix(workflow): cap needs_resume re-claim cycles to auto_resume_limit (#2820)

### DIFF
--- a/conductor-core/src/workflow/manager/recovery.rs
+++ b/conductor-core/src/workflow/manager/recovery.rs
@@ -1035,13 +1035,35 @@ pub fn classify_resumable_workflows(conn: &Connection, auto_resume_limit: u32) -
 }
 
 pub fn claim_needs_resume_runs(conn: &Connection, config: &Config) -> Result<Vec<String>> {
-    // Step 1: find all needs_resume root runs.
+    let limit = config.general.auto_resume_limit;
+
+    // Phase 1: Escalate any needs_resume runs that have hit or exceeded the cap.
+    let escalated = conn.execute(
+        "UPDATE workflow_runs \
+         SET status = 'failed', \
+             error  = :error \
+         WHERE status = 'needs_resume' \
+           AND parent_workflow_run_id IS NULL \
+           AND iteration >= :limit",
+        named_params![
+            ":limit": limit,
+            ":error": format!("exceeded auto_resume_limit ({limit})"),
+        ],
+    )?;
+    if escalated > 0 {
+        tracing::warn!(
+            "claim_needs_resume_runs: escalated {escalated} over-limit needs_resume run(s) to failed"
+        );
+    }
+
+    // Phase 2: Select only runs still under the cap.
     let candidates: Vec<String> = query_collect(
         conn,
         "SELECT id FROM workflow_runs \
-             WHERE status = 'needs_resume' \
-               AND parent_workflow_run_id IS NULL",
-        [],
+         WHERE status = 'needs_resume' \
+           AND parent_workflow_run_id IS NULL \
+           AND iteration < :limit",
+        named_params![":limit": limit],
         |row| row.get("id"),
     )?;
 
@@ -1049,14 +1071,28 @@ pub fn claim_needs_resume_runs(conn: &Connection, config: &Config) -> Result<Vec
         return Ok(vec![]);
     }
 
-    cas_claim_ids_and_notify(
+    // Phase 3: CAS-claim and bump iteration so the cap advances each cycle.
+    let claimed = cas_claim_ids_and_notify(
         conn,
         config,
         &candidates,
         "needs_resume",
         "Orphaned: parent agent run died — auto-resumed by watchdog",
         "claim_needs_resume_runs",
-    )
+    )?;
+
+    if !claimed.is_empty() {
+        let placeholders = sql_placeholders(claimed.len());
+        let sql = format!(
+            "UPDATE workflow_runs SET iteration = iteration + 1 WHERE id IN ({placeholders})"
+        );
+        conn.execute(
+            &sql,
+            rusqlite::params_from_iter(claimed.iter().map(|s| s.as_str())),
+        )?;
+    }
+
+    Ok(claimed)
 }
 
 /// Claim any expired-lease workflow runs, kill their stale subprocesses, and
@@ -1212,6 +1248,26 @@ mod tests {
             "SELECT status FROM workflow_runs WHERE id = :id",
             named_params![":id": run_id],
             |row| row.get("status"),
+        )
+        .unwrap()
+    }
+
+    /// Read the `iteration` of a workflow_run by ID.
+    fn run_iteration(conn: &rusqlite::Connection, run_id: &str) -> i64 {
+        conn.query_row(
+            "SELECT iteration FROM workflow_runs WHERE id = :id",
+            named_params![":id": run_id],
+            |row| row.get("iteration"),
+        )
+        .unwrap()
+    }
+
+    /// Read the `error` of a workflow_run by ID.
+    fn run_error(conn: &rusqlite::Connection, run_id: &str) -> Option<String> {
+        conn.query_row(
+            "SELECT error FROM workflow_runs WHERE id = :id",
+            named_params![":id": run_id],
+            |row| row.get("error"),
         )
         .unwrap()
     }
@@ -1390,6 +1446,98 @@ mod tests {
             "watchdog should not touch non-needs_resume runs"
         );
         assert_eq!(run_status(&conn, "run1"), "failed");
+    }
+
+    #[test]
+    fn test_watchdog_bumps_iteration_on_claim() {
+        let (conn, parent_id) = setup();
+        insert_run(
+            &conn,
+            "run1",
+            &parent_id,
+            "needs_resume",
+            Some(ORPHAN_ERROR),
+            0,
+        );
+        let config = Config::default(); // auto_resume_limit = 3
+        let claimed = crate::workflow::claim_needs_resume_runs(&conn, &config).unwrap();
+
+        assert_eq!(claimed.len(), 1, "watchdog should claim the run");
+        assert_eq!(
+            run_iteration(&conn, "run1"),
+            1,
+            "iteration should be bumped to 1 after claim"
+        );
+    }
+
+    #[test]
+    fn test_watchdog_terminalizes_over_cap_run() {
+        let (conn, parent_id) = setup();
+        // iteration == limit (3) → at cap, must be escalated
+        insert_run(
+            &conn,
+            "run1",
+            &parent_id,
+            "needs_resume",
+            Some(ORPHAN_ERROR),
+            3,
+        );
+        let config = Config::default(); // auto_resume_limit = 3
+        let claimed = crate::workflow::claim_needs_resume_runs(&conn, &config).unwrap();
+
+        assert!(claimed.is_empty(), "over-cap run must not be claimed");
+        assert_eq!(
+            run_status(&conn, "run1"),
+            "failed",
+            "over-cap run must be escalated to failed"
+        );
+        let err = run_error(&conn, "run1").unwrap_or_default();
+        assert!(
+            err.contains("exceeded auto_resume_limit"),
+            "error must mention the limit, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_watchdog_caps_multi_cycle() {
+        let (conn, parent_id) = setup();
+        insert_run(
+            &conn,
+            "run1",
+            &parent_id,
+            "needs_resume",
+            Some(ORPHAN_ERROR),
+            0,
+        );
+        let config = Config::default(); // auto_resume_limit = 3
+        let limit = config.general.auto_resume_limit as i64;
+
+        // Simulate `limit` reap→claim cycles; iteration should advance each time.
+        for i in 0..limit {
+            let claimed = crate::workflow::claim_needs_resume_runs(&conn, &config).unwrap();
+            assert_eq!(claimed.len(), 1, "cycle {i}: should claim the run");
+            assert_eq!(
+                run_iteration(&conn, "run1"),
+                i + 1,
+                "cycle {i}: iteration should be {}",
+                i + 1
+            );
+            // Simulate the reaper writing needs_resume again (status only, not iteration).
+            conn.execute(
+                "UPDATE workflow_runs SET status = 'needs_resume' WHERE id = 'run1'",
+                [],
+            )
+            .unwrap();
+        }
+
+        // On the (limit+1)th call, iteration == limit → Phase 1 escalates to failed.
+        let claimed = crate::workflow::claim_needs_resume_runs(&conn, &config).unwrap();
+        assert!(claimed.is_empty(), "must not claim over-cap run");
+        assert_eq!(
+            run_status(&conn, "run1"),
+            "failed",
+            "over-cap run must be failed after multi-cycle test"
+        );
     }
 
     #[test]

--- a/conductor-core/src/workflow/manager/recovery.rs
+++ b/conductor-core/src/workflow/manager/recovery.rs
@@ -527,17 +527,18 @@ fn cas_flip_run_to_failed_from(
     error_msg: &str,
     bump_iteration: bool,
 ) -> Result<bool> {
-    let sql = if bump_iteration {
-        "UPDATE workflow_runs \
-             SET status = 'failed', error = :error, iteration = iteration + 1 \
-             WHERE id = :id AND status = :from"
+    let iter_clause = if bump_iteration {
+        ", iteration = iteration + 1"
     } else {
-        "UPDATE workflow_runs \
-             SET status = 'failed', error = :error \
-             WHERE id = :id AND status = :from"
+        ""
     };
+    let sql = format!(
+        "UPDATE workflow_runs \
+         SET status = 'failed', error = :error{iter_clause} \
+         WHERE id = :id AND status = :from"
+    );
     let changed = conn.execute(
-        sql,
+        &sql,
         named_params![":id": run_id, ":from": from_status, ":error": error_msg],
     )?;
     Ok(changed == 1)

--- a/conductor-core/src/workflow/manager/recovery.rs
+++ b/conductor-core/src/workflow/manager/recovery.rs
@@ -525,11 +525,19 @@ fn cas_flip_run_to_failed_from(
     run_id: &str,
     from_status: &str,
     error_msg: &str,
+    bump_iteration: bool,
 ) -> Result<bool> {
-    let changed = conn.execute(
+    let sql = if bump_iteration {
+        "UPDATE workflow_runs \
+             SET status = 'failed', error = :error, iteration = iteration + 1 \
+             WHERE id = :id AND status = :from"
+    } else {
         "UPDATE workflow_runs \
              SET status = 'failed', error = :error \
-             WHERE id = :id AND status = :from",
+             WHERE id = :id AND status = :from"
+    };
+    let changed = conn.execute(
+        sql,
         named_params![":id": run_id, ":from": from_status, ":error": error_msg],
     )?;
     Ok(changed == 1)
@@ -542,10 +550,11 @@ fn cas_claim_ids_and_notify(
     from_status: &str,
     error_msg: &str,
     caller_name: &str,
+    bump_iteration: bool,
 ) -> Result<Vec<String>> {
     let mut claimed: Vec<String> = Vec::new();
     for run_id in candidates {
-        if !cas_flip_run_to_failed_from(conn, run_id, from_status, error_msg)? {
+        if !cas_flip_run_to_failed_from(conn, run_id, from_status, error_msg, bump_iteration)? {
             tracing::debug!(
                 run_id = %run_id,
                 "{caller_name}: CAS lost race (already claimed)"
@@ -586,6 +595,7 @@ pub fn claim_stuck_workflows(
         "running",
         ORPHAN_BETWEEN_STEPS_MSG,
         "claim_stuck_workflows",
+        false,
     )?;
 
     if !flipped_ids.is_empty() {
@@ -637,6 +647,7 @@ pub fn claim_expired_lease_runs(
         "running",
         ORPHAN_BETWEEN_STEPS_MSG,
         "claim_expired_lease_runs",
+        false,
     )?
     .into_iter()
     .collect();
@@ -1071,7 +1082,8 @@ pub fn claim_needs_resume_runs(conn: &Connection, config: &Config) -> Result<Vec
         return Ok(vec![]);
     }
 
-    // Phase 3: CAS-claim and bump iteration so the cap advances each cycle.
+    // Phase 3: CAS-claim; iteration bump is included in the same UPDATE so the
+    // cap advances even if the process crashes before the engine starts.
     let claimed = cas_claim_ids_and_notify(
         conn,
         config,
@@ -1079,18 +1091,8 @@ pub fn claim_needs_resume_runs(conn: &Connection, config: &Config) -> Result<Vec
         "needs_resume",
         "Orphaned: parent agent run died — auto-resumed by watchdog",
         "claim_needs_resume_runs",
+        true,
     )?;
-
-    if !claimed.is_empty() {
-        let placeholders = sql_placeholders(claimed.len());
-        let sql = format!(
-            "UPDATE workflow_runs SET iteration = iteration + 1 WHERE id IN ({placeholders})"
-        );
-        conn.execute(
-            &sql,
-            rusqlite::params_from_iter(claimed.iter().map(|s| s.as_str())),
-        )?;
-    }
 
     Ok(claimed)
 }

--- a/conductor-core/src/workflow/tests/manager.rs
+++ b/conductor-core/src/workflow/tests/manager.rs
@@ -4880,6 +4880,7 @@ fn test_active_step_exists_false_for_timed_out() {
 
 /// Insert one terminal step + its linked agent_run into an existing workflow run.
 /// Use this to build up multi-step scenarios without re-creating the parent run.
+#[allow(clippy::too_many_arguments)]
 fn insert_step_with_agent(
     conn: &Connection,
     run_id: &str,


### PR DESCRIPTION
claim_needs_resume_runs now runs three phases: (1) escalate any needs_resume root runs at or above the iteration cap to 'failed' with error "exceeded auto_resume_limit (N)", (2) select only under-cap candidates, and (3) bump iteration = iteration + 1 after each successful CAS claim so the counter advances on every reap-driven resume cycle.

Prevents a workflow whose engine deterministically crashes mid-body from cycling running→needs_resume indefinitely after #2819 made the reaper write needs_resume directly.