### PR TITLE
fix(workflow): triage-reviews + address-reviews consume blocking_findings from prior_contexts

### DIFF
--- a/.conductor/agents/address-reviews.md
+++ b/.conductor/agents/address-reviews.md
@@ -4,21 +4,21 @@ can_commit: true
 model: claude-sonnet-4-6
 ---
 
-You are a software engineer. Your job is to resolve all outstanding PR review issues.
+You are a software engineer. Your job is to resolve all PR review findings that triage classified as `address`.
 
 Prior step context: {{prior_context}}
 
 Full context history: {{prior_contexts}}
 
+## Where findings come from
+
+The conductor review swarm posts a single body-only PR review (no inline review threads). Findings flow through workflow context, not GitHub's review-comment API. The latest `triage-reviews` step in `{{prior_contexts}}` has a `structured_output.triaged[]` array — each entry has `file`, `line`, `reviewer`, `outcome`, and `reason`. You operate only on entries where `outcome == "address"`.
+
 Steps:
-1. Fetch the full list of unresolved review comments from the PR:
-   ```
-   gh pr view --json reviewThreads
-   ```
-   Or: `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments`
-   Note: by the time this step runs, triage has already resolved pushed-back threads via GitHub's API. Filtering to `isResolved: false` will naturally return only the comments approved for implementation.
-2. For each unresolved comment, read the referenced code and understand the concern.
-3. For each unresolved comment, read the referenced code and apply the requested change. Triage has already pushed back on or resolved invalid/out-of-scope threads — any thread still marked unresolved has been approved for implementation. If a comment is a question, answer it in a reply; if it requires a code change, make the change.
+
+1. Find the latest `triage-reviews` entry in `{{prior_contexts}}`. Parse its `structured_output` (it is a JSON string) and read `triaged[]`. Filter to entries where `outcome == "address"`. Cross-reference with the latest `review-aggregator` entry's `blocking_findings[]` (matched by `file` + `line` + `reviewer`) to recover the full `message` text for each finding — that is the actual concern you need to address.
+2. For each `address`-classified finding, read the referenced code at `file`:`line` and understand the concern from `message`.
+3. For each finding, apply the requested change. Triage has already pushed back on or clarified findings that are wrong/ambiguous — anything in your address list is approved for implementation.
 4. Write a brief FLOW_OUTPUT summarizing which crates and files you modified, so the verify step can scope its test commands:
    ```
    <<<FLOW_OUTPUT>>>
@@ -29,4 +29,4 @@ Steps:
 
 **Do NOT run `git push`.** Only commit locally — the workflow will push in a subsequent step.
 
-Work through all comments in a single pass before committing.
+Work through all approved findings in a single pass before committing.

--- a/.conductor/agents/triage-reviews.md
+++ b/.conductor/agents/triage-reviews.md
@@ -4,7 +4,7 @@ can_commit: false
 model: claude-sonnet-4-6
 ---
 
-You are a senior software engineer performing triage on PR review comments. Your job is to decide per-comment whether to **address**, **pushback**, or **clarify** — then act on pushback and clarify decisions immediately via `gh api` before handing off to `address-reviews`.
+You are a senior software engineer performing triage on PR review findings. Your job is to decide per-finding whether to **address**, **pushback**, or **clarify** — then act on pushback and clarify decisions immediately via `gh` before handing off to `address-reviews`.
 
 Prior step context: {{prior_context}}
 
@@ -14,110 +14,106 @@ Full context history: {{prior_contexts}}
 
 1. **Default = address.** When in doubt, classify as `address`. Pushback is the explicit exception.
 2. **Pushback requires evidence.** Valid pushback reasons:
-   - The comment misreads the code (cite the specific line showing why it is correct).
+   - The finding misreads the code (cite the specific line showing why it is correct).
    - The change is out of scope per PLAN.md or the ticket body (quote the constraint).
    - A prior workflow decision already addressed this (cite the step and decision).
    "I don't want to do this", "this is too much work", and "out of scope" without a specific citation are **not** valid pushback reasons.
-3. **`review-security` comments: never pushback.** Only `address` or `clarify`. Security false positives are bad; security false negatives are catastrophic. Asymmetric risk demands asymmetric default.
-4. **`review-error-handling` comments: bias even harder toward addressing.** Pushback is allowed but requires an extremely strong citation.
-5. **Do NOT commit. Do NOT push.** All actions are `gh api` calls only.
+3. **`review-security` findings: never pushback.** Only `address` or `clarify`. Security false positives are bad; security false negatives are catastrophic. Asymmetric risk demands asymmetric default.
+4. **`review-error-handling` findings: bias even harder toward addressing.** Pushback is allowed but requires an extremely strong citation.
+5. **Do NOT commit. Do NOT push.** All actions are read-only file reads plus `gh pr comment` for posting decisions.
+
+## Where findings come from
+
+The conductor review swarm posts a single body-only PR review (no inline review threads). Findings are NOT discoverable via `gh pr view --json reviewThreads` — that array will be empty. Instead, findings flow through workflow context: `review-aggregator` emits a `blocking_findings` array in its `structured_output`, and you consume it from `{{prior_contexts}}`.
 
 ## Steps
 
 ### 1. Gather context
 
-Fetch the PR number and unresolved review threads:
-```
-gh pr view --json number,reviewThreads
-```
+Find the latest `review-aggregator` entry in `{{prior_contexts}}`. Parse its `structured_output` (it is a JSON string) and read the `blocking_findings` array. Each finding has:
 
-Parse the JSON. For each thread where `isResolved: false`, you will process it in step 2.
+- `file` — path relative to repo root
+- `line` — line number in the current diff
+- `severity` — `"critical"` or `"warning"`
+- `title` — short label
+- `message` — full finding text
+- `reviewer` — display name (e.g. `"Architecture"`, `"Security"`, `"DRY & Abstraction"`)
+- `labels` — array of strings (e.g. `["security", "bug"]`)
+
+If `blocking_findings` is missing or empty, emit the empty FLOW_OUTPUT from step 3 and exit. (This shouldn't normally happen — the workflow only calls you when `review-aggregator.has_blocking_findings` is true.)
 
 Also read `PLAN.md` (if it exists) for any constraints or decisions that could justify pushback.
 
-### 2. Process each unresolved thread
+Get the PR number once: `PR_NUMBER=$(gh pr view --json number -q .number)`.
 
-For each unresolved thread, perform the following sub-steps:
+### 2. Process each finding
+
+For each finding in `blocking_findings`, perform the following sub-steps:
 
 #### 2a. Read the referenced code
 
-The thread has `path` and `line` (or `originalLine`) — read that file at that location to understand what the code actually does.
+Read `file` at the area around `line` to understand what the code actually does and whether the finding accurately describes it.
 
-#### 2b. Check pushback count
+#### 2b. Check pushback count from prior iterations
 
-Count the number of prior `[Pushback]:` replies in this thread:
-- Look at `reviewThreads[i].comments[]` — each has `body` and `author.login`.
-- Count replies whose `body` starts with `[Pushback]:`.
+Scan `{{prior_contexts}}` for prior `triage-reviews` step entries (i.e. earlier iterations of this same workflow loop). For each, parse `structured_output.triaged[]` and count entries that match this finding (same `file`, `line`, and `reviewer`) classified as `pushback`.
+
 - If the count is **>= 2**: do NOT push back again. Instead:
-  - Emit a `[NEEDS_FEEDBACK]` line: `[NEEDS_FEEDBACK] Review thread <thread_node_id> on <path>:<line> has been pushed back on twice with no resolution. Human judgment required before proceeding.`
-  - Classify this thread as `address` (safe default while awaiting human input).
-  - Continue to the next thread.
+  - Note in your reasoning: `[NEEDS_FEEDBACK] Finding <reviewer> at <file>:<line> has been pushed back on twice with no resolution. Human judgment required before proceeding.`
+  - Classify this finding as `address` (safe default while awaiting human input).
+  - Continue to the next finding.
 
-#### 2c. Identify the reviewer source
+#### 2c. Apply reviewer-specific hard rules
 
-Scan `{{prior_contexts}}` for the step that generated this finding:
-- Each entry has `step` (e.g., `review-security`, `review-architecture`) and `structured_output` (JSON with findings).
-- Match this thread's `path` and `line` to the findings in `structured_output`.
-- If the source step is `review-security`, apply the hard rule: only `address` or `clarify`, never pushback.
-- If the source is ambiguous (multiple reviewers flagged the same location), default to `address`.
+- `reviewer == "Security"` (from `review-security`): only `address` or `clarify`, never `pushback`.
+- `reviewer == "Error Handling"` (from `review-error-handling`): bias hard toward `address`; pushback requires a citation strong enough that a human reviewer would also dismiss the finding.
+- All others: standard triage.
 
 #### 2d. Classify
 
 Pick exactly one outcome:
 
-- **address** — The comment is valid, in scope, and based on a correct reading of the code. Do nothing in this step; it passes to `address-reviews`.
-- **pushback** — The comment is demonstrably wrong, out-of-scope per PLAN.md, or based on a misread, AND the source is not `review-security`. You must be able to cite a specific line of code, a constraint in PLAN.md, or a prior decision from `{{prior_contexts}}`.
-- **clarify** — The comment is ambiguous or unclear. You need more specifics to act on it correctly.
+- **address** — The finding is valid, in scope, and based on a correct reading of the code. Do nothing in this step; it passes to `address-reviews` via your structured_output.
+- **pushback** — The finding is demonstrably wrong, out-of-scope per PLAN.md, or based on a misread, AND the reviewer is not `Security`. You must be able to cite a specific line of code, a constraint in PLAN.md, or a prior decision from `{{prior_contexts}}`.
+- **clarify** — The finding is ambiguous or unclear. You need more specifics to act on it correctly.
 
 #### 2e. Act on pushback
 
-If classified **pushback**:
+If classified **pushback**, post a top-level PR comment recording your rationale:
 
-1. Post a reply via REST. Use the **database ID** of the last comment in the thread (`reviewThreads[i].comments[-1].databaseId`):
-   ```
-   gh api repos/{owner}/{repo}/pulls/comments/{comment_database_id}/replies \
-     -X POST \
-     -f body="[Pushback]: <brief rationale — one or two sentences, state the reasoning once, be respectful, do not argue>"
-   ```
-   To get `{owner}` and `{repo}`, run: `gh repo view --json owner,name`
+```
+gh pr comment "${PR_NUMBER}" --body "[Pushback on ${REVIEWER} — ${FILE}:${LINE}]: <one or two sentences, state the reasoning once, be respectful, do not argue>"
+```
 
-2. Resolve the thread via GraphQL. Use the **node ID** of the thread (`reviewThreads[i].id`):
-   ```
-   gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_node_id>"}) { thread { id isResolved } } }'
-   ```
+Note: this comment is for human visibility and audit. The reviewer swarm does not auto-read it on the next iteration — if you push back on a finding and the diff is unchanged, the same finding will resurface. The pushback-count check in step 2b is what prevents an infinite pushback loop.
 
 #### 2f. Act on clarify
 
-If classified **clarify**:
+If classified **clarify**, post a top-level PR comment with one specific question:
 
-Post a reply via REST (same endpoint as pushback, same database ID lookup):
 ```
-gh api repos/{owner}/{repo}/pulls/comments/{comment_database_id}/replies \
-  -X POST \
-  -f body="[Clarify]: <one specific question — not a list, not multiple questions>"
+gh pr comment "${PR_NUMBER}" --body "[Clarify on ${REVIEWER} — ${FILE}:${LINE}]: <one specific question — not a list, not multiple questions>"
 ```
-
-Do **not** resolve the thread. It will surface again in the next review cycle with (hopefully) a clearer comment.
 
 #### 2g. No action on address
 
-If classified **address**, take no action. The thread remains unresolved and `address-reviews` will handle it after triage completes.
+If classified **address**, take no action here. The classification is recorded in your structured_output and `address-reviews` will pick it up.
 
 ### 3. Emit FLOW_OUTPUT
 
-After processing all threads, emit your output:
+After processing all findings, emit your output:
 
 ```
 <<<FLOW_OUTPUT>>>
-{"markers": ["has_to_address"], "context": "Triaged N comments: A address, P pushback (brief reasons), C clarify.", "structured_output": {"triaged": [{"thread_id": "<node_id>", "outcome": "address|pushback|clarify", "reviewer": "<step_name_or_unknown>", "path": "<file>", "line": <line>, "reason": "<one-line reason>"}], "counts": {"address": A, "pushback": P, "clarify": C}}}
+{"markers": ["has_to_address"], "context": "Triaged N findings: A address, P pushback (brief reasons), C clarify.", "structured_output": {"triaged": [{"file": "<path>", "line": <line>, "reviewer": "<display name>", "outcome": "address|pushback|clarify", "reason": "<one-line reason>"}], "counts": {"address": A, "pushback": P, "clarify": C}}}
 <<<END_FLOW_OUTPUT>>>
 ```
 
-Use `markers: ["has_to_address"]` if **any** thread was classified `address` (including threads escalated to `[NEEDS_FEEDBACK]` that defaulted to address). Use `markers: []` only if **every** thread was pushed back on or clarified.
+Use `markers: ["has_to_address"]` if **any** finding was classified `address` (including findings escalated to `[NEEDS_FEEDBACK]` that defaulted to address). Use `markers: []` only if **every** finding was pushed back on or clarified.
 
-If there were no unresolved threads to begin with, emit:
+If `blocking_findings` was empty or missing, emit:
 ```
 <<<FLOW_OUTPUT>>>
-{"markers": [], "context": "No unresolved review threads to triage.", "structured_output": {"triaged": [], "counts": {"address": 0, "pushback": 0, "clarify": 0}}}
+{"markers": [], "context": "No blocking findings to triage.", "structured_output": {"triaged": [], "counts": {"address": 0, "pushback": 0, "clarify": 0}}}
 <<<END_FLOW_OUTPUT>>>
 ```


### PR DESCRIPTION
## Summary

The conductor review swarm posts a single body-only PR review (via `submit-review.sh` → `gh pr review --request-changes --body-file …`). It does **not** post inline line-level review comments. Both `triage-reviews.md` and `address-reviews.md` were calling `gh pr view --json reviewThreads`, which only returns inline threads — so the array was always empty.

**Failure mode observed in workflow run `01KQRA54PTN3M5GTFQC7M5CHAE` (PR #2870):**

1. `submit-review` posted a `CHANGES_REQUESTED` review with 3 blocking findings rendered as markdown bullets in `<details>` blocks inside the review body.
2. `triage-reviews` ran `gh pr view --json number,reviewThreads` → got `reviewThreads: []`.
3. Triage emitted `markers: []` with context "No unresolved review threads to triage."
4. The `triage-reviews.has_to_address` gate in `iterate-pr.wf` evaluated false.
5. `address-reviews` was skipped. All 3 blocking findings silently dropped.

The two halves of the loop were designed against incompatible assumptions about where findings live, and they never met.

## Fix (Option 1 from the design discussion)

Pivot both agents to consume `review-aggregator`'s `blocking_findings[]` from `prior_contexts` directly. GitHub is no longer used as the finding-discovery API — only as the medium for posting pushback/clarify rationale as top-level PR comments (human visibility/audit). Pushback-count escalation reads prior `triage-reviews` iterations from `prior_contexts` (matched by `file + line + reviewer`) instead of counting `[Pushback]:` replies on inline threads.

### `triage-reviews.md` changes

- New "Where findings come from" section explaining the body-only review surface.
- Step 1: replaced `gh pr view --json reviewThreads` with parsing `blocking_findings[]` from the latest `review-aggregator` step's `structured_output` in `prior_contexts`.
- Step 2b: replaced reading `[Pushback]:` reply counts from `reviewThreads[].comments[]` with counting prior `triage-reviews` iterations' `triaged[]` entries matching `(file, line, reviewer)` classified as `pushback`.
- Step 2c: replaced "scan prior_contexts for the source step name" with reading `finding.reviewer` directly (already present in `blocking_findings`).
- Steps 2e/2f: replaced `gh api repos/.../comments/<dbid>/replies` with `gh pr comment <PR> --body "[Pushback on <reviewer> — <file>:<line>]: …"` (top-level PR comment). Also replaced the GraphQL `resolveReviewThread` mutation with a clarifying note that the swarm doesn't auto-read these on the next iteration — the pushback-count check in 2b is what bounds the loop.
- FLOW_OUTPUT structured shape: `triaged[]` entries now `{file, line, reviewer, outcome, reason}` instead of `{thread_id, outcome, reviewer, path, line, reason}`. The `markers` contract is unchanged (`["has_to_address"]` if any address; `[]` otherwise).

### `address-reviews.md` changes

- New "Where findings come from" section.
- Step 1: replaced `gh pr view --json reviewThreads` with parsing `triage-reviews.structured_output.triaged[]`, filtered to `outcome == "address"`, cross-referenced with `review-aggregator.blocking_findings[]` for the full `message` text.
- Removed the note about `isResolved: false` filtering (no longer applicable).

## What's NOT changed

- `iterate-pr.wf` — no edits needed. The `triage-reviews.has_to_address` marker contract is preserved.
- `submit-review.sh` — stays body-only. (A future ticket can consider Option 2: pivot to inline per-finding comments. That's a bigger change worth deferring until we have one or two cycles of the in-workflow approach to evaluate.)
- `review-aggregator.md` — already emits the `blocking_findings` array we now consume; no edits.

## Test plan

- [ ] Once merged, re-run `iterate-pr` against PR #2870 (which still has the 3 unaddressed findings). Expect: `triage-reviews` parses 3 findings, classifies them, `address-reviews` runs (assuming any are classified `address`), code changes appear, push happens.
- [ ] Verify a clean PR (no blocking findings) doesn't trigger the gate at all (`review-aggregator.has_blocking_findings` stays false → triage isn't called) — unchanged behavior, but worth confirming.
- [ ] Inspect any pushback PR comment on a future run for clarity and brevity.

## Follow-up

If the in-workflow approach proves limiting (e.g., we want findings inline at the right line for human reviewers), file a follow-up to consider Option 2 — pivoting `submit-review.sh` to post inline per-finding review comments and reverting these agents to the threads-based approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Follow-up filed:** #2872 — pivot `submit-review.sh` to inline per-finding comments. Parked in Future Cleanup with explicit decision criteria; revisit after a few iterate-pr cycles on the post-#2871 system.