### PR TITLE
fix(workflow): forbid cargo verification in implement + plan agents

### DIFF
--- a/.conductor/agents/implement.md
+++ b/.conductor/agents/implement.md
@@ -22,3 +22,9 @@ Steps:
 4. Commit all changes with a clear, descriptive commit message referencing the ticket.
 
 Do not create files or make changes beyond what the plan specifies. If you discover the plan is incomplete or incorrect, document the deviation in `PLAN.md` before proceeding.
+
+## Do NOT verify your own work
+
+**Do NOT run `cargo build`, `cargo test`, `cargo nextest`, `cargo clippy`, or `cargo fmt`.** A separate `verify` step (Haiku, runs automatically after you commit) handles all verification via Task sub-agent delegation, keeping cargo's voluminous output out of your context window. The verify step will loop back to you with a structured failure summary if anything fails — that is where you fix issues, not preemptively here. If `PLAN.md` lists cargo commands as "definition of done", ignore them; verify owns that work now.
+
+Trust your reasoning, commit, and let verify catch what you missed. The whole point of the implement → verify split is that build/test/clippy output never enters this context.

--- a/.conductor/agents/plan.md
+++ b/.conductor/agents/plan.md
@@ -26,3 +26,9 @@ Steps:
    - An estimated total duration in minutes for the full implementation
 
 Write the plan to `PLAN.md` in the worktree root. This file will be used by the next step.
+
+## Do NOT include verification commands in the plan
+
+Do **not** include `cargo build`, `cargo test`, `cargo nextest`, `cargo clippy`, or `cargo fmt` instructions in `PLAN.md` (no "definition of done", no "verification" section, no "finally run X" trailing notes). Verification runs automatically as a separate `verify` step (Haiku) after `implement` commits. Including cargo commands in the plan causes the implement agent to dutifully execute them, which fills its context with build output and defeats the implement → verify split.
+
+If verification approach matters for the plan (e.g. "this change requires running the full E2E suite, not just unit tests"), describe it as a note for verify to consider, not as a command for implement to run.


### PR DESCRIPTION
## Summary

The v0.12.2 implement → verify split (#2868) moved cargo verification *instructions* out of `implement.md` but did not *forbid* implement from running cargo on its own initiative — and `plan.md` has no knowledge of verify, so it routinely drafts PLAN.md sections like "Finally run \`cargo clippy --workspace ...\`" that implement then dutifully executes.

## Failure mode (still active)

Observed in workflow run \`01KQSPHAMQAY6XJKBR9PEKFQ8B\` (ticket #2849, the RunContext rebuild keystone). \`implement\` agent log shows **15 of 18 total Bash tool calls were cargo invocations:**

| Command | Invocations |
|---|---|
| \`cargo build\` (workspace + scoped variants) | 8 |
| \`cargo test -p runkon-flow -p conductor-core\` | 3 |
| \`cargo clippy ... -- -D warnings\` | 2 |
| \`cargo fmt --all\` / \`--check\` | 2 |

This is exactly the auto-compaction surface the v0.12.2 split was designed to eliminate. The trait-cleanup keystone PRs (where context fidelity matters most) are hitting this hardest.

PLAN.md for the run contained the literal string \`cargo clippy --workspace --all-targets -- -D warnings\` and fix any warnings. Finally run \`cargo ...\`, which implement quoted back five times in its log — direct evidence of the plan → implement contamination.

## Why removing the *instruction* wasn't enough

1. **No explicit prohibition.** The v0.12.2 prompt removed cargo from the steps list but said nothing forbidding it. Sonnet sees "implement" + "commit" and naturally inserts "verify it builds first" between them — that *is* the obvious right thing to do absent context that something else handles it.
2. **implement has no awareness of verify.** Without that context, skipping verification looks like negligence, not delegation.
3. **plan ↔ implement contamination via PLAN.md.** The plan agent isn't aware of verify either, so it includes "definition of done" cargo commands. Implement reads PLAN.md as authoritative and executes them.

## Fix

Two single-section additions, both written to frame verify as a trusted partner rather than verification as forbidden:

**\`implement.md\`:**
- New "Do NOT verify your own work" section with explicit prohibition on \`cargo build\` / \`test\` / \`nextest\` / \`clippy\` / \`fmt\`.
- States the rationale (verify owns this, runs after commit, output stays out of implement context, will loop back with structured failure summary).
- Explicitly handles the PLAN.md case: "If \`PLAN.md\` lists cargo commands as 'definition of done', ignore them; verify owns that work now."
- Closing reframe: "Trust your reasoning, commit, and let verify catch what you missed."

**\`plan.md\`:**
- New "Do NOT include verification commands in the plan" section.
- Forbids cargo commands in PLAN.md (no "definition of done", no "verification" section, no "finally run X" trailing notes).
- Names the failure mode explicitly so future readers understand why: "Including cargo commands in the plan causes the implement agent to dutifully execute them, which fills its context with build output and defeats the implement → verify split."
- Carves out the legitimate case: "If verification approach matters for the plan (e.g. 'this change requires running the full E2E suite, not just unit tests'), describe it as a note for verify to consider, not as a command for implement to run."

## What's NOT changed

- \`verify.md\` — unchanged. Already owns cargo verification correctly via Task sub-agent delegation.
- \`ticket-to-pr.wf\` / \`iterate-pr.wf\` — unchanged. Verify step wiring is correct; the fix is purely on the prompt side.
- \`address-reviews.md\` — unchanged. Already had cargo instructions removed in v0.12.2 (#2868) and isn't running cargo in practice.

## Test plan

- [ ] Once merged, dispatch \`ticket-to-pr\` against a small ticket. Expect: implement's Bash tool calls contain zero \`cargo\` invocations; verify runs as its own step and produces the structured PASS/FAIL FLOW_OUTPUT.
- [ ] Inspect a fresh PLAN.md from a small ticket: confirm no cargo commands appear in the body.
- [ ] Compare implement's \`num_turns\` and final input/output token totals before/after on a comparable ticket — expect a meaningful drop.

## Risk

Low. Markdown-only prompt changes; no Rust touched, no workflow wiring changed, no DB schema. Worst case: implement misses a code-correctness issue that verify then catches and bounces back — that's exactly the loop's intended design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)