### PR TITLE
chore: bump workspace version to 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-cli"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-desktop"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-tui"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "conductor-web"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "runkon-flow"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "runkon-runtimes"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "libc",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["conductor-core", "conductor-cli", "conductor-tui", "conductor-web", 
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/devinrosen/conductor-ai"


### PR DESCRIPTION
## Summary

The 0.14.1 release ([commit 0ef2e284](https://github.com/devinrosen/conductor-ai/commit/0ef2e284db96a5fa0ae6b71e6e10971d3722d25a), #2919) merged without bumping `workspace.package.version` or refreshing `Cargo.lock`. This PR brings them up to match the published `v0.14.1` GitHub release.

- `Cargo.toml`: `0.14.0` → `0.14.1`
- `Cargo.lock`: regenerated via `cargo update --workspace` (locks all 7 workspace crates to `0.14.1`)

## Test plan

- [ ] CI green (clippy + test workspace)