### PR TITLE
fix(workflow): bubble child workflow contexts into parent prior_contexts; harden triage against stale-review fallback

### DIFF
--- a/.conductor/agents/triage-reviews.md
+++ b/.conductor/agents/triage-reviews.md
@@ -21,6 +21,7 @@ Full context history: {{prior_contexts}}
 3. **`review-security` findings: never pushback.** Only `address` or `clarify`. Security false positives are bad; security false negatives are catastrophic. Asymmetric risk demands asymmetric default.
 4. **`review-error-handling` findings: bias even harder toward addressing.** Pushback is allowed but requires an extremely strong citation.
 5. **Do NOT commit. Do NOT push.** All actions are read-only file reads plus `gh pr comment` for posting decisions.
+6. **Do NOT fall back to `gh pr view --json reviews` or any other GitHub API to discover findings.** If `prior_contexts` lacks `review-aggregator` output, halt — do not improvise (see "Halting on missing data" below). The dismissed-review trap is real: GitHub's reviews endpoint returns BOTH dismissed and active reviews; picking the wrong one means triaging stale findings against fresh code.
 
 ## Where findings come from
 
@@ -40,7 +41,25 @@ Find the latest `review-aggregator` entry in `{{prior_contexts}}`. Parse its `st
 - `reviewer` — display name (e.g. `"Architecture"`, `"Security"`, `"DRY & Abstraction"`)
 - `labels` — array of strings (e.g. `["security", "bug"]`)
 
-If `blocking_findings` is missing or empty, emit the empty FLOW_OUTPUT from step 3 and exit. (This shouldn't normally happen — the workflow only calls you when `review-aggregator.has_blocking_findings` is true.)
+### Halting on missing data
+
+If you cannot find a `review-aggregator` entry in `{{prior_contexts}}`, OR its `structured_output` does not parse as JSON, OR `blocking_findings` is missing — **do not fall back to fetching reviews from GitHub.** A dismissed-review trap caused triage to push back against stale findings on PR #2887 (workflow run `01KQTMKWWF9E96WQYZW5KEG1V4`). Instead emit:
+
+```
+<<<FLOW_OUTPUT>>>
+{"markers": [], "context": "BUG: review-aggregator output missing from prior_contexts. Refusing to triage by fetching reviews from GitHub (risk of triaging dismissed/stale review). Halting cleanly so the loop exits without pushback or address-reviews. See workflow run history for the missing aggregator step.", "structured_output": {"triaged": [], "counts": {"address": 0, "pushback": 0, "clarify": 0}, "halt_reason": "missing_aggregator_output"}}
+<<<END_FLOW_OUTPUT>>>
+```
+
+This is intentional: better to halt than to push back on the wrong findings or commit address-reviews to fixing things that aren't actually flagged in the current review.
+
+If `blocking_findings` is present but empty, that's different — it means review-aggregator ran and found nothing blocking. The workflow normally only calls you when `review-aggregator.has_blocking_findings` is true, so this shouldn't happen, but if it does emit:
+
+```
+<<<FLOW_OUTPUT>>>
+{"markers": [], "context": "No blocking findings to triage.", "structured_output": {"triaged": [], "counts": {"address": 0, "pushback": 0, "clarify": 0}}}
+<<<END_FLOW_OUTPUT>>>
+```
 
 Also read `PLAN.md` (if it exists) for any constraints or decisions that could justify pushback.
 
@@ -111,9 +130,4 @@ After processing all findings, emit your output:
 
 Use `markers: ["has_to_address"]` if **any** finding was classified `address` (including findings escalated to `[NEEDS_FEEDBACK]` that defaulted to address). Use `markers: []` only if **every** finding was pushed back on or clarified.
 
-If `blocking_findings` was empty or missing, emit:
-```
-<<<FLOW_OUTPUT>>>
-{"markers": [], "context": "No blocking findings to triage.", "structured_output": {"triaged": [], "counts": {"address": 0, "pushback": 0, "clarify": 0}}}
-<<<END_FLOW_OUTPUT>>>
-```
+(Empty / missing `blocking_findings` is handled in step 1's "Halting on missing data" section above — do not duplicate that path here.)

--- a/runkon-flow/src/engine.rs
+++ b/runkon-flow/src/engine.rs
@@ -878,12 +878,29 @@ pub fn restore_completed_step(
     state.contexts.push(success.into());
 }
 
-/// Fetch both the final step output (markers + context) and all completed step
-/// results for a child workflow run in a single DB query.
+/// Returned by [`fetch_child_completion_data`].
+/// `0` — final-step `(markers, context)` of the child workflow.
+/// `1` — bubble-up step-results map keyed by child step name (used by parent
+/// for `if step.marker` checks).
+/// `2` — child step contexts in chronological order (pushed into parent's
+/// `state.contexts` so downstream agents see child step outputs in `prior_contexts`).
+pub type ChildCompletionData = (
+    (Vec<String>, String),
+    HashMap<String, StepResult>,
+    Vec<ContextEntry>,
+);
+
+/// Fetch the final step output, the bubble-up step-results map, AND the
+/// child workflow's context entries — in a single DB query. The context
+/// entries are pushed into the parent's `state.contexts` so that downstream
+/// agents in the parent workflow see child-workflow step outputs via
+/// `prior_contexts` in their prompt templates. Without this third return
+/// value, only `state.step_results` carries child step data and parent-side
+/// agents have no access to child step `context_out` / `structured_output`.
 pub fn fetch_child_completion_data(
     persistence: &dyn WorkflowPersistence,
     workflow_run_id: &str,
-) -> ((Vec<String>, String), HashMap<String, StepResult>) {
+) -> ChildCompletionData {
     let steps = match persistence.get_steps(workflow_run_id) {
         Ok(s) => s,
         Err(e) => {
@@ -891,15 +908,17 @@ pub fn fetch_child_completion_data(
                 "Failed to fetch steps for child workflow run '{}': {e}",
                 workflow_run_id,
             );
-            return ((Vec::new(), String::new()), HashMap::new());
+            return ((Vec::new(), String::new()), HashMap::new(), Vec::new());
         }
     };
 
-    // Collect completed steps once; derive both final output and bubble-up map from it.
-    let completed: Vec<_> = steps
+    // Collect completed steps once, ordered by position so context bubble-up
+    // preserves chronological order in the parent's `state.contexts`.
+    let mut completed: Vec<_> = steps
         .into_iter()
         .filter(|s| s.status == WorkflowStepStatus::Completed)
         .collect();
+    completed.sort_by_key(|s| s.position);
 
     let final_output = match completed.iter().max_by_key(|s| s.position) {
         Some(step) => {
@@ -910,25 +929,29 @@ pub fn fetch_child_completion_data(
         None => (Vec::new(), String::new()),
     };
 
-    // Build bubble-up map from all completed steps.
-    let child_steps = completed
-        .into_iter()
-        .map(|s| {
-            let markers = parse_markers_out(s.markers_out.as_deref(), &s.step_name);
-            let context = s.context_out.clone().unwrap_or_default();
-            let success = crate::types::StepSuccess::from_workflow_run_step(
-                s.step_name.clone(),
-                &s,
-                markers,
-                context,
-                0,
-            );
-            let result = StepResult::completed_without_metrics(&success);
-            (s.step_name, result)
-        })
-        .collect();
+    // Build the bubble-up step-results map AND the contexts list from the
+    // same StepSuccess values. The map is keyed by step name (used for
+    // `if step.marker` checks); the list preserves chronological order
+    // (used as `prior_contexts` in agent prompts).
+    let mut child_steps = HashMap::with_capacity(completed.len());
+    let mut child_contexts = Vec::with_capacity(completed.len());
+    for s in completed {
+        let markers = parse_markers_out(s.markers_out.as_deref(), &s.step_name);
+        let context = s.context_out.clone().unwrap_or_default();
+        let success = crate::types::StepSuccess::from_workflow_run_step(
+            s.step_name.clone(),
+            &s,
+            markers,
+            context,
+            0,
+        );
+        let result = StepResult::completed_without_metrics(&success);
+        let entry: ContextEntry = success.into();
+        child_steps.insert(s.step_name, result);
+        child_contexts.push(entry);
+    }
 
-    (final_output, child_steps)
+    (final_output, child_steps, child_contexts)
 }
 
 /// Check whether the loop is stuck (identical marker sets for `stuck_after` consecutive
@@ -1479,5 +1502,115 @@ mod tests {
                 assert!(res.is_err(), "should detect stuck at iteration {i}");
             }
         }
+    }
+
+    #[test]
+    fn fetch_child_completion_data_bubbles_contexts_in_position_order() {
+        use crate::persistence_memory::InMemoryWorkflowPersistence;
+        use crate::traits::persistence::{NewStep, StepUpdate};
+
+        let p = InMemoryWorkflowPersistence::new();
+        let child_run = "01CHILDRUNID0000000000000";
+        p.seed_run(child_run);
+
+        // Insert two steps in reverse position order to verify the function
+        // sorts before bubbling — without sorting, contexts would land in
+        // insertion order, which doesn't match the chronological order
+        // parent-side agents expect.
+        let step_b = p
+            .insert_step(NewStep {
+                workflow_run_id: child_run.to_string(),
+                step_name: "step-b".to_string(),
+                role: "actor".to_string(),
+                can_commit: false,
+                position: 2,
+                iteration: 0,
+                retry_count: Some(0),
+            })
+            .unwrap();
+        let step_a = p
+            .insert_step(NewStep {
+                workflow_run_id: child_run.to_string(),
+                step_name: "step-a".to_string(),
+                role: "actor".to_string(),
+                can_commit: false,
+                position: 1,
+                iteration: 0,
+                retry_count: Some(0),
+            })
+            .unwrap();
+
+        p.update_step(
+            &step_a,
+            StepUpdate::completed(
+                0,
+                None,
+                Some("a-result".into()),
+                Some("context-from-a".into()),
+                Some(r#"["m-a"]"#.into()),
+                0,
+                Some(r#"{"k":"a"}"#.into()),
+            ),
+        )
+        .unwrap();
+        p.update_step(
+            &step_b,
+            StepUpdate::completed(
+                0,
+                None,
+                Some("b-result".into()),
+                Some("context-from-b".into()),
+                Some(r#"["m-b"]"#.into()),
+                0,
+                Some(r#"{"k":"b"}"#.into()),
+            ),
+        )
+        .unwrap();
+
+        let ((final_markers, final_context), step_results, child_contexts) =
+            fetch_child_completion_data(&p, child_run);
+
+        // Final output is the highest-position step (step-b at position 2).
+        assert_eq!(final_markers, vec!["m-b".to_string()]);
+        assert_eq!(final_context, "context-from-b");
+
+        // Both steps reachable by name in the bubble-up step_results map.
+        assert!(step_results.contains_key("step-a"));
+        assert!(step_results.contains_key("step-b"));
+
+        // Child contexts bubbled in position order regardless of insert order,
+        // and carry the per-step context_out + structured_output so parent
+        // agents downstream of call_workflow can read them via prior_contexts.
+        assert_eq!(child_contexts.len(), 2);
+        assert_eq!(child_contexts[0].step, "step-a");
+        assert_eq!(child_contexts[0].context, "context-from-a");
+        assert_eq!(child_contexts[0].markers, vec!["m-a".to_string()]);
+        assert_eq!(
+            child_contexts[0].structured_output.as_deref(),
+            Some(r#"{"k":"a"}"#)
+        );
+        assert_eq!(child_contexts[1].step, "step-b");
+        assert_eq!(child_contexts[1].context, "context-from-b");
+        assert_eq!(child_contexts[1].markers, vec!["m-b".to_string()]);
+        assert_eq!(
+            child_contexts[1].structured_output.as_deref(),
+            Some(r#"{"k":"b"}"#)
+        );
+    }
+
+    #[test]
+    fn fetch_child_completion_data_returns_empty_contexts_on_persistence_error() {
+        use crate::persistence_memory::InMemoryWorkflowPersistence;
+
+        let p = InMemoryWorkflowPersistence::new();
+        p.set_fail_get_steps(true);
+
+        let ((markers, context), step_results, child_contexts) =
+            fetch_child_completion_data(&p, "any-run-id");
+
+        assert!(markers.is_empty());
+        assert!(context.is_empty());
+        assert!(step_results.is_empty());
+        assert!(child_contexts.is_empty());
     }
 }

--- a/runkon-flow/src/executors/call_workflow.rs
+++ b/runkon-flow/src/executors/call_workflow.rs
@@ -40,14 +40,14 @@ pub fn execute_call_workflow(
     let step_key = node.workflow.clone();
     let mut last_error = String::new();
 
-    // Helper: persist success and bubble up child step results.
+    // Helper: persist success and bubble up child step results + contexts.
     // Used by both the resume-success path and the fresh-success path.
     let record_child_success = |state: &mut ExecutionState,
                                 step_id: &str,
                                 result: &crate::types::WorkflowResult,
                                 attempt: u32|
      -> Result<()> {
-        let ((markers, context), child_steps) =
+        let ((markers, context), child_steps, child_contexts) =
             fetch_child_completion_data(state.persistence.as_ref(), &result.workflow_run_id);
 
         let markers_json = crate::helpers::serialize_or_empty_array(
@@ -65,6 +65,14 @@ pub fn execute_call_workflow(
             attempt,
             None,
         )?;
+
+        // Bubble up child contexts BEFORE the call_workflow's own success
+        // entry so prior_contexts preserves chronological order: child steps
+        // happened first, then the call_workflow summary entry. Without this,
+        // parent-side agents downstream of the call_workflow have no access to
+        // child step `context_out` / `structured_output` (only markers bubble
+        // up via state.step_results below).
+        state.contexts.extend(child_contexts);
 
         record_step_success(
             state,


### PR DESCRIPTION
## Summary

Two coupled bugs surfaced on workflow run \`01KQTMKWWF9E96WQYZW5KEG1V4\` (PR #2887). Both fixed here:

### Bug 1 — call_workflow only bubbles up step_results, not contexts

When \`iterate-pr.wf\` does \`call workflow review-pr\`, the child workflow's \`review-aggregator\` step produces \`blocking_findings\` in its structured_output. Markers and step_results bubble up via \`state.step_results\` so iterate-pr can correctly gate on \`review-aggregator.has_blocking_findings\`. But \`prior_contexts\` (built from \`state.contexts\`) never received the child step entries — only the call_workflow's own summary entry. Triage-reviews looking for review-aggregator's blocking_findings via prior_contexts found nothing.

### Bug 2 — triage's prompt left an undefined fallback

When the agent couldn't find data in prior_contexts, it improvised: fetched reviews from \`gh pr view\` and picked one. On the observed run it picked the **DISMISSED** review (state=DISMISSED from a prior workflow run) instead of the freshly-submitted CHANGES_REQUESTED review. Triage's own \`context_out\` admits it:

> "Triaged 2 Architecture findings **from the dismissed review body** (no review-aggregator structured_output in prior_contexts)."

Triage pushed back on stale findings against fresh code; address-reviews was skipped (no \`has_to_address\` marker); the loop exited with the actual findings unaddressed.

## Engine fix

- **\`fetch_child_completion_data\`** (\`runkon-flow/src/engine.rs\`) now returns a third value: \`Vec<ContextEntry>\` built from the child's completed steps, sorted by position for chronological order.
- New \`ChildCompletionData\` type alias keeps \`clippy::type_complexity\` happy.
- **\`call_workflow.rs\` \`record_child_success\`** pushes the child contexts into \`state.contexts\` **before** \`record_step_success\` pushes the call_workflow's own summary entry — preserves chronological order so prior_contexts reads naturally for downstream agents.
- Two unit tests (\`engine::tests\`):
  - \`fetch_child_completion_data_bubbles_contexts_in_position_order\` — inserts steps out of position order, verifies bubble-up returns them sorted, with all per-step data (\`context\`, \`markers\`, \`structured_output\`) preserved.
  - \`fetch_child_completion_data_returns_empty_contexts_on_persistence_error\` — confirms the new return value degrades cleanly to an empty Vec on get_steps failure (no panic, no partial state).

## Prompt fix (\`.conductor/agents/triage-reviews.md\`)

- New hard rule #6: **"Do NOT fall back to \`gh pr view --json reviews\` or any other GitHub API to discover findings."** Names the dismissed-review trap explicitly.
- New "Halting on missing data" section: if prior_contexts lacks review-aggregator output (or its structured_output doesn't parse), emit \`markers:[]\` with \`context\` explaining the bug and \`structured_output.halt_reason: "missing_aggregator_output"\`. Better to halt cleanly than to push back on the wrong findings or commit address-reviews to fixing the wrong thing.
- Empty-but-present \`blocking_findings\` (workflow shouldn't even call triage in that case) keeps its existing markers:[] handling.

Without (1), (2)'s defensive halt would fire on every nested-workflow run. Without (2), (1) alone leaves the dismissed-review trap open for any other prior_contexts gap. Both belong in the same PR.

## Test plan

- [x] \`cargo test -p runkon-flow\` — 268/268 pass (2 new tests + all existing).
- [x] \`cargo test -p conductor-core --lib\` — 1992/1992 pass (no regressions; bubble-up doesn't affect the persistence-side write path).
- [x] \`cargo clippy --workspace --exclude conductor-web --exclude conductor-desktop --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [ ] Post-merge smoke: re-dispatch iterate-pr against a PR with fresh blocking findings; confirm triage now consumes review-aggregator's structured_output via prior_contexts and pushes back / addresses correctly.
- [ ] Post-merge defensive verify: temporarily break the bubble-up (e.g. comment out the \`state.contexts.extend\` line) and confirm triage halts cleanly with the new \`halt_reason\` instead of falling back to GitHub.

## Why this isn't entangled with v0.13.0 trait-cleanup

The fix touches \`fetch_child_completion_data\`'s return shape (a public function) and the \`record_child_success\` closure inside \`call_workflow\`. No trait surface changes — \`WorkflowPersistence\`, \`ActionExecutor\`, \`ItemProvider\`, \`RunContext\` are all untouched. Doesn't trip the runkon-flow trait-surface freeze (commit \`0efc0917\`).

## Risk

Low. The engine change is additive (new third return value; existing callers updated; no behavior change for non-nested workflows). The prompt change forbids a fallback path the design never sanctioned and replaces it with a clean halt. Both are reversible with a single revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)