### PR TITLE
feat(picker): runtime-aware model picker (TUI) and Settings → Runtimes pane

### DIFF
--- a/conductor-core/src/agent_config.rs
+++ b/conductor-core/src/agent_config.rs
@@ -1234,6 +1234,27 @@ Implement the plan written in PLAN.md.
     }
 
     #[test]
+    fn validate_agent_runtime_claude_ignores_supported_models() {
+        // Regression: when `runtimes.claude.supported_models` is populated (e.g. from
+        // a custom_models migration or user-configured custom Claude models), the
+        // built-in claude runtime must NOT enforce that list as a strict allowlist —
+        // those entries are additive picker rows, not a replacement for KNOWN_MODELS.
+        let mut runtimes = HashMap::new();
+        runtimes.insert(
+            "claude".to_string(),
+            RuntimeConfig {
+                supported_models: vec!["claude-opus-4-7".to_string()],
+                ..RuntimeConfig::default()
+            },
+        );
+        let def = make_def("claude", None);
+        assert!(
+            validate_agent_runtime(&def, &runtimes, Some("claude-sonnet-4-6")).is_ok(),
+            "claude runtime must accept built-in models even when supported_models is set"
+        );
+    }
+
+    #[test]
     fn validate_agent_runtime_missing_named_runtime_is_error() {
         let runtimes = HashMap::new();
         let def = make_def("my-local", None);

--- a/conductor-core/src/config.rs
+++ b/conductor-core/src/config.rs
@@ -570,12 +570,50 @@ pub fn load_config() -> Result<Config> {
     load_config_from(&config_path())
 }
 
+/// Migrate `general.custom_models` into `runtimes.claude.supported_models`.
+///
+/// Returns `true` when the config was modified and must be re-saved.
+///
+/// - Case 1: `custom_models` non-empty + claude entry absent/empty → move + clear source.
+/// - Case 2: both non-empty → warn, union (target order first, then source), dedupe, clear source.
+/// - Case 3: `custom_models` empty → no-op (returns false).
+fn migrate_custom_models_into_claude_runtime(config: &mut Config) -> bool {
+    if config.general.custom_models.is_empty() {
+        return false;
+    }
+
+    let source: Vec<String> = std::mem::take(&mut config.general.custom_models);
+    let claude_entry = config.runtimes.entry("claude".to_string()).or_default();
+
+    if claude_entry.supported_models.is_empty() {
+        // Case 1: clean move
+        claude_entry.supported_models = source;
+    } else {
+        // Case 2: union; target order preserved first, then source
+        tracing::warn!(
+            "Both general.custom_models and runtimes.claude.supported_models are non-empty; \
+             merging into runtimes.claude.supported_models (target order first)"
+        );
+        let mut seen = std::collections::HashSet::new();
+        for m in claude_entry.supported_models.iter() {
+            seen.insert(m.clone());
+        }
+        for m in source {
+            if seen.insert(m.clone()) {
+                claude_entry.supported_models.push(m);
+            }
+        }
+    }
+
+    true
+}
+
 fn load_config_from(path: &std::path::Path) -> Result<Config> {
     if !path.exists() {
         return Ok(Config::default());
     }
     let contents = std::fs::read_to_string(path)?;
-    let config: Config =
+    let mut config: Config =
         toml::from_str(&contents).map_err(|e| ConductorError::Config(e.to_string()))?;
 
     // Parse raw TOML once for migration checks and github.app validation.
@@ -644,6 +682,13 @@ fn load_config_from(path: &std::path::Path) -> Result<Config> {
                         })?;
                 }
             }
+        }
+    }
+
+    // Migrate legacy general.custom_models → runtimes.claude.supported_models.
+    if migrate_custom_models_into_claude_runtime(&mut config) {
+        if let Err(e) = save_config_to(&config, path) {
+            tracing::warn!("failed to persist custom_models migration: {e}");
         }
     }
 
@@ -1954,5 +1999,118 @@ vapid_subject = "mailto:test@example.com"
             Some("mailto:test@example.com"),
             "vapid_subject should be preserved verbatim"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Migration tests: general.custom_models → runtimes.claude.supported_models
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_migrate_custom_models_case1_moves_to_runtimes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+[general]
+custom_models = ["my-model-v1", "my-model-v2"]
+"#,
+        )
+        .unwrap();
+
+        let config = load_config_from(&path).unwrap();
+        // Source cleared
+        assert!(
+            config.general.custom_models.is_empty(),
+            "custom_models should be cleared after migration"
+        );
+        // Target populated
+        let claude = config.runtimes.get("claude").expect("claude entry created");
+        assert_eq!(
+            claude.supported_models,
+            vec!["my-model-v1".to_string(), "my-model-v2".to_string()]
+        );
+
+        // Idempotency: re-load should not change anything
+        let config2 = load_config_from(&path).unwrap();
+        assert!(config2.general.custom_models.is_empty());
+        let claude2 = config2.runtimes.get("claude").unwrap();
+        assert_eq!(claude2.supported_models, claude.supported_models);
+    }
+
+    #[test]
+    fn test_migrate_custom_models_case2_union_dedup() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+[general]
+custom_models = ["my-model-v1", "shared-model"]
+
+[runtimes.claude]
+supported_models = ["existing-model", "shared-model"]
+"#,
+        )
+        .unwrap();
+
+        let config = load_config_from(&path).unwrap();
+        // Source cleared
+        assert!(config.general.custom_models.is_empty());
+        // Target: target order first, then source additions (deduplicated)
+        let claude = config.runtimes.get("claude").unwrap();
+        // "existing-model" first, "shared-model" second (target order),
+        // then "my-model-v1" from source (shared-model already seen)
+        assert_eq!(
+            claude.supported_models,
+            vec![
+                "existing-model".to_string(),
+                "shared-model".to_string(),
+                "my-model-v1".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_migrate_custom_models_case3_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+[runtimes.claude]
+supported_models = ["existing-model"]
+"#,
+        )
+        .unwrap();
+
+        let config = load_config_from(&path).unwrap();
+        // No custom_models → no migration
+        let claude = config.runtimes.get("claude").unwrap();
+        assert_eq!(claude.supported_models, vec!["existing-model".to_string()]);
+    }
+
+    #[test]
+    fn test_migrate_custom_models_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+[general]
+custom_models = ["model-a"]
+"#,
+        )
+        .unwrap();
+
+        // First load triggers migration
+        let config1 = load_config_from(&path).unwrap();
+        assert!(config1.general.custom_models.is_empty());
+
+        // Second load: file was saved without custom_models, so no migration
+        let config2 = load_config_from(&path).unwrap();
+        assert!(config2.general.custom_models.is_empty());
+        let claude2 = config2.runtimes.get("claude").unwrap();
+        assert_eq!(claude2.supported_models, vec!["model-a".to_string()]);
     }
 }

--- a/conductor-core/src/config.rs
+++ b/conductor-core/src/config.rs
@@ -688,7 +688,10 @@ fn load_config_from(path: &std::path::Path) -> Result<Config> {
     // Migrate legacy general.custom_models → runtimes.claude.supported_models.
     if migrate_custom_models_into_claude_runtime(&mut config) {
         if let Err(e) = save_config_to(&config, path) {
-            tracing::warn!("failed to persist custom_models migration: {e}");
+            tracing::warn!(
+                "failed to persist custom_models migration to {}: {e}",
+                path.display()
+            );
         }
     }
 

--- a/conductor-tui/src/action.rs
+++ b/conductor-tui/src/action.rs
@@ -496,6 +496,14 @@ pub enum Action {
     /// Open Confirm modal to delete the selected custom model entry.
     ModelsDelete,
 
+    // Settings → Runtimes
+    /// Open Input modal to add a new runtime entry (step 1: name).
+    RuntimesAdd,
+    /// Open Input modal to edit the selected runtime's supported models.
+    RuntimesEdit,
+    /// Open Confirm modal to delete the selected runtime.
+    RuntimesDelete,
+
     // Settings view
     /// Navigate to View::Settings.
     OpenSettings,

--- a/conductor-tui/src/app/action_dispatch.rs
+++ b/conductor-tui/src/app/action_dispatch.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use conductor_core::workflow::parse_workflow_str;
 
 use crate::action::Action;
-use crate::state::{Modal, View, WorkflowDefFocus};
+use crate::state::{model_picker_total, Modal, View, WorkflowDefFocus};
 
 use super::helpers::{collapse_loop_iterations, max_scroll, workflow_parse_warning_message};
 use super::App;
@@ -683,12 +683,8 @@ impl App {
                     allow_default,
                     ..
                 } => {
-                    let total = runtime_sections
-                        .iter()
-                        .map(|s| s.models.len())
-                        .sum::<usize>()
-                        + usize::from(allow_default);
-                    *selected = total.saturating_sub(1);
+                    *selected =
+                        model_picker_total(runtime_sections, allow_default).saturating_sub(1);
                 }
                 Modal::BranchPicker {
                     ref items,

--- a/conductor-tui/src/app/action_dispatch.rs
+++ b/conductor-tui/src/app/action_dispatch.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use conductor_core::models;
 use conductor_core::workflow::parse_workflow_str;
 
 use crate::action::Action;
@@ -383,6 +382,9 @@ impl App {
             Action::IssueSourceDelete => self.handle_issue_source_delete(),
             Action::ModelsAdd => self.handle_models_add(),
             Action::ModelsDelete => self.handle_models_delete(),
+            Action::RuntimesAdd => self.handle_runtimes_add(),
+            Action::RuntimesEdit => self.handle_runtimes_edit(),
+            Action::RuntimesDelete => self.handle_runtimes_delete(),
             Action::DiscoverGithubOrgs => self.handle_discover_github_orgs(),
             Action::GithubOrgsLoaded { orgs } => self.handle_github_orgs_loaded(orgs),
             Action::GithubOrgsFailed { error } => self.handle_github_orgs_failed(error),
@@ -677,12 +679,14 @@ impl App {
                 }
                 Modal::ModelPicker {
                     ref mut selected,
-                    ref custom_models,
+                    ref runtime_sections,
                     allow_default,
                     ..
                 } => {
-                    let total = models::KNOWN_MODELS.len()
-                        + custom_models.len()
+                    let total = runtime_sections
+                        .iter()
+                        .map(|s| s.models.len())
+                        .sum::<usize>()
                         + usize::from(allow_default);
                     *selected = total.saturating_sub(1);
                 }

--- a/conductor-tui/src/app/agent_execution.rs
+++ b/conductor-tui/src/app/agent_execution.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -28,15 +27,18 @@ pub(super) struct HeadlessRunConfig {
     pub bot_name: Option<String>,
     pub permission_mode: Option<conductor_core::config::AgentPermissionMode>,
     pub stall_threshold: std::time::Duration,
+    /// Runtime name resolved from the picker (`Some("qwen-local")`, …) or `None`
+    /// to use the built-in `"claude"` runtime.
+    pub runtime: Option<String>,
 }
 
-fn synthesize_tui_agent_def(model: Option<&str>) -> AgentDef {
+fn synthesize_tui_agent_def(model: Option<&str>, runtime: &str) -> AgentDef {
     AgentDef {
         name: "tui-ad-hoc".to_string(),
         role: AgentRole::Actor,
         can_commit: true,
         model: model.map(String::from),
-        runtime: "claude".to_string(),
+        runtime: runtime.to_string(),
         prompt: String::new(),
     }
 }
@@ -97,6 +99,11 @@ pub(super) fn drive_headless_run(
         None => vec![],
     };
 
+    // Load the host config so non-claude runtimes resolve with their `[runtimes.*]`
+    // env overlay and binary path. Falls back to an empty config on failure (which
+    // means non-claude runtimes will fail to resolve with a clearer error).
+    let host_config = conductor_core::config::load_config().unwrap_or_default();
+
     let runtime_options = RuntimeOptions {
         binary_path: conductor_core::agent_runtime::resolve_conductor_bin().into(),
         env: Default::default(),
@@ -110,14 +117,19 @@ pub(super) fn drive_headless_run(
         max_turns: None,
     };
 
-    let runtime =
-        match resolve_runtime("claude", permission_mode, &HashMap::new(), &runtime_options) {
-            Ok(r) => r,
-            Err(e) => {
-                let _ = tx.send(on_launched(Err(e.to_string())));
-                return;
-            }
-        };
+    let runtime_name: &str = config.runtime.as_deref().unwrap_or("claude");
+    let runtime = match resolve_runtime(
+        runtime_name,
+        permission_mode,
+        &host_config.runtimes,
+        &runtime_options,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = tx.send(on_launched(Err(e.to_string())));
+            return;
+        }
+    };
 
     let db = conductor_core::config::db_path();
     let adapter = match SqliteHostAdapter::new(db) {
@@ -136,7 +148,7 @@ pub(super) fn drive_headless_run(
 
     let request = RuntimeRequest {
         run_id: run.id.clone(),
-        agent_def: synthesize_tui_agent_def(config.model.as_deref()),
+        agent_def: synthesize_tui_agent_def(config.model.as_deref(), runtime_name),
         prompt: config.prompt.clone(),
         working_dir: PathBuf::from(&config.working_dir),
         model: config.model.clone(),
@@ -378,6 +390,7 @@ impl App {
                 wt.slug.clone(),
                 resume_session_id,
                 selected_model,
+                None, // Auto-suggest path uses the default claude runtime
             );
             return;
         }
@@ -422,6 +435,7 @@ impl App {
                 worktree_slug: wt.slug.clone(),
                 resume_session_id,
                 resolved_default,
+                runtime: None, // Filled in from picker selection at submit time
             },
         };
     }
@@ -846,6 +860,7 @@ impl App {
         };
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn start_agent_headless(
         &mut self,
         prompt: String,
@@ -854,6 +869,7 @@ impl App {
         _worktree_slug: String,
         resume_session_id: Option<String>,
         model: Option<String>,
+        runtime: Option<String>,
     ) {
         let Some(ref tx) = self.bg_tx else { return };
         let tx = tx.clone();
@@ -886,6 +902,17 @@ impl App {
                 }
             };
 
+            // Persist the runtime selection on the run so list/detail views show
+            // which runtime serviced the request.
+            if let Some(ref rt_name) = runtime {
+                if let Err(e) = mgr.update_run_runtime(&run.id, rt_name) {
+                    tracing::warn!(
+                        "failed to persist runtime '{rt_name}' on run {}: {e}",
+                        run.id
+                    );
+                }
+            }
+
             drive_headless_run(
                 run,
                 HeadlessRunConfig {
@@ -896,6 +923,7 @@ impl App {
                     bot_name: None,
                     permission_mode: None,
                     stall_threshold,
+                    runtime,
                 },
                 &tx,
                 |result| Action::AgentLaunchComplete { result },
@@ -965,6 +993,7 @@ impl App {
                     bot_name: None,
                     permission_mode: Some(conductor_core::config::AgentPermissionMode::RepoSafe),
                     stall_threshold,
+                    runtime: None,
                 },
                 &tx,
                 |result| Action::RepoAgentLaunched { result },
@@ -1040,6 +1069,8 @@ impl App {
             let prompt = new_run.prompt.clone();
             let model = new_run.model.clone();
             let bot_name = new_run.bot_name.clone();
+            // Restart inherits the previous run's runtime (already on the row).
+            let runtime = new_run.runtime.clone();
             drive_headless_run(
                 new_run,
                 HeadlessRunConfig {
@@ -1050,6 +1081,7 @@ impl App {
                     bot_name,
                     permission_mode: None,
                     stall_threshold,
+                    runtime: Some(runtime),
                 },
                 &tx,
                 |result| Action::AgentRestartComplete { result },

--- a/conductor-tui/src/app/agent_execution.rs
+++ b/conductor-tui/src/app/agent_execution.rs
@@ -19,6 +19,10 @@ use super::App;
 /// of inputs the three TUI launch flows (`start_agent_headless`,
 /// `start_repo_agent_headless`, `handle_restart_agent`) need to pass into
 /// [`drive_headless_run`].
+///
+/// All fields are captured on the main thread so `drive_headless_run` runs
+/// purely off-thread without re-reading process-wide state — see the
+/// [TUI threading rule](../../../../docs/tui-threading.md).
 pub(super) struct HeadlessRunConfig {
     pub working_dir: String,
     pub prompt: String,
@@ -30,6 +34,10 @@ pub(super) struct HeadlessRunConfig {
     /// Runtime name resolved from the picker (`Some("qwen-local")`, …) or `None`
     /// to use the built-in `"claude"` runtime.
     pub runtime: Option<String>,
+    /// Snapshot of `[runtimes.*]` from the host config (cloned from `self.config`
+    /// on the main thread). Used by `resolve_runtime` to look up `env` overlays
+    /// and binary paths for non-claude runtimes.
+    pub runtimes: std::collections::HashMap<String, conductor_core::config::RuntimeConfig>,
 }
 
 fn synthesize_tui_agent_def(model: Option<&str>, runtime: &str) -> AgentDef {
@@ -99,11 +107,6 @@ pub(super) fn drive_headless_run(
         None => vec![],
     };
 
-    // Load the host config so non-claude runtimes resolve with their `[runtimes.*]`
-    // env overlay and binary path. Falls back to an empty config on failure (which
-    // means non-claude runtimes will fail to resolve with a clearer error).
-    let host_config = conductor_core::config::load_config().unwrap_or_default();
-
     let runtime_options = RuntimeOptions {
         binary_path: conductor_core::agent_runtime::resolve_conductor_bin().into(),
         env: Default::default(),
@@ -121,7 +124,7 @@ pub(super) fn drive_headless_run(
     let runtime = match resolve_runtime(
         runtime_name,
         permission_mode,
-        &host_config.runtimes,
+        &config.runtimes,
         &runtime_options,
     ) {
         Ok(r) => r,
@@ -874,6 +877,9 @@ impl App {
         let Some(ref tx) = self.bg_tx else { return };
         let tx = tx.clone();
         let stall_threshold = self.config.agents.stall_threshold();
+        // Capture runtimes on the main thread per the TUI threading rule —
+        // drive_headless_run runs off-thread and must not re-read process state.
+        let runtimes = self.config.runtimes.clone();
 
         self.state.modal = Modal::Progress {
             message: "Launching agent…".into(),
@@ -924,6 +930,7 @@ impl App {
                     permission_mode: None,
                     stall_threshold,
                     runtime,
+                    runtimes,
                 },
                 &tx,
                 |result| Action::AgentLaunchComplete { result },
@@ -955,6 +962,7 @@ impl App {
         let Some(ref tx) = self.bg_tx else { return };
         let tx = tx.clone();
         let stall_threshold = self.config.agents.stall_threshold();
+        let runtimes = self.config.runtimes.clone();
 
         self.state.modal = Modal::Progress {
             message: "Launching repo agent…".into(),
@@ -994,6 +1002,7 @@ impl App {
                     permission_mode: Some(conductor_core::config::AgentPermissionMode::RepoSafe),
                     stall_threshold,
                     runtime: None,
+                    runtimes,
                 },
                 &tx,
                 |result| Action::RepoAgentLaunched { result },
@@ -1038,6 +1047,7 @@ impl App {
         let tx = tx.clone();
         let run_id = run.id.clone();
         let stall_threshold = self.config.agents.stall_threshold();
+        let runtimes = self.config.runtimes.clone();
 
         self.state.modal = crate::state::Modal::Progress {
             message: "Restarting agent…".into(),
@@ -1082,6 +1092,7 @@ impl App {
                     permission_mode: None,
                     stall_threshold,
                     runtime: Some(runtime),
+                    runtimes,
                 },
                 &tx,
                 |result| Action::AgentRestartComplete { result },

--- a/conductor-tui/src/app/agent_execution.rs
+++ b/conductor-tui/src/app/agent_execution.rs
@@ -383,11 +383,6 @@ impl App {
         }
 
         // Otherwise, show the model picker (current behavior)
-        let initial_selected = conductor_core::models::KNOWN_MODELS
-            .iter()
-            .position(|m| m.alias == suggested)
-            .unwrap_or(1);
-
         let (effective_default, effective_source) = match &resolved_default {
             Some(m) => {
                 let source = if wt_model.is_some() {
@@ -402,12 +397,22 @@ impl App {
             None => (None, "not set".to_string()),
         };
 
+        // Build runtime sections from config
+        let runtime_sections = crate::app::input_handling::build_runtime_sections(&self.config);
+
+        let initial_selected = crate::app::input_handling::picker_initial_selected(
+            &runtime_sections,
+            effective_default.as_deref(),
+            Some(suggested),
+            true,
+        );
+
         self.state.modal = Modal::ModelPicker {
             context_label: "agent run".to_string(),
             effective_default,
             effective_source,
             selected: initial_selected,
-            custom_models: self.config.general.custom_models.clone(),
+            runtime_sections,
             suggested: Some(suggested.to_string()),
             allow_default: true,
             on_submit: InputAction::AgentModelOverride {

--- a/conductor-tui/src/app/input_handling.rs
+++ b/conductor-tui/src/app/input_handling.rs
@@ -39,13 +39,7 @@ pub(crate) fn build_runtime_sections(config: &Config) -> Vec<RuntimeSection> {
     }];
 
     // Additional user runtimes sorted by name (skip "claude" — already handled)
-    let mut other: Vec<(&String, &conductor_core::config::RuntimeConfig)> = config
-        .runtimes
-        .iter()
-        .filter(|(k, _)| k.as_str() != "claude")
-        .collect();
-    other.sort_by_key(|(k, _)| k.as_str());
-    for (name, rt) in other {
+    for (name, rt) in crate::state::user_runtimes_sorted(&config.runtimes) {
         if !rt.supported_models.is_empty() {
             sections.push(RuntimeSection {
                 name: name.clone(),
@@ -412,18 +406,30 @@ impl App {
             Modal::ModelPicker {
                 selected,
                 runtime_sections,
-                on_submit,
+                mut on_submit,
                 allow_default,
                 ..
             } => {
-                let value = if allow_default && selected == 0 {
+                let (runtime_opt, value) = if allow_default && selected == 0 {
                     // "Default" row selected — empty string maps to model: None
-                    String::new()
+                    (None, String::new())
                 } else {
-                    resolve_picker_selection(&runtime_sections, selected, allow_default)
-                        .map(|(_, model)| model)
-                        .unwrap_or_default()
+                    match resolve_picker_selection(&runtime_sections, selected, allow_default) {
+                        Some((rt, model)) => (Some(rt), model),
+                        None => (None, String::new()),
+                    }
                 };
+                // Inject the picker's runtime selection into model-bearing variants
+                // that persist runtime context. SetWorktreeModel/SetRepoModel are
+                // intentionally model-only; per-scope runtime persistence is
+                // deferred per #2960.
+                if let InputAction::AgentModelOverride {
+                    runtime: ref mut rt_field,
+                    ..
+                } = on_submit
+                {
+                    *rt_field = runtime_opt;
+                }
                 (value, on_submit)
             }
             _ => return,
@@ -663,6 +669,7 @@ impl App {
                         worktree_slug,
                         resume_session_id,
                         resolved_default,
+                        runtime: None, // Filled in from picker selection at submit time
                     },
                 };
             }
@@ -673,6 +680,7 @@ impl App {
                 worktree_slug,
                 resume_session_id,
                 resolved_default,
+                runtime,
             } => {
                 // Empty value means "use the resolved default"
                 let model = if value.trim().is_empty() {
@@ -687,6 +695,7 @@ impl App {
                     worktree_slug,
                     resume_session_id,
                     model,
+                    runtime,
                 );
             }
             InputAction::WorkflowModelOverride { action, inputs } => {
@@ -837,6 +846,7 @@ impl App {
                 worktree_slug,
                 resume_session_id,
                 resolved_default,
+                runtime,
             } => {
                 let model = if value.trim().is_empty() {
                     resolved_default
@@ -850,6 +860,7 @@ impl App {
                     worktree_slug,
                     resume_session_id,
                     model,
+                    runtime,
                 );
             }
             InputAction::SettingsSetModel | InputAction::SettingsSetSyncInterval => {
@@ -1236,6 +1247,71 @@ mod tests {
         app.handle_input_submit();
         let expected = format!("Model for feat-test set to: {}", KNOWN_MODELS[0].alias);
         assert_eq!(app.state.status_message.as_deref(), Some(expected.as_str()));
+    }
+
+    // The picker injects the resolved runtime into AgentModelOverride so non-claude
+    // selections aren't silently dropped. Default row leaves runtime as None.
+    #[test]
+    fn model_picker_injects_runtime_into_agent_model_override() {
+        use crate::state::RuntimeSection;
+        let sections = vec![
+            RuntimeSection {
+                name: "claude".to_string(),
+                models: vec!["opus".to_string(), "sonnet".to_string()],
+            },
+            RuntimeSection {
+                name: "qwen-local".to_string(),
+                models: vec!["qwen-72b".to_string()],
+            },
+        ];
+        // selected=2 with allow_default=false → second section, first model (qwen-72b)
+        let extracted = pick_and_extract_runtime(sections.clone(), 2, false);
+        assert_eq!(
+            extracted,
+            Some("qwen-local".to_string()),
+            "non-claude selection must surface the runtime name"
+        );
+        // selected=0 with allow_default=true → "Default" row → runtime stays None
+        let extracted_default = pick_and_extract_runtime(sections, 0, true);
+        assert_eq!(
+            extracted_default, None,
+            "Default row must leave runtime unset"
+        );
+    }
+
+    /// Helper: simulate the ModelPicker submission shape and return the runtime
+    /// field that was injected into the resulting `AgentModelOverride`.
+    fn pick_and_extract_runtime(
+        runtime_sections: Vec<crate::state::RuntimeSection>,
+        selected: usize,
+        allow_default: bool,
+    ) -> Option<String> {
+        use crate::state::InputAction;
+        let mut on_submit = InputAction::AgentModelOverride {
+            prompt: String::new(),
+            worktree_id: "w1".into(),
+            worktree_path: "/tmp/wt".into(),
+            worktree_slug: "feat-test".into(),
+            resume_session_id: None,
+            resolved_default: None,
+            runtime: None,
+        };
+        let runtime_opt = if allow_default && selected == 0 {
+            None
+        } else {
+            resolve_picker_selection(&runtime_sections, selected, allow_default).map(|(rt, _)| rt)
+        };
+        if let InputAction::AgentModelOverride {
+            runtime: ref mut rt_field,
+            ..
+        } = on_submit
+        {
+            *rt_field = runtime_opt;
+        }
+        match on_submit {
+            InputAction::AgentModelOverride { runtime, .. } => runtime,
+            _ => panic!("expected AgentModelOverride"),
+        }
     }
 
     // selecting the first custom model row submits its value

--- a/conductor-tui/src/app/input_handling.rs
+++ b/conductor-tui/src/app/input_handling.rs
@@ -1377,6 +1377,216 @@ mod tests {
         assert!(matches!(app.state.modal, Modal::None));
     }
 
+    // ---------- build_runtime_sections tests ----------
+
+    fn config_with_custom_runtimes(
+        claude_custom: Vec<&str>,
+        other: Vec<(&str, Vec<&str>)>,
+    ) -> Config {
+        use conductor_core::config::RuntimeConfig;
+        let mut config = Config::default();
+        if !claude_custom.is_empty() {
+            config.runtimes.insert(
+                "claude".to_string(),
+                RuntimeConfig {
+                    supported_models: claude_custom.into_iter().map(String::from).collect(),
+                    ..Default::default()
+                },
+            );
+        }
+        for (name, models) in other {
+            config.runtimes.insert(
+                name.to_string(),
+                RuntimeConfig {
+                    supported_models: models.into_iter().map(String::from).collect(),
+                    ..Default::default()
+                },
+            );
+        }
+        config
+    }
+
+    #[test]
+    fn build_runtime_sections_empty_config_returns_claude_with_known_models() {
+        let config = Config::default();
+        let sections = build_runtime_sections(&config);
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].name, "claude");
+        for km in KNOWN_MODELS {
+            assert!(
+                sections[0].models.contains(&km.alias.to_string()),
+                "expected alias {} in claude section",
+                km.alias
+            );
+        }
+        assert_eq!(sections[0].models.len(), KNOWN_MODELS.len());
+    }
+
+    #[test]
+    fn build_runtime_sections_claude_custom_models_appended_without_duplicates() {
+        let config = config_with_custom_runtimes(vec!["sonnet", "my-custom-model"], vec![]);
+        let sections = build_runtime_sections(&config);
+        assert_eq!(sections.len(), 1);
+        let models = &sections[0].models;
+        assert!(models.contains(&"my-custom-model".to_string()));
+        assert_eq!(
+            models.iter().filter(|m| m.as_str() == "sonnet").count(),
+            1,
+            "sonnet should appear exactly once (no duplicate from custom list)"
+        );
+        assert_eq!(models.len(), KNOWN_MODELS.len() + 1);
+    }
+
+    #[test]
+    fn build_runtime_sections_custom_runtimes_appear_after_claude_sorted() {
+        let config = config_with_custom_runtimes(
+            vec![],
+            vec![("zebra-rt", vec!["z-model"]), ("alpha-rt", vec!["a-model"])],
+        );
+        let sections = build_runtime_sections(&config);
+        assert_eq!(sections.len(), 3);
+        assert_eq!(sections[0].name, "claude");
+        assert_eq!(sections[1].name, "alpha-rt");
+        assert_eq!(sections[2].name, "zebra-rt");
+    }
+
+    #[test]
+    fn build_runtime_sections_empty_custom_runtime_excluded() {
+        let config = config_with_custom_runtimes(vec![], vec![("empty-rt", vec![])]);
+        let sections = build_runtime_sections(&config);
+        assert_eq!(
+            sections.len(),
+            1,
+            "runtime with no supported_models should be excluded"
+        );
+    }
+
+    // ---------- resolve_picker_selection tests ----------
+
+    fn two_section_sections() -> Vec<crate::state::RuntimeSection> {
+        vec![
+            crate::state::RuntimeSection {
+                name: "claude".to_string(),
+                models: vec!["opus".to_string(), "sonnet".to_string()],
+            },
+            crate::state::RuntimeSection {
+                name: "gemini".to_string(),
+                models: vec!["gemini-pro".to_string()],
+            },
+        ]
+    }
+
+    #[test]
+    fn resolve_picker_no_default_idx0_returns_first_model() {
+        let sections = two_section_sections();
+        assert_eq!(
+            resolve_picker_selection(&sections, 0, false),
+            Some(("claude".to_string(), "opus".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_picker_no_default_idx1_returns_second_model() {
+        let sections = two_section_sections();
+        assert_eq!(
+            resolve_picker_selection(&sections, 1, false),
+            Some(("claude".to_string(), "sonnet".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_picker_no_default_idx2_crosses_section_boundary() {
+        let sections = two_section_sections();
+        assert_eq!(
+            resolve_picker_selection(&sections, 2, false),
+            Some(("gemini".to_string(), "gemini-pro".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_picker_with_default_idx0_returns_none() {
+        let sections = two_section_sections();
+        assert_eq!(resolve_picker_selection(&sections, 0, true), None);
+    }
+
+    #[test]
+    fn resolve_picker_with_default_idx1_returns_first_model_with_offset() {
+        let sections = two_section_sections();
+        assert_eq!(
+            resolve_picker_selection(&sections, 1, true),
+            Some(("claude".to_string(), "opus".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_picker_out_of_range_returns_none() {
+        let sections = two_section_sections();
+        assert_eq!(resolve_picker_selection(&sections, 999, false), None);
+    }
+
+    // ---------- picker_initial_selected tests ----------
+
+    fn sonnet_flat_idx(sections: &[crate::state::RuntimeSection], allow_default: bool) -> usize {
+        let offset = usize::from(allow_default);
+        let mut flat = offset;
+        for s in sections {
+            for m in &s.models {
+                if m == "sonnet" {
+                    return flat;
+                }
+                flat += 1;
+            }
+        }
+        panic!("sonnet not found in sections");
+    }
+
+    #[test]
+    fn picker_initial_selected_effective_default_alias_selects_correct_row() {
+        let sections = claude_only_sections();
+        let expected = sonnet_flat_idx(&sections, false);
+        assert_eq!(
+            picker_initial_selected(&sections, Some("sonnet"), None, false),
+            expected
+        );
+    }
+
+    #[test]
+    fn picker_initial_selected_suggested_sonnet_selects_correct_row() {
+        let sections = claude_only_sections();
+        let expected = sonnet_flat_idx(&sections, false);
+        assert_eq!(
+            picker_initial_selected(&sections, None, Some("sonnet"), false),
+            expected
+        );
+    }
+
+    #[test]
+    fn picker_initial_selected_no_hint_defaults_to_sonnet() {
+        let sections = claude_only_sections();
+        let expected = sonnet_flat_idx(&sections, false);
+        assert_eq!(
+            picker_initial_selected(&sections, None, None, false),
+            expected
+        );
+    }
+
+    #[test]
+    fn picker_initial_selected_allow_default_adds_offset_to_sonnet() {
+        let sections = claude_only_sections();
+        let expected = sonnet_flat_idx(&sections, true);
+        assert_eq!(
+            picker_initial_selected(&sections, None, None, true),
+            expected
+        );
+    }
+
+    #[test]
+    fn picker_initial_selected_empty_sections_returns_offset() {
+        let empty: Vec<crate::state::RuntimeSection> = vec![];
+        assert_eq!(picker_initial_selected(&empty, None, None, false), 0);
+        assert_eq!(picker_initial_selected(&empty, None, None, true), 1);
+    }
+
     // ---------- Base branch picker tests ----------
 
     fn base_branch_picker_modal(selected: usize) -> Modal {

--- a/conductor-tui/src/app/input_handling.rs
+++ b/conductor-tui/src/app/input_handling.rs
@@ -6,10 +6,136 @@ use conductor_core::worktree::WorktreeManager;
 
 use crate::state::{
     BranchPickerItem, ConfirmAction, FormAction, FormField, FormFieldType, InputAction, Modal,
+    RuntimeSection,
 };
 
 use super::helpers::advance_form_field;
 use super::App;
+
+/// Build the `Vec<RuntimeSection>` shown in the model picker from the current config.
+///
+/// The built-in `"claude"` section is always first, combining `KNOWN_MODELS` aliases
+/// with any models in `config.runtimes["claude"].supported_models`. Additional
+/// user-defined runtimes follow in sorted order by name.
+pub(crate) fn build_runtime_sections(config: &Config) -> Vec<RuntimeSection> {
+    use conductor_core::models::KNOWN_MODELS;
+
+    // Build "claude" section: KNOWN_MODELS aliases + migrated custom models
+    let mut claude_models: Vec<String> = KNOWN_MODELS.iter().map(|m| m.alias.to_string()).collect();
+    if let Some(claude_rt) = config.runtimes.get("claude") {
+        for m in &claude_rt.supported_models {
+            let already_known = KNOWN_MODELS
+                .iter()
+                .any(|km| km.alias == m.as_str() || km.id == m.as_str());
+            if !already_known && !claude_models.contains(m) {
+                claude_models.push(m.clone());
+            }
+        }
+    }
+
+    let mut sections = vec![RuntimeSection {
+        name: "claude".to_string(),
+        models: claude_models,
+    }];
+
+    // Additional user runtimes sorted by name (skip "claude" — already handled)
+    let mut other: Vec<(&String, &conductor_core::config::RuntimeConfig)> = config
+        .runtimes
+        .iter()
+        .filter(|(k, _)| k.as_str() != "claude")
+        .collect();
+    other.sort_by_key(|(k, _)| k.as_str());
+    for (name, rt) in other {
+        if !rt.supported_models.is_empty() {
+            sections.push(RuntimeSection {
+                name: name.clone(),
+                models: rt.supported_models.clone(),
+            });
+        }
+    }
+
+    sections
+}
+
+/// Resolve flat selectable index → `(runtime_name, model_string)`.
+///
+/// `offset` is 1 when `allow_default` is true (Default row at index 0).
+/// Returns `None` when the index is out of range.
+pub(crate) fn resolve_picker_selection(
+    sections: &[RuntimeSection],
+    selected: usize,
+    allow_default: bool,
+) -> Option<(String, String)> {
+    let offset = usize::from(allow_default);
+    if allow_default && selected == 0 {
+        return None; // "Default" row
+    }
+    let mut flat = offset;
+    for section in sections {
+        for model in &section.models {
+            if flat == selected {
+                return Some((section.name.clone(), model.clone()));
+            }
+            flat += 1;
+        }
+    }
+    None
+}
+
+/// Compute the initial `selected` index for the picker given an effective default.
+pub(crate) fn picker_initial_selected(
+    sections: &[RuntimeSection],
+    effective_default: Option<&str>,
+    suggested: Option<&str>,
+    allow_default: bool,
+) -> usize {
+    use conductor_core::models::KNOWN_MODELS;
+
+    let offset = usize::from(allow_default);
+
+    // Try to pre-select based on effective_default
+    if let Some(default) = effective_default {
+        let mut flat = offset;
+        for section in sections {
+            for model in &section.models {
+                let matches = model == default
+                    || KNOWN_MODELS
+                        .iter()
+                        .any(|km| (km.id == default || km.alias == default) && km.alias == model);
+                if matches {
+                    return flat;
+                }
+                flat += 1;
+            }
+        }
+    }
+
+    // Fall back to suggested model in claude section
+    if let Some(sug) = suggested {
+        let mut flat = offset;
+        if let Some(claude_section) = sections.iter().find(|s| s.name == "claude") {
+            for model in &claude_section.models {
+                if model == sug {
+                    return flat;
+                }
+                flat += 1;
+            }
+        }
+    }
+
+    // Default: sonnet (alias) if present in claude section, otherwise offset
+    let mut flat = offset;
+    if let Some(claude_section) = sections.iter().find(|s| s.name == "claude") {
+        for model in &claude_section.models {
+            if model == "sonnet" {
+                return flat;
+            }
+            flat += 1;
+        }
+    }
+
+    offset // fallback to first selectable row
+}
 
 /// Build the "From PR (optional)" input modal used to transition into the PR step
 /// of worktree creation. Centralised here to avoid duplicating the title/prompt strings.
@@ -285,23 +411,18 @@ impl App {
             }
             Modal::ModelPicker {
                 selected,
-                custom_models,
+                runtime_sections,
                 on_submit,
                 allow_default,
                 ..
             } => {
-                let models = conductor_core::models::KNOWN_MODELS;
-                let offset = usize::from(allow_default);
                 let value = if allow_default && selected == 0 {
                     // "Default" row selected — empty string maps to model: None
                     String::new()
-                } else if selected < offset + models.len() {
-                    // Selected a known model — use its alias
-                    models[selected - offset].alias.to_string()
                 } else {
-                    // Selected a saved custom model
-                    let custom_idx = selected - offset - models.len();
-                    custom_models.get(custom_idx).cloned().unwrap_or_default()
+                    resolve_picker_selection(&runtime_sections, selected, allow_default)
+                        .map(|(_, model)| model)
+                        .unwrap_or_default()
                 };
                 (value, on_submit)
             }
@@ -502,12 +623,6 @@ impl App {
                 // Suggest a model based on the prompt text
                 let suggested = conductor_core::models::suggest_model(&value);
 
-                // Pre-select the suggested model in the picker
-                let initial_selected = conductor_core::models::KNOWN_MODELS
-                    .iter()
-                    .position(|m| m.alias == suggested)
-                    .unwrap_or(1); // default to sonnet
-
                 let (effective_default, effective_source) = match &resolved_default {
                     Some(m) => {
                         let source = if wt_model.is_some() {
@@ -522,12 +637,23 @@ impl App {
                     None => (None, "not set".to_string()),
                 };
 
+                // Build runtime sections from config
+                let runtime_sections = build_runtime_sections(&self.config);
+
+                // Pre-select the suggested model in the picker
+                let initial_selected = picker_initial_selected(
+                    &runtime_sections,
+                    effective_default.as_deref(),
+                    Some(suggested),
+                    true,
+                );
+
                 self.state.modal = Modal::ModelPicker {
                     context_label: "agent run".to_string(),
                     effective_default,
                     effective_source,
                     selected: initial_selected,
-                    custom_models: self.config.general.custom_models.clone(),
+                    runtime_sections,
                     suggested: Some(suggested.to_string()),
                     allow_default: true,
                     on_submit: InputAction::AgentModelOverride {
@@ -649,7 +775,10 @@ impl App {
             InputAction::SettingsSetModel
             | InputAction::SettingsSetSyncInterval
             | InputAction::SettingsAddCustomModel
-            | InputAction::SettingsSetStallTimeout => {
+            | InputAction::SettingsSetStallTimeout
+            | InputAction::SettingsAddRuntime
+            | InputAction::SettingsAddRuntimeModels { .. }
+            | InputAction::SettingsEditRuntimeModels { .. } => {
                 self.handle_settings_input_submit(on_submit, value);
             }
             InputAction::AdoptWorktree { repo_slug } => {
@@ -1024,13 +1153,20 @@ mod tests {
         }
     }
 
+    fn claude_only_sections() -> Vec<crate::state::RuntimeSection> {
+        vec![crate::state::RuntimeSection {
+            name: "claude".to_string(),
+            models: KNOWN_MODELS.iter().map(|m| m.alias.to_string()).collect(),
+        }]
+    }
+
     fn model_picker(selected: usize, allow_default: bool) -> Modal {
         Modal::ModelPicker {
             context_label: "test".to_string(),
             effective_default: None,
             effective_source: "not set".to_string(),
             selected,
-            custom_models: vec![],
+            runtime_sections: claude_only_sections(),
             suggested: None,
             on_submit: set_wt_model_action(),
             allow_default,
@@ -1042,12 +1178,18 @@ mod tests {
         allow_default: bool,
         custom: Vec<String>,
     ) -> Modal {
+        // Custom models live inside the built-in claude section after KNOWN_MODELS aliases.
+        let mut models: Vec<String> = KNOWN_MODELS.iter().map(|m| m.alias.to_string()).collect();
+        models.extend(custom);
         Modal::ModelPicker {
             context_label: "test".to_string(),
             effective_default: None,
             effective_source: "not set".to_string(),
             selected,
-            custom_models: custom,
+            runtime_sections: vec![crate::state::RuntimeSection {
+                name: "claude".to_string(),
+                models,
+            }],
             suggested: None,
             on_submit: set_wt_model_action(),
             allow_default,

--- a/conductor-tui/src/app/modal_dialog.rs
+++ b/conductor-tui/src/app/modal_dialog.rs
@@ -200,6 +200,11 @@ impl App {
                 self.save_config_background();
                 self.refresh_settings_display();
             }
+            ConfirmAction::DeleteRuntime { name } => {
+                self.config.runtimes.remove(&name);
+                self.save_config_background();
+                self.refresh_settings_display();
+            }
             ConfirmAction::Quit => {
                 self.state.should_quit = true;
             }

--- a/conductor-tui/src/app/navigation.rs
+++ b/conductor-tui/src/app/navigation.rs
@@ -1,8 +1,8 @@
 use ratatui::widgets::ListState;
 
 use crate::state::{
-    info_row, repo_info_row, workflow_run_info_row, DashboardRow, FormField, Modal,
-    RepoDetailFocus, View, WorkflowDefFocus, WorkflowPickerItem, WorkflowRunDetailFocus,
+    info_row, model_picker_total, repo_info_row, workflow_run_info_row, DashboardRow, FormField,
+    Modal, RepoDetailFocus, View, WorkflowDefFocus, WorkflowPickerItem, WorkflowRunDetailFocus,
     WorkflowsFocus, WorktreeDetailFocus,
 };
 
@@ -483,12 +483,10 @@ impl App {
                 allow_default,
                 ..
             } => {
-                let total = runtime_sections
-                    .iter()
-                    .map(|s| s.models.len())
-                    .sum::<usize>()
-                    + usize::from(allow_default);
-                wrap_decrement(selected, total);
+                wrap_decrement(
+                    selected,
+                    model_picker_total(runtime_sections, allow_default),
+                );
                 return;
             }
             Modal::BranchPicker {
@@ -646,12 +644,10 @@ impl App {
                 allow_default,
                 ..
             } => {
-                let total = runtime_sections
-                    .iter()
-                    .map(|s| s.models.len())
-                    .sum::<usize>()
-                    + usize::from(allow_default);
-                wrap_increment(selected, total);
+                wrap_increment(
+                    selected,
+                    model_picker_total(runtime_sections, allow_default),
+                );
                 return;
             }
             Modal::BranchPicker {

--- a/conductor-tui/src/app/navigation.rs
+++ b/conductor-tui/src/app/navigation.rs
@@ -479,12 +479,14 @@ impl App {
             }
             Modal::ModelPicker {
                 ref mut selected,
-                ref custom_models,
+                ref runtime_sections,
                 allow_default,
                 ..
             } => {
-                let total = conductor_core::models::KNOWN_MODELS.len()
-                    + custom_models.len()
+                let total = runtime_sections
+                    .iter()
+                    .map(|s| s.models.len())
+                    .sum::<usize>()
                     + usize::from(allow_default);
                 wrap_decrement(selected, total);
                 return;
@@ -640,12 +642,14 @@ impl App {
             }
             Modal::ModelPicker {
                 ref mut selected,
-                ref custom_models,
+                ref runtime_sections,
                 allow_default,
                 ..
             } => {
-                let total = conductor_core::models::KNOWN_MODELS.len()
-                    + custom_models.len()
+                let total = runtime_sections
+                    .iter()
+                    .map(|s| s.models.len())
+                    .sum::<usize>()
                     + usize::from(allow_default);
                 wrap_increment(selected, total);
                 return;

--- a/conductor-tui/src/app/settings_management.rs
+++ b/conductor-tui/src/app/settings_management.rs
@@ -93,14 +93,7 @@ impl App {
             env_count: claude_env,
             is_built_in: true,
         });
-        let mut other: Vec<(&String, &conductor_core::config::RuntimeConfig)> = self
-            .config
-            .runtimes
-            .iter()
-            .filter(|(k, _)| k.as_str() != "claude")
-            .collect();
-        other.sort_by_key(|(k, _)| k.as_str());
-        for (name, rt) in other {
+        for (name, rt) in crate::state::user_runtimes_sorted(&self.config.runtimes) {
             let type_hint = rt
                 .runtime_type
                 .clone()

--- a/conductor-tui/src/app/settings_management.rs
+++ b/conductor-tui/src/app/settings_management.rs
@@ -78,6 +78,42 @@ impl App {
 
         let custom_models = self.config.general.custom_models.clone();
 
+        // Build the runtimes display list. The built-in `claude` runtime is always
+        // shown first; user-defined runtimes follow in sorted order by name.
+        let mut runtimes: Vec<(String, String, usize, usize, bool)> = Vec::new();
+        let claude_entry = self.config.runtimes.get("claude");
+        let claude_models = claude_entry
+            .map(|rt| rt.supported_models.len())
+            .unwrap_or(0);
+        let claude_env = claude_entry.map(|rt| rt.env.len()).unwrap_or(0);
+        runtimes.push((
+            "claude".to_string(),
+            "claude".to_string(),
+            claude_models,
+            claude_env,
+            true,
+        ));
+        let mut other: Vec<(&String, &conductor_core::config::RuntimeConfig)> = self
+            .config
+            .runtimes
+            .iter()
+            .filter(|(k, _)| k.as_str() != "claude")
+            .collect();
+        other.sort_by_key(|(k, _)| k.as_str());
+        for (name, rt) in other {
+            let type_hint = rt
+                .runtime_type
+                .clone()
+                .unwrap_or_else(|| "claude".to_string());
+            runtimes.push((
+                name.clone(),
+                type_hint,
+                rt.supported_models.len(),
+                rt.env.len(),
+                false,
+            ));
+        }
+
         self.state.settings_display = SettingsDisplayCache {
             model,
             permission_mode,
@@ -88,6 +124,7 @@ impl App {
             theme,
             hooks,
             custom_models,
+            runtimes,
         };
     }
 
@@ -144,6 +181,9 @@ impl App {
             }
             SettingsCategory::Models => {
                 // Enter in Models pane is a no-op; [a]/[d] are the actions.
+            }
+            SettingsCategory::Runtimes => {
+                // Enter in Runtimes pane is a no-op; [a]/[e]/[d] are the actions.
             }
         }
     }
@@ -353,6 +393,7 @@ impl App {
             SettingsCategory::Appearance => appearance_row::COUNT,
             SettingsCategory::Notifications => self.state.settings_display.hooks.len().max(1),
             SettingsCategory::Models => self.state.settings_display.custom_models.len().max(1),
+            SettingsCategory::Runtimes => self.state.settings_display.runtimes.len().max(1),
         }
     }
 
@@ -392,6 +433,60 @@ impl App {
                     self.refresh_settings_display();
                 }
             }
+            InputAction::SettingsAddRuntime => {
+                let name = value.trim().to_string();
+                if name.is_empty() {
+                    self.state.modal = Modal::None;
+                    return;
+                }
+                if name == "claude" {
+                    self.state.modal = Modal::Error {
+                        message: "\"claude\" is the built-in runtime and cannot be added manually."
+                            .into(),
+                    };
+                    return;
+                }
+                if self.config.runtimes.contains_key(&name) {
+                    self.state.modal = Modal::Error {
+                        message: format!("Runtime \"{name}\" already exists."),
+                    };
+                    return;
+                }
+                // Step 2: prompt for comma-separated supported models
+                self.state.modal = Modal::Input {
+                    title: format!("Add runtime: {name}"),
+                    prompt: "Supported models (comma-separated):".into(),
+                    value: String::new(),
+                    on_submit: InputAction::SettingsAddRuntimeModels { name },
+                };
+                return;
+            }
+            InputAction::SettingsAddRuntimeModels { name } => {
+                let models = parse_comma_models(&value);
+                let rt = conductor_core::config::RuntimeConfig {
+                    runtime_type: Some("claude".to_string()),
+                    supported_models: models,
+                    ..Default::default()
+                };
+                self.config.runtimes.insert(name, rt);
+                self.save_config_background();
+                self.refresh_settings_display();
+            }
+            InputAction::SettingsEditRuntimeModels { name } => {
+                let models = parse_comma_models(&value);
+                if let Some(rt) = self.config.runtimes.get_mut(&name) {
+                    rt.supported_models = models;
+                } else {
+                    let rt = conductor_core::config::RuntimeConfig {
+                        runtime_type: Some("claude".to_string()),
+                        supported_models: models,
+                        ..Default::default()
+                    };
+                    self.config.runtimes.insert(name, rt);
+                }
+                self.save_config_background();
+                self.refresh_settings_display();
+            }
             InputAction::SettingsSetStallTimeout => {
                 if value.trim().is_empty() {
                     self.config.agents.stall_threshold_secs = None;
@@ -428,6 +523,71 @@ impl App {
         };
     }
 
+    /// Open the Input modal to add a new runtime entry (step 1: name).
+    pub(super) fn handle_runtimes_add(&mut self) {
+        self.state.modal = Modal::Input {
+            title: "Add runtime".into(),
+            prompt: "Runtime name (e.g. claude-qwen-local):".into(),
+            value: String::new(),
+            on_submit: InputAction::SettingsAddRuntime,
+        };
+    }
+
+    /// Open the Input modal to edit the currently selected runtime's models.
+    pub(super) fn handle_runtimes_edit(&mut self) {
+        let runtimes = &self.state.settings_display.runtimes;
+        if runtimes.is_empty() {
+            return;
+        }
+        let idx = self
+            .state
+            .settings_row_index
+            .min(runtimes.len().saturating_sub(1));
+        let (name, _, _, _, is_built_in) = &runtimes[idx];
+        if *is_built_in {
+            self.state.status_message = Some(
+                "Built-in claude runtime is read-only \u{2014} use Models pane to add custom models"
+                    .into(),
+            );
+            return;
+        }
+        let current = self
+            .config
+            .runtimes
+            .get(name)
+            .map(|rt| rt.supported_models.join(", "))
+            .unwrap_or_default();
+        self.state.modal = Modal::Input {
+            title: format!("Edit models: {name}"),
+            prompt: "Supported models (comma-separated):".into(),
+            value: current,
+            on_submit: InputAction::SettingsEditRuntimeModels { name: name.clone() },
+        };
+    }
+
+    /// Open the Confirm modal to delete the currently selected runtime.
+    pub(super) fn handle_runtimes_delete(&mut self) {
+        let runtimes = &self.state.settings_display.runtimes;
+        if runtimes.is_empty() {
+            return;
+        }
+        let idx = self
+            .state
+            .settings_row_index
+            .min(runtimes.len().saturating_sub(1));
+        let (name, _, _, _, is_built_in) = &runtimes[idx];
+        if *is_built_in {
+            self.state.status_message = Some("Cannot delete built-in claude runtime".into());
+            return;
+        }
+        let name = name.clone();
+        self.state.modal = Modal::Confirm {
+            title: "Delete runtime".into(),
+            message: format!("Remove runtime \"{name}\" from config?"),
+            on_confirm: ConfirmAction::DeleteRuntime { name },
+        };
+    }
+
     /// Open the Confirm modal to delete the currently selected custom model entry.
     pub(super) fn handle_models_delete(&mut self) {
         let models = &self.state.settings_display.custom_models;
@@ -453,6 +613,15 @@ impl App {
             SettingsFocus::SettingsList => SettingsFocus::CategoryList,
         };
     }
+}
+
+/// Parse a comma-separated list of model strings into a `Vec<String>`,
+/// trimming whitespace and dropping empty entries.
+fn parse_comma_models(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(|m| m.trim().to_string())
+        .filter(|m| !m.is_empty())
+        .collect()
 }
 
 impl AppState {

--- a/conductor-tui/src/app/settings_management.rs
+++ b/conductor-tui/src/app/settings_management.rs
@@ -4,8 +4,8 @@ use conductor_core::notification_hooks::HookRunner;
 
 use crate::action::Action;
 use crate::state::{
-    AppState, ConfirmAction, InputAction, Modal, SettingsCategory, SettingsDisplayCache,
-    SettingsFocus, View,
+    AppState, ConfirmAction, InputAction, Modal, RuntimeDisplayRow, SettingsCategory,
+    SettingsDisplayCache, SettingsFocus, View,
 };
 use crate::ui::settings::{appearance_row, general_row};
 
@@ -80,19 +80,19 @@ impl App {
 
         // Build the runtimes display list. The built-in `claude` runtime is always
         // shown first; user-defined runtimes follow in sorted order by name.
-        let mut runtimes: Vec<(String, String, usize, usize, bool)> = Vec::new();
+        let mut runtimes: Vec<RuntimeDisplayRow> = Vec::new();
         let claude_entry = self.config.runtimes.get("claude");
         let claude_models = claude_entry
             .map(|rt| rt.supported_models.len())
             .unwrap_or(0);
         let claude_env = claude_entry.map(|rt| rt.env.len()).unwrap_or(0);
-        runtimes.push((
-            "claude".to_string(),
-            "claude".to_string(),
-            claude_models,
-            claude_env,
-            true,
-        ));
+        runtimes.push(RuntimeDisplayRow {
+            name: "claude".to_string(),
+            type_hint: "claude".to_string(),
+            model_count: claude_models,
+            env_count: claude_env,
+            is_built_in: true,
+        });
         let mut other: Vec<(&String, &conductor_core::config::RuntimeConfig)> = self
             .config
             .runtimes
@@ -105,13 +105,13 @@ impl App {
                 .runtime_type
                 .clone()
                 .unwrap_or_else(|| "claude".to_string());
-            runtimes.push((
-                name.clone(),
+            runtimes.push(RuntimeDisplayRow {
+                name: name.clone(),
                 type_hint,
-                rt.supported_models.len(),
-                rt.env.len(),
-                false,
-            ));
+                model_count: rt.supported_models.len(),
+                env_count: rt.env.len(),
+                is_built_in: false,
+            });
         }
 
         self.state.settings_display = SettingsDisplayCache {
@@ -543,8 +543,8 @@ impl App {
             .state
             .settings_row_index
             .min(runtimes.len().saturating_sub(1));
-        let (name, _, _, _, is_built_in) = &runtimes[idx];
-        if *is_built_in {
+        let row = &runtimes[idx];
+        if row.is_built_in {
             self.state.status_message = Some(
                 "Built-in claude runtime is read-only \u{2014} use Models pane to add custom models"
                     .into(),
@@ -554,14 +554,16 @@ impl App {
         let current = self
             .config
             .runtimes
-            .get(name)
+            .get(&row.name)
             .map(|rt| rt.supported_models.join(", "))
             .unwrap_or_default();
         self.state.modal = Modal::Input {
-            title: format!("Edit models: {name}"),
+            title: format!("Edit models: {}", row.name),
             prompt: "Supported models (comma-separated):".into(),
             value: current,
-            on_submit: InputAction::SettingsEditRuntimeModels { name: name.clone() },
+            on_submit: InputAction::SettingsEditRuntimeModels {
+                name: row.name.clone(),
+            },
         };
     }
 
@@ -575,12 +577,12 @@ impl App {
             .state
             .settings_row_index
             .min(runtimes.len().saturating_sub(1));
-        let (name, _, _, _, is_built_in) = &runtimes[idx];
-        if *is_built_in {
+        let row = &runtimes[idx];
+        if row.is_built_in {
             self.state.status_message = Some("Cannot delete built-in claude runtime".into());
             return;
         }
-        let name = name.clone();
+        let name = row.name.clone();
         self.state.modal = Modal::Confirm {
             title: "Delete runtime".into(),
             message: format!("Remove runtime \"{name}\" from config?"),

--- a/conductor-tui/src/app/tests/action_handler_tests.rs
+++ b/conductor-tui/src/app/tests/action_handler_tests.rs
@@ -1375,7 +1375,10 @@ fn input_backspace_on_model_picker_non_custom_clears_model() {
         effective_default: Some("claude-sonnet-4-5-20250514".into()),
         effective_source: "global config".into(),
         selected: 0,
-        custom_models: vec![],
+        runtime_sections: vec![crate::state::RuntimeSection {
+            name: "claude".into(),
+            models: vec!["opus".into(), "sonnet".into(), "haiku".into()],
+        }],
         suggested: None,
         on_submit: InputAction::SetRepoModel {
             slug: "test-repo".into(),

--- a/conductor-tui/src/app/tests/action_handler_tests.rs
+++ b/conductor-tui/src/app/tests/action_handler_tests.rs
@@ -2227,3 +2227,186 @@ fn settings_handle_models_add_opens_input_modal() {
     app.handle_models_add();
     assert!(matches!(app.state.modal, Modal::Input { .. }));
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// Settings → Runtimes CRUD (settings_management.rs)
+// ═══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn runtimes_add_action_opens_input_modal_for_name() {
+    let mut app = make_app();
+    app.update(Action::OpenSettings);
+    app.state.settings_category = crate::state::SettingsCategory::Runtimes;
+    app.state.settings_focus = crate::state::SettingsFocus::SettingsList;
+    app.update(Action::RuntimesAdd);
+    match &app.state.modal {
+        Modal::Input {
+            title, on_submit, ..
+        } => {
+            assert!(title.contains("Add"));
+            assert!(matches!(
+                on_submit,
+                crate::state::InputAction::SettingsAddRuntime
+            ));
+        }
+        other => panic!("expected Input modal for runtime name, got {other:?}"),
+    }
+}
+
+#[test]
+fn runtimes_add_name_step_opens_models_step() {
+    use crate::state::InputAction;
+    let mut app = make_app();
+    app.handle_settings_input_submit(InputAction::SettingsAddRuntime, "qwen-local".into());
+    match &app.state.modal {
+        Modal::Input { on_submit, .. } => match on_submit {
+            InputAction::SettingsAddRuntimeModels { name } => {
+                assert_eq!(name, "qwen-local");
+            }
+            other => panic!("expected SettingsAddRuntimeModels, got {other:?}"),
+        },
+        other => panic!("expected Input modal for models step, got {other:?}"),
+    }
+}
+
+#[test]
+fn runtimes_add_rejects_claude_name() {
+    use crate::state::InputAction;
+    let mut app = make_app();
+    app.handle_settings_input_submit(InputAction::SettingsAddRuntime, "claude".into());
+    assert!(matches!(app.state.modal, Modal::Error { .. }));
+    assert!(!app.config.runtimes.contains_key("claude"));
+}
+
+#[test]
+fn runtimes_add_rejects_duplicate_name() {
+    use crate::state::InputAction;
+    let mut app = make_app();
+    app.config.runtimes.insert(
+        "qwen-local".to_string(),
+        conductor_core::config::RuntimeConfig::default(),
+    );
+    app.handle_settings_input_submit(InputAction::SettingsAddRuntime, "qwen-local".into());
+    assert!(matches!(app.state.modal, Modal::Error { .. }));
+}
+
+#[test]
+fn runtimes_add_models_step_persists_runtime_with_supported_models() {
+    use crate::state::InputAction;
+    let mut app = make_app();
+    app.handle_settings_input_submit(
+        InputAction::SettingsAddRuntimeModels {
+            name: "qwen-local".into(),
+        },
+        "qwen-72b, qwen-7b".into(),
+    );
+    let rt = app.config.runtimes.get("qwen-local").expect("inserted");
+    assert_eq!(rt.supported_models, vec!["qwen-72b", "qwen-7b"]);
+    assert_eq!(rt.runtime_type.as_deref(), Some("claude"));
+}
+
+#[test]
+fn runtimes_edit_action_opens_input_with_current_models() {
+    let mut app = make_app();
+    let rt = conductor_core::config::RuntimeConfig {
+        runtime_type: Some("claude".into()),
+        supported_models: vec!["a".into(), "b".into()],
+        ..Default::default()
+    };
+    app.config.runtimes.insert("qwen-local".into(), rt);
+    app.refresh_settings_display();
+    app.state.settings_category = crate::state::SettingsCategory::Runtimes;
+    app.state.settings_focus = crate::state::SettingsFocus::SettingsList;
+    // Index 0 is built-in claude (read-only); 1 is qwen-local.
+    app.state.settings_row_index = 1;
+    app.handle_runtimes_edit();
+    match &app.state.modal {
+        Modal::Input {
+            value, on_submit, ..
+        } => {
+            assert_eq!(value, "a, b");
+            match on_submit {
+                crate::state::InputAction::SettingsEditRuntimeModels { name } => {
+                    assert_eq!(name, "qwen-local");
+                }
+                other => panic!("expected SettingsEditRuntimeModels, got {other:?}"),
+            }
+        }
+        other => panic!("expected Input modal, got {other:?}"),
+    }
+}
+
+#[test]
+fn runtimes_edit_built_in_claude_is_noop_with_status_message() {
+    let mut app = make_app();
+    app.refresh_settings_display();
+    app.state.settings_category = crate::state::SettingsCategory::Runtimes;
+    app.state.settings_focus = crate::state::SettingsFocus::SettingsList;
+    app.state.settings_row_index = 0; // claude built-in
+    app.handle_runtimes_edit();
+    assert!(matches!(app.state.modal, Modal::None));
+    assert!(app
+        .state
+        .status_message
+        .as_deref()
+        .unwrap_or("")
+        .contains("read-only"));
+}
+
+#[test]
+fn runtimes_delete_built_in_claude_is_noop_with_status_message() {
+    let mut app = make_app();
+    app.refresh_settings_display();
+    app.state.settings_category = crate::state::SettingsCategory::Runtimes;
+    app.state.settings_focus = crate::state::SettingsFocus::SettingsList;
+    app.state.settings_row_index = 0; // claude built-in
+    app.handle_runtimes_delete();
+    assert!(matches!(app.state.modal, Modal::None));
+    assert!(app
+        .state
+        .status_message
+        .as_deref()
+        .unwrap_or("")
+        .contains("Cannot delete"));
+}
+
+#[test]
+fn runtimes_delete_user_runtime_opens_confirm_modal() {
+    let mut app = make_app();
+    app.config.runtimes.insert(
+        "qwen-local".into(),
+        conductor_core::config::RuntimeConfig::default(),
+    );
+    app.refresh_settings_display();
+    app.state.settings_category = crate::state::SettingsCategory::Runtimes;
+    app.state.settings_focus = crate::state::SettingsFocus::SettingsList;
+    app.state.settings_row_index = 1;
+    app.handle_runtimes_delete();
+    match &app.state.modal {
+        Modal::Confirm {
+            message,
+            on_confirm,
+            ..
+        } => {
+            assert!(message.contains("qwen-local"));
+            assert!(matches!(
+                on_confirm,
+                crate::state::ConfirmAction::DeleteRuntime { name } if name == "qwen-local"
+            ));
+        }
+        other => panic!("expected Confirm modal, got {other:?}"),
+    }
+}
+
+#[test]
+fn runtimes_confirm_delete_removes_runtime_from_config() {
+    let mut app = make_app();
+    app.config.runtimes.insert(
+        "qwen-local".into(),
+        conductor_core::config::RuntimeConfig::default(),
+    );
+    app.execute_confirm_action(crate::state::ConfirmAction::DeleteRuntime {
+        name: "qwen-local".into(),
+    });
+    assert!(!app.config.runtimes.contains_key("qwen-local"));
+}

--- a/conductor-tui/src/app/theme_management.rs
+++ b/conductor-tui/src/app/theme_management.rs
@@ -1,4 +1,5 @@
 use crate::action::Action;
+use crate::app::input_handling::{build_runtime_sections, picker_initial_selected};
 use crate::state::{DashboardRow, InputAction, Modal, View};
 
 use super::App;
@@ -141,18 +142,12 @@ impl App {
                 }
             };
 
+        // Build runtime sections once for all pickers in this handler
+        let runtime_sections_cache = build_runtime_sections(&self.config);
+
         // Helper to find the initial selected index matching current model
         let initial_selected = |current: &Option<String>| -> usize {
-            match current {
-                Some(m) => conductor_core::models::KNOWN_MODELS
-                    .iter()
-                    .position(|km| km.id == m.as_str() || km.alias == m.as_str())
-                    .unwrap_or(conductor_core::models::KNOWN_MODELS.len()),
-                None => {
-                    // Default to sonnet (index 1)
-                    1
-                }
-            }
+            picker_initial_selected(&runtime_sections_cache, current.as_deref(), None, false)
         };
 
         match self.state.view {
@@ -178,7 +173,7 @@ impl App {
                             effective_default: effective,
                             effective_source: source,
                             selected,
-                            custom_models: self.config.general.custom_models.clone(),
+                            runtime_sections: runtime_sections_cache.clone(),
                             suggested: None,
                             allow_default: false,
                             on_submit: InputAction::SetWorktreeModel {
@@ -205,7 +200,7 @@ impl App {
                             effective_default: effective,
                             effective_source: source,
                             selected,
-                            custom_models: self.config.general.custom_models.clone(),
+                            runtime_sections: runtime_sections_cache.clone(),
                             suggested: None,
                             allow_default: false,
                             on_submit: InputAction::SetRepoModel {
@@ -241,7 +236,7 @@ impl App {
                     effective_default: effective,
                     effective_source: source,
                     selected,
-                    custom_models: self.config.general.custom_models.clone(),
+                    runtime_sections: runtime_sections_cache.clone(),
                     suggested: None,
                     allow_default: false,
                     on_submit: InputAction::SetWorktreeModel {
@@ -274,7 +269,7 @@ impl App {
                     effective_default: effective,
                     effective_source: source,
                     selected,
-                    custom_models: self.config.general.custom_models.clone(),
+                    runtime_sections: runtime_sections_cache.clone(),
                     suggested: None,
                     allow_default: false,
                     on_submit: InputAction::SetRepoModel {

--- a/conductor-tui/src/app/workflow_management.rs
+++ b/conductor-tui/src/app/workflow_management.rs
@@ -907,12 +907,14 @@ impl App {
             },
         };
 
+        let runtime_sections = crate::app::input_handling::build_runtime_sections(&self.config);
+
         self.state.modal = Modal::ModelPicker {
             context_label: format!("workflow: {}", def.name),
             effective_default,
             effective_source,
             selected: 0, // "Default" row pre-selected
-            custom_models: self.config.general.custom_models.clone(),
+            runtime_sections,
             suggested: None,
             allow_default: true,
             on_submit: crate::state::InputAction::WorkflowModelOverride {

--- a/conductor-tui/src/input.rs
+++ b/conductor-tui/src/input.rs
@@ -499,20 +499,34 @@ pub fn map_key(key: KeyEvent, state: &AppState) -> Action {
             }
             KeyCode::Char('a') => {
                 use crate::state::{SettingsCategory, SettingsFocus};
-                if state.settings_category == SettingsCategory::Models
-                    && state.settings_focus == SettingsFocus::SettingsList
-                {
-                    Action::ModelsAdd
+                if state.settings_focus == SettingsFocus::SettingsList {
+                    match state.settings_category {
+                        SettingsCategory::Models => Action::ModelsAdd,
+                        SettingsCategory::Runtimes => Action::RuntimesAdd,
+                        _ => Action::None,
+                    }
                 } else {
                     Action::None
                 }
             }
             KeyCode::Char('d') => {
                 use crate::state::{SettingsCategory, SettingsFocus};
-                if state.settings_category == SettingsCategory::Models
+                if state.settings_focus == SettingsFocus::SettingsList {
+                    match state.settings_category {
+                        SettingsCategory::Models => Action::ModelsDelete,
+                        SettingsCategory::Runtimes => Action::RuntimesDelete,
+                        _ => Action::None,
+                    }
+                } else {
+                    Action::None
+                }
+            }
+            KeyCode::Char('e') => {
+                use crate::state::{SettingsCategory, SettingsFocus};
+                if state.settings_category == SettingsCategory::Runtimes
                     && state.settings_focus == SettingsFocus::SettingsList
                 {
-                    Action::ModelsDelete
+                    Action::RuntimesEdit
                 } else {
                     Action::None
                 }

--- a/conductor-tui/src/state/app_state.rs
+++ b/conductor-tui/src/state/app_state.rs
@@ -208,6 +208,8 @@ pub struct SettingsDisplayCache {
     pub hooks: Vec<(String, String)>,
     /// Saved custom model IDs (mirrors config so render_models doesn't borrow config).
     pub custom_models: Vec<String>,
+    /// Runtime display rows: (name, type_hint, model_count, env_count, is_built_in).
+    pub runtimes: Vec<(String, String, usize, usize, bool)>,
 }
 
 impl Default for AppState {

--- a/conductor-tui/src/state/app_state.rs
+++ b/conductor-tui/src/state/app_state.rs
@@ -13,8 +13,9 @@ use super::workflow_rows::max_iteration_for_run;
 use super::{
     build_ticket_tree_indices_sorted_by, build_worktree_tree, build_worktree_tree_indices,
     parse_target_label, push_children, push_steps_for_run, ColumnFocus, DashboardRow, DataCache,
-    FilterState, Modal, RepoDetailFocus, SettingsCategory, SettingsFocus, TargetType, TicketSort,
-    TreePosition, View, WorkflowDefFocus, WorkflowRunDetailFocus, WorkflowRunRow, WorkflowsFocus,
+    FilterState, Modal, RepoDetailFocus, RuntimeDisplayRow, SettingsCategory, SettingsFocus,
+    TargetType, TicketSort, TreePosition, View, WorkflowDefFocus, WorkflowRunDetailFocus,
+    WorkflowRunRow, WorkflowsFocus,
 };
 use crate::theme::Theme;
 
@@ -208,8 +209,7 @@ pub struct SettingsDisplayCache {
     pub hooks: Vec<(String, String)>,
     /// Saved custom model IDs (mirrors config so render_models doesn't borrow config).
     pub custom_models: Vec<String>,
-    /// Runtime display rows: (name, type_hint, model_count, env_count, is_built_in).
-    pub runtimes: Vec<(String, String, usize, usize, bool)>,
+    pub runtimes: Vec<RuntimeDisplayRow>,
 }
 
 impl Default for AppState {

--- a/conductor-tui/src/state/enums.rs
+++ b/conductor-tui/src/state/enums.rs
@@ -26,6 +26,7 @@ pub enum SettingsCategory {
     Appearance,
     Notifications,
     Models,
+    Runtimes,
 }
 
 impl SettingsCategory {
@@ -35,6 +36,7 @@ impl SettingsCategory {
             SettingsCategory::Appearance,
             SettingsCategory::Notifications,
             SettingsCategory::Models,
+            SettingsCategory::Runtimes,
         ]
     }
 
@@ -44,8 +46,18 @@ impl SettingsCategory {
             Self::Appearance => "Appearance",
             Self::Notifications => "Notifications",
             Self::Models => "Models",
+            Self::Runtimes => "Runtimes",
         }
     }
+}
+
+/// One section in the runtime-aware model picker.
+/// `name` is the runtime key (e.g. `"claude"`, `"gemini"`).
+/// `models` is the ordered list of model strings for that runtime.
+#[derive(Debug, Clone)]
+pub struct RuntimeSection {
+    pub name: String,
+    pub models: Vec<String>,
 }
 
 /// A row in the unified dashboard list — repo header or worktree entry.
@@ -444,6 +456,9 @@ pub enum ConfirmAction {
     DeleteCustomModel {
         model: String,
     },
+    DeleteRuntime {
+        name: String,
+    },
     Quit,
 }
 
@@ -569,5 +584,15 @@ pub enum InputAction {
     /// Adopt an existing on-disk git worktree: user enters the path.
     AdoptWorktree {
         repo_slug: String,
+    },
+    /// Settings → Runtimes: add a new runtime entry (first step: name).
+    SettingsAddRuntime,
+    /// Settings → Runtimes: add models for a newly-named runtime (second step).
+    SettingsAddRuntimeModels {
+        name: String,
+    },
+    /// Settings → Runtimes: edit models for an existing runtime.
+    SettingsEditRuntimeModels {
+        name: String,
     },
 }

--- a/conductor-tui/src/state/enums.rs
+++ b/conductor-tui/src/state/enums.rs
@@ -75,6 +75,20 @@ pub struct RuntimeDisplayRow {
     pub is_built_in: bool,
 }
 
+/// Iterate over user-defined runtimes (excluding the built-in `"claude"` entry)
+/// in name-sorted order. Used by both the picker and Settings → Runtimes so
+/// they agree on iteration order.
+pub fn user_runtimes_sorted(
+    runtimes: &std::collections::HashMap<String, conductor_core::config::RuntimeConfig>,
+) -> Vec<(&String, &conductor_core::config::RuntimeConfig)> {
+    let mut other: Vec<_> = runtimes
+        .iter()
+        .filter(|(k, _)| k.as_str() != "claude")
+        .collect();
+    other.sort_by_key(|(k, _)| k.as_str());
+    other
+}
+
 /// A row in the unified dashboard list — repo header or worktree entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DashboardRow {
@@ -560,6 +574,8 @@ pub enum InputAction {
     },
     /// Second step: optionally override the model for this run.
     /// `resolved_default` is the already-resolved model (worktree → repo → global config).
+    /// `runtime` is the runtime chosen in the picker (`Some("qwen-local")`, `Some("claude")`, …);
+    /// `None` means the user picked the "Default" row and no override is applied.
     AgentModelOverride {
         prompt: String,
         worktree_id: String,
@@ -567,6 +583,7 @@ pub enum InputAction {
         worktree_slug: String,
         resume_session_id: Option<String>,
         resolved_default: Option<String>,
+        runtime: Option<String>,
     },
     /// Set (or clear) the default model for a worktree.
     SetWorktreeModel {

--- a/conductor-tui/src/state/enums.rs
+++ b/conductor-tui/src/state/enums.rs
@@ -60,6 +60,21 @@ pub struct RuntimeSection {
     pub models: Vec<String>,
 }
 
+/// Total number of selectable rows in the model picker (model entries + optional Default row).
+pub fn model_picker_total(sections: &[RuntimeSection], allow_default: bool) -> usize {
+    sections.iter().map(|s| s.models.len()).sum::<usize>() + usize::from(allow_default)
+}
+
+/// A display row for a runtime entry in the Settings → Runtimes pane.
+#[derive(Debug, Clone)]
+pub struct RuntimeDisplayRow {
+    pub name: String,
+    pub type_hint: String,
+    pub model_count: usize,
+    pub env_count: usize,
+    pub is_built_in: bool,
+}
+
 /// A row in the unified dashboard list — repo header or worktree entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DashboardRow {

--- a/conductor-tui/src/state/modal.rs
+++ b/conductor-tui/src/state/modal.rs
@@ -6,8 +6,8 @@ use conductor_core::tickets::Ticket;
 use tui_textarea::TextArea;
 
 use super::{
-    BranchPickerItem, ConfirmAction, FormAction, FormField, InputAction, TreePosition,
-    WorkflowPickerItem, WorkflowPickerTarget,
+    BranchPickerItem, ConfirmAction, FormAction, FormField, InputAction, RuntimeSection,
+    TreePosition, WorkflowPickerItem, WorkflowPickerTarget,
 };
 
 pub use crate::ui::graph::{GraphData, GraphNavState, GraphNodeType};
@@ -76,7 +76,7 @@ pub enum Modal {
         effective_default: Option<String>,
         /// Where the effective default came from (e.g. "global config", "repo", "worktree")
         effective_source: String,
-        /// Index of the currently selected item in the list
+        /// Index of the currently selected item in the flat selectable list
         selected: usize,
         /// Suggested model alias based on prompt keywords (e.g. "haiku", "opus"), if any
         suggested: Option<String>,
@@ -85,8 +85,9 @@ pub enum Modal {
         /// When true, show a "Default (per-agent frontmatter)" row at index 0.
         /// Used for run-time pickers (agent + workflow) where the user can opt out of overriding.
         allow_default: bool,
-        /// Snapshot of saved custom models at picker-open time (insertion order).
-        custom_models: Vec<String>,
+        /// Runtime sections shown in the picker. The built-in "claude" section is
+        /// first; additional user runtimes follow in sorted order.
+        runtime_sections: Vec<RuntimeSection>,
     },
     /// Gate action modal for approving/rejecting a workflow gate step.
     GateAction {

--- a/conductor-tui/src/ui/mod.rs
+++ b/conductor-tui/src/ui/mod.rs
@@ -130,7 +130,7 @@ pub fn render(frame: &mut Frame, state: &AppState) {
             effective_default,
             effective_source,
             selected,
-            custom_models,
+            runtime_sections,
             suggested,
             allow_default,
             ..
@@ -141,7 +141,7 @@ pub fn render(frame: &mut Frame, state: &AppState) {
             effective_default.as_deref(),
             effective_source,
             *selected,
-            custom_models,
+            runtime_sections,
             suggested.as_deref(),
             *allow_default,
             &state.theme,

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -919,14 +919,14 @@ pub fn render_model_picker(
     effective_default: Option<&str>,
     effective_source: &str,
     selected: usize,
-    custom_models: &[String],
+    runtime_sections: &[crate::state::RuntimeSection],
     suggested: Option<&str>,
     allow_default: bool,
     theme: &Theme,
 ) {
     use conductor_core::models::KNOWN_MODELS;
 
-    let popup = centered_rect(55, 55, area);
+    let popup = centered_rect(55, 65, area);
     frame.render_widget(Clear, popup);
 
     let dim = Style::default().fg(theme.label_secondary);
@@ -980,81 +980,116 @@ pub fn render_model_picker(
         ]));
     }
 
-    // Known models list
-    for (i, model) in KNOWN_MODELS.iter().enumerate() {
-        let is_selected = i + offset == selected;
-        let is_current = effective_default.is_some_and(|d| d == model.id || d == model.alias);
+    // Render sections: built-in "claude" first, then user runtimes
+    let mut flat_idx = offset; // index into selectable rows (excluding headers + Default)
 
-        let prefix = if is_selected { "\u{25b8} " } else { "  " };
+    for section in runtime_sections {
+        let is_claude = section.name == "claude";
 
-        let current_marker = if is_current { " (current)" } else { "" };
-
-        let suggested_marker = if suggested == Some(model.alias) && !is_current {
-            " [Suggested]"
+        // Section header (non-selectable)
+        let header_label = if is_claude {
+            " claude (built-in) ".to_string()
         } else {
-            ""
+            format!(" {} ", section.name)
         };
+        lines.push(Line::from(Span::styled(header_label, cyan_bold)));
 
-        let style = if is_selected {
-            Style::default()
-                .fg(theme.label_warning)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(theme.label_primary)
-        };
+        // When a runtime has only one model skip the per-section "Default" row.
+        let show_section_default = allow_default && section.models.len() != 1 && is_claude;
+        // (For now only claude section gets its own default row when multi-model)
 
-        lines.push(Line::from(vec![
-            Span::styled(format!("  {prefix}"), style),
-            Span::styled(
-                format!("{} ", model.tier_stars()),
-                Style::default().fg(match model.tier {
-                    conductor_core::models::ModelTier::Powerful => theme.status_waiting,
-                    conductor_core::models::ModelTier::Balanced => theme.label_accent,
-                    conductor_core::models::ModelTier::Fast => theme.status_completed,
-                }),
-            ),
-            Span::styled(format!("{:<7}", model.alias), style),
-            Span::styled(format!(" \u{2014} {}", model.description), dim),
-            Span::styled(current_marker, Style::default().fg(theme.label_secondary)),
-            Span::styled(
-                suggested_marker,
-                Style::default()
-                    .fg(theme.status_completed)
-                    .add_modifier(Modifier::BOLD),
-            ),
-        ]));
+        for model_str in &section.models {
+            if is_claude {
+                // Look up the KNOWN_MODELS entry by alias or id
+                let known = KNOWN_MODELS
+                    .iter()
+                    .find(|m| m.alias == model_str.as_str() || m.id == model_str.as_str());
+
+                if let Some(model) = known {
+                    let is_selected = flat_idx == selected;
+                    let is_current =
+                        effective_default.is_some_and(|d| d == model.id || d == model.alias);
+                    let prefix = if is_selected { "\u{25b8} " } else { "  " };
+                    let current_marker = if is_current { " (current)" } else { "" };
+                    let suggested_marker = if suggested == Some(model.alias) && !is_current {
+                        " [Suggested]"
+                    } else {
+                        ""
+                    };
+                    let style = if is_selected {
+                        Style::default()
+                            .fg(theme.label_warning)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(theme.label_primary)
+                    };
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("  {prefix}"), style),
+                        Span::styled(
+                            format!("{} ", model.tier_stars()),
+                            Style::default().fg(match model.tier {
+                                conductor_core::models::ModelTier::Powerful => theme.status_waiting,
+                                conductor_core::models::ModelTier::Balanced => theme.label_accent,
+                                conductor_core::models::ModelTier::Fast => theme.status_completed,
+                            }),
+                        ),
+                        Span::styled(format!("{:<7}", model.alias), style),
+                        Span::styled(format!(" \u{2014} {}", model.description), dim),
+                        Span::styled(current_marker, Style::default().fg(theme.label_secondary)),
+                        Span::styled(
+                            suggested_marker,
+                            Style::default()
+                                .fg(theme.status_completed)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                    ]));
+                } else {
+                    // Custom model string inside claude section (from migration)
+                    let is_selected = flat_idx == selected;
+                    let is_current = effective_default.is_some_and(|d| d == model_str.as_str());
+                    let prefix = if is_selected { "\u{25b8} " } else { "  " };
+                    let current_marker = if is_current { " (current)" } else { "" };
+                    let style = if is_selected {
+                        Style::default()
+                            .fg(theme.label_warning)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(theme.label_primary)
+                    };
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("  {prefix}"), style),
+                        Span::styled("\u{00b7} ", dim),
+                        Span::styled(model_str.clone(), style),
+                        Span::styled(current_marker, Style::default().fg(theme.label_secondary)),
+                    ]));
+                }
+            } else {
+                // Non-claude runtime: plain string, no tier badges
+                let is_selected = flat_idx == selected;
+                let is_current = effective_default.is_some_and(|d| d == model_str.as_str());
+                let prefix = if is_selected { "\u{25b8} " } else { "  " };
+                let current_marker = if is_current { " (current)" } else { "" };
+                let style = if is_selected {
+                    Style::default()
+                        .fg(theme.label_warning)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(theme.label_primary)
+                };
+                lines.push(Line::from(vec![
+                    Span::styled(format!("  {prefix}"), style),
+                    Span::styled("\u{00b7} ", dim),
+                    Span::styled(model_str.clone(), style),
+                    Span::styled(current_marker, Style::default().fg(theme.label_secondary)),
+                ]));
+            }
+            flat_idx += 1;
+        }
+
+        // Suppress unused warning for show_section_default (future use)
+        let _ = show_section_default;
+        lines.push(Line::from(""));
     }
-
-    // Saved custom models
-    for (j, model_id) in custom_models.iter().enumerate() {
-        let idx = offset + KNOWN_MODELS.len() + j;
-        let is_selected = idx == selected;
-        let is_current = effective_default.is_some_and(|d| d == model_id.as_str());
-        let prefix = if is_selected { "\u{25b8} " } else { "  " };
-        let current_marker = if is_current { " (current)" } else { "" };
-        let style = if is_selected {
-            Style::default()
-                .fg(theme.label_warning)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(theme.label_primary)
-        };
-        lines.push(Line::from(vec![
-            Span::styled(format!("  {prefix}"), style),
-            Span::styled("\u{00b7} ", dim),
-            Span::styled(model_id.clone(), style),
-            Span::styled(current_marker, Style::default().fg(theme.label_secondary)),
-        ]));
-    }
-
-    if custom_models.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "  (Add custom models in Settings \u{2192} Models)",
-            dim,
-        )));
-    }
-
-    lines.push(Line::from(""));
 
     // Clear option
     lines.push(Line::from(Span::styled(
@@ -1070,7 +1105,7 @@ pub fn render_model_picker(
                 .fg(theme.label_warning)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(" navigate  ", dim),
+        Span::styled(" navigate sections  ", dim),
         Span::styled(
             "Enter",
             Style::default()

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -1025,10 +1025,6 @@ pub fn render_model_picker(
         };
         lines.push(Line::from(Span::styled(header_label, cyan_bold)));
 
-        // When a runtime has only one model skip the per-section "Default" row.
-        let show_section_default = allow_default && section.models.len() != 1 && is_claude;
-        // (For now only claude section gets its own default row when multi-model)
-
         for model_str in &section.models {
             if is_claude {
                 // Look up the KNOWN_MODELS entry by alias or id
@@ -1099,8 +1095,6 @@ pub fn render_model_picker(
             flat_idx += 1;
         }
 
-        // Suppress unused warning for show_section_default (future use)
-        let _ = show_section_default;
         lines.push(Line::from(""));
     }
 

--- a/conductor-tui/src/ui/modal.rs
+++ b/conductor-tui/src/ui/modal.rs
@@ -911,6 +911,37 @@ pub fn render_agent_prompt(
     frame.render_widget(hint, chunks[2]);
 }
 
+/// Render a plain (no tier badge) model row used for custom claude models and non-claude runtimes.
+fn plain_model_row(
+    model_str: &str,
+    flat_idx: usize,
+    selected: usize,
+    effective_default: Option<&str>,
+    dim: Style,
+    theme: &Theme,
+) -> Line<'static> {
+    let is_selected = flat_idx == selected;
+    let is_current = effective_default.is_some_and(|d| d == model_str);
+    let prefix = if is_selected { "\u{25b8} " } else { "  " };
+    let current_marker = if is_current { " (current)" } else { "" };
+    let style = if is_selected {
+        Style::default()
+            .fg(theme.label_warning)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.label_primary)
+    };
+    Line::from(vec![
+        Span::styled(format!("  {prefix}"), style),
+        Span::styled("\u{00b7} ", dim),
+        Span::styled(model_str.to_string(), style),
+        Span::styled(
+            current_marker.to_string(),
+            Style::default().fg(theme.label_secondary),
+        ),
+    ])
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn render_model_picker(
     frame: &mut Frame,
@@ -1045,43 +1076,25 @@ pub fn render_model_picker(
                     ]));
                 } else {
                     // Custom model string inside claude section (from migration)
-                    let is_selected = flat_idx == selected;
-                    let is_current = effective_default.is_some_and(|d| d == model_str.as_str());
-                    let prefix = if is_selected { "\u{25b8} " } else { "  " };
-                    let current_marker = if is_current { " (current)" } else { "" };
-                    let style = if is_selected {
-                        Style::default()
-                            .fg(theme.label_warning)
-                            .add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default().fg(theme.label_primary)
-                    };
-                    lines.push(Line::from(vec![
-                        Span::styled(format!("  {prefix}"), style),
-                        Span::styled("\u{00b7} ", dim),
-                        Span::styled(model_str.clone(), style),
-                        Span::styled(current_marker, Style::default().fg(theme.label_secondary)),
-                    ]));
+                    lines.push(plain_model_row(
+                        model_str,
+                        flat_idx,
+                        selected,
+                        effective_default,
+                        dim,
+                        theme,
+                    ));
                 }
             } else {
                 // Non-claude runtime: plain string, no tier badges
-                let is_selected = flat_idx == selected;
-                let is_current = effective_default.is_some_and(|d| d == model_str.as_str());
-                let prefix = if is_selected { "\u{25b8} " } else { "  " };
-                let current_marker = if is_current { " (current)" } else { "" };
-                let style = if is_selected {
-                    Style::default()
-                        .fg(theme.label_warning)
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default().fg(theme.label_primary)
-                };
-                lines.push(Line::from(vec![
-                    Span::styled(format!("  {prefix}"), style),
-                    Span::styled("\u{00b7} ", dim),
-                    Span::styled(model_str.clone(), style),
-                    Span::styled(current_marker, Style::default().fg(theme.label_secondary)),
-                ]));
+                lines.push(plain_model_row(
+                    model_str,
+                    flat_idx,
+                    selected,
+                    effective_default,
+                    dim,
+                    theme,
+                ));
             }
             flat_idx += 1;
         }

--- a/conductor-tui/src/ui/settings.rs
+++ b/conductor-tui/src/ui/settings.rs
@@ -441,9 +441,7 @@ fn render_runtimes(frame: &mut Frame, area: Rect, block: Block, state: &AppState
             Style::default().fg(theme.label_secondary),
         )));
     } else {
-        for (i, (name, type_hint, model_count, env_count, is_built_in)) in
-            d.runtimes.iter().enumerate()
-        {
+        for (i, row) in d.runtimes.iter().enumerate() {
             let is_selected = i == sel && focused;
             let style = if is_selected {
                 Style::default()
@@ -453,14 +451,17 @@ fn render_runtimes(frame: &mut Frame, area: Rect, block: Block, state: &AppState
                 Style::default().fg(theme.label_secondary)
             };
             let prefix = if is_selected { "\u{25b8} " } else { "  " };
-            let suffix = if *is_built_in {
+            let suffix = if row.is_built_in {
                 "  (built-in)".to_string()
             } else {
-                format!("  type={type_hint} models={model_count} env={env_count}")
+                format!(
+                    "  type={} models={} env={}",
+                    row.type_hint, row.model_count, row.env_count
+                )
             };
             lines.push(Line::from(vec![
                 Span::styled(format!("  {prefix}"), style),
-                Span::styled(name.clone(), style.add_modifier(Modifier::BOLD)),
+                Span::styled(row.name.clone(), style.add_modifier(Modifier::BOLD)),
                 Span::styled(suffix, Style::default().fg(theme.label_secondary)),
             ]));
         }

--- a/conductor-tui/src/ui/settings.rs
+++ b/conductor-tui/src/ui/settings.rs
@@ -33,6 +33,13 @@ pub mod models_row {
     pub const COUNT_PER_MODEL: usize = 1;
 }
 
+/// Row count helper for Runtimes settings (right pane).
+/// One row per runtime (claude built-in always rendered first, then user runtimes).
+pub mod runtimes_row {
+    #[allow(dead_code)]
+    pub const COUNT_PER_RUNTIME: usize = 1;
+}
+
 pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
     let theme = &state.theme;
 
@@ -118,6 +125,9 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState) {
         }
         SettingsCategory::Models => {
             render_models(frame, right_area, right_block, state, right_focused)
+        }
+        SettingsCategory::Runtimes => {
+            render_runtimes(frame, right_area, right_block, state, right_focused)
         }
     }
 }
@@ -395,6 +405,72 @@ fn render_models(frame: &mut Frame, area: Rect, block: Block, state: &AppState, 
         }
     }
 
+    lines.push(Line::from(""));
+    lines.push(hint_line);
+
+    let para = Paragraph::new(lines);
+    frame.render_widget(para, inner);
+}
+
+fn render_runtimes(frame: &mut Frame, area: Rect, block: Block, state: &AppState, focused: bool) {
+    let theme = &state.theme;
+    let sel = state.settings_row_index;
+    let d = &state.settings_display;
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let hint_line = if focused {
+        Line::from(Span::styled(
+            "  [a] add  [e] edit models  [d] delete  [Esc] back",
+            Style::default().fg(theme.label_secondary),
+        ))
+    } else {
+        Line::from(Span::styled(
+            "  [Tab] switch pane",
+            Style::default().fg(theme.label_secondary),
+        ))
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(""));
+
+    if d.runtimes.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  No runtimes configured",
+            Style::default().fg(theme.label_secondary),
+        )));
+    } else {
+        for (i, (name, type_hint, model_count, env_count, is_built_in)) in
+            d.runtimes.iter().enumerate()
+        {
+            let is_selected = i == sel && focused;
+            let style = if is_selected {
+                Style::default()
+                    .fg(theme.label_primary)
+                    .bg(theme.highlight_bg)
+            } else {
+                Style::default().fg(theme.label_secondary)
+            };
+            let prefix = if is_selected { "\u{25b8} " } else { "  " };
+            let suffix = if *is_built_in {
+                "  (built-in)".to_string()
+            } else {
+                format!("  type={type_hint} models={model_count} env={env_count}")
+            };
+            lines.push(Line::from(vec![
+                Span::styled(format!("  {prefix}"), style),
+                Span::styled(name.clone(), style.add_modifier(Modifier::BOLD)),
+                Span::styled(suffix, Style::default().fg(theme.label_secondary)),
+            ]));
+        }
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  Note: edit env via ~/.conductor/config.toml directly",
+        Style::default().fg(theme.label_secondary),
+    )));
     lines.push(Line::from(""));
     lines.push(hint_line);
 

--- a/conductor-tui/tests/snapshots/tui_snapshots__snap_modal_model_picker.snap
+++ b/conductor-tui/tests/snapshots/tui_snapshots__snap_modal_model_picker.snap
@@ -1,11 +1,8 @@
 ---
 source: conductor-tui/tests/tui_snapshots.rs
-assertion_line: 590
 expression: render_to_string(&state)
 ---
 "┌ Repos & Worktrees (0 active) ──────────────────────────────────────────────┐┌ All Workflow Runs (H: show history, V: ┐"
-"│                                                                            ││                                        │"
-"│                                                                            ││                                        │"
 "│                                                                            ││                                        │"
 "│                                                                            ││                                        │"
 "│                                                                            ││                                        │"
@@ -19,14 +16,18 @@ expression: render_to_string(&state)
 "│                          │  Using: claude-sonnet-4-6  (from global config)                │                          │"
 "│                          │         ↑ override with:                                       │                          │"
 "│                          │                                                                │                          │"
+"│                          │ claude (built-in)                                              │                          │"
 "│                          │    ★★★ opus    — Planning, architecture, complex analysis      │                          │"
 "│                          │  ▸ ★★ sonnet  — General implementation (default) (current)     │                          │"
 "│                          │    ★ haiku   — Commit messages, formatting, quick edits        │                          │"
-"│                          │  (Add custom models in Settings → Models)                      │                          │"
 "│                          │                                                                │                          │"
 "│                          │  (Backspace to clear model override)                           │                          │"
 "│                          │                                                                │                          │"
-"│                          │  j/k navigate  Enter select  Esc cancel                        │                          │"
+"│                          │  j/k navigate sections  Enter select  Esc cancel               │                          │"
+"│                          │                                                                │                          │"
+"│                          │                                                                │                          │"
+"│                          │                                                                │                          │"
+"│                          │                                                                │                          │"
 "│                          │                                                                │                          │"
 "│                          │                                                                │                          │"
 "│                          │                                                                │                          │"
@@ -34,8 +35,6 @@ expression: render_to_string(&state)
 "│                          │                                                                │                          │"
 "│                          │                                                                │                          │"
 "│                          └────────────────────────────────────────────────────────────────┘                          │"
-"│                                                                            ││                                        │"
-"│                                                                            ││                                        │"
 "│                                                                            ││                                        │"
 "│                                                                            ││                                        │"
 "│                                                                            │└────────────────────────────────────────┘"

--- a/conductor-tui/tests/tui_snapshots.rs
+++ b/conductor-tui/tests/tui_snapshots.rs
@@ -578,7 +578,10 @@ fn snap_modal_model_picker() {
         effective_default: Some("claude-sonnet-4-6".into()),
         effective_source: "global config".into(),
         selected: 1,
-        custom_models: vec![],
+        runtime_sections: vec![conductor_tui::state::RuntimeSection {
+            name: "claude".into(),
+            models: vec!["opus".into(), "sonnet".into(), "haiku".into()],
+        }],
         suggested: None,
         on_submit: InputAction::SetWorktreeModel {
             worktree_id: "w1".into(),

--- a/runkon-flow-executors/src/claude_agent.rs
+++ b/runkon-flow-executors/src/claude_agent.rs
@@ -91,20 +91,13 @@ impl ClaudeAgentExecutor {
         )?;
 
         // Validate supported_models before spawning — catches misconfiguration early.
-        if let Some(rt_config) = ctx.runtimes.get(&agent_def.runtime) {
-            if !rt_config.supported_models.is_empty() {
-                let effective_model = ctx.model.as_deref().or(agent_def.model.as_deref());
-                if let Some(m) = effective_model {
-                    if !rt_config.supported_models.iter().any(|s| s == m) {
-                        return Err(format!(
-                            "runtime '{}' only accepts models {:?}; \
-                             agent '{}' resolved model is '{m}'",
-                            agent_def.runtime, rt_config.supported_models, agent_def.name
-                        ));
-                    }
-                }
-            }
-        }
+        check_supported_models(
+            &agent_def.runtime,
+            &agent_def.name,
+            agent_def.model.as_deref(),
+            ctx.model.as_deref(),
+            &ctx.runtimes,
+        )?;
 
         // API fast path: schema + key both present.
         if let (Some(schema), Some(api_key)) = (params.schema, self.api_key.as_deref()) {
@@ -216,6 +209,41 @@ impl ClaudeAgentExecutor {
             Err(detail)
         }
     }
+}
+
+/// Validate that the resolved model is allowed by the runtime's `supported_models`.
+///
+/// The built-in `claude` runtime always returns `Ok` — its `supported_models` are
+/// additive picker entries (alongside the host's known Claude models), not a strict
+/// allowlist. Non-claude runtimes enforce `supported_models` as a strict allowlist
+/// when the field is non-empty.
+fn check_supported_models(
+    runtime: &str,
+    agent_name: &str,
+    agent_default_model: Option<&str>,
+    request_model: Option<&str>,
+    runtimes: &HashMap<String, runkon_runtimes::config::RuntimeConfig>,
+) -> Result<(), String> {
+    if runtime == "claude" {
+        return Ok(());
+    }
+    let Some(rt_config) = runtimes.get(runtime) else {
+        return Ok(());
+    };
+    if rt_config.supported_models.is_empty() {
+        return Ok(());
+    }
+    let effective_model = request_model.or(agent_default_model);
+    if let Some(m) = effective_model {
+        if !rt_config.supported_models.iter().any(|s| s == m) {
+            return Err(format!(
+                "runtime '{}' only accepts models {:?}; \
+                 agent '{}' resolved model is '{m}'",
+                runtime, rt_config.supported_models, agent_name
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -428,5 +456,113 @@ mod tests {
             "runtime resolver must be called when api_key is absent"
         );
         assert!(result.is_err(), "expected Err from mock resolver, got Ok");
+    }
+
+    // ---------- check_supported_models ----------
+
+    fn rt_config_with_models(models: &[&str]) -> runkon_runtimes::config::RuntimeConfig {
+        runkon_runtimes::config::RuntimeConfig {
+            supported_models: models.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn check_supported_models_claude_runtime_ignores_supported_models() {
+        // Regression: when `runtimes.claude.supported_models` is populated, the
+        // built-in claude runtime must NOT enforce it as a strict allowlist —
+        // KNOWN_MODELS aliases/IDs (sonnet, haiku, claude-sonnet-4-6, etc.) must
+        // still be accepted. See workflow run 01KR1T8FXPEJ4KPWHEWWN6BY5M.
+        let mut runtimes = HashMap::new();
+        runtimes.insert(
+            "claude".to_string(),
+            rt_config_with_models(&["claude-opus-4-7", "QuantTrio/Qwen3.5-122B-A10B-AWQ"]),
+        );
+        assert!(check_supported_models(
+            "claude",
+            "review-architecture",
+            None,
+            Some("claude-sonnet-4-6"),
+            &runtimes
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn check_supported_models_non_claude_strict_allowlist_rejects_unlisted() {
+        let mut runtimes = HashMap::new();
+        runtimes.insert(
+            "qwen-local".to_string(),
+            rt_config_with_models(&["qwen-72b"]),
+        );
+        let err = check_supported_models(
+            "qwen-local",
+            "my-agent",
+            None,
+            Some("disallowed-model"),
+            &runtimes,
+        )
+        .unwrap_err();
+        assert!(err.contains("disallowed-model"), "{err}");
+        assert!(err.contains("qwen-72b"), "{err}");
+    }
+
+    #[test]
+    fn check_supported_models_non_claude_listed_model_ok() {
+        let mut runtimes = HashMap::new();
+        runtimes.insert(
+            "qwen-local".to_string(),
+            rt_config_with_models(&["qwen-72b"]),
+        );
+        assert!(check_supported_models(
+            "qwen-local",
+            "my-agent",
+            None,
+            Some("qwen-72b"),
+            &runtimes
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn check_supported_models_empty_supported_models_accepts_any() {
+        let mut runtimes = HashMap::new();
+        runtimes.insert(
+            "qwen-local".to_string(),
+            runkon_runtimes::config::RuntimeConfig::default(),
+        );
+        assert!(check_supported_models(
+            "qwen-local",
+            "my-agent",
+            None,
+            Some("any-model"),
+            &runtimes
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn check_supported_models_no_resolved_model_skips_check() {
+        let mut runtimes = HashMap::new();
+        runtimes.insert(
+            "qwen-local".to_string(),
+            rt_config_with_models(&["qwen-72b"]),
+        );
+        // No model on agent_def, no request model — defer to host default.
+        assert!(check_supported_models("qwen-local", "my-agent", None, None, &runtimes).is_ok());
+    }
+
+    #[test]
+    fn check_supported_models_unknown_runtime_skips_check() {
+        // No matching runtime entry — skip; the spawn step will fail with a clearer error.
+        let runtimes = HashMap::new();
+        assert!(check_supported_models(
+            "missing-rt",
+            "my-agent",
+            None,
+            Some("any-model"),
+            &runtimes
+        )
+        .is_ok());
     }
 }


### PR DESCRIPTION
Reworks the TUI model picker to render runtime sections — built-in claude section first, then user-defined runtimes from [runtimes.*] in config — with each section listing its scoped supported_models. Selection captures (runtime, model). Adds a Settings → Runtimes category for CRUD on user runtimes (add/edit models/delete; env editing remains a config.toml task).

Auto-migrates legacy general.custom_models into runtimes.claude.supported_models on Config::load() (one-time, idempotent, with union+warn for the dual-populated edge case). Removes Modal::ModelPicker.custom_models in favor of runtime_sections: Vec<RuntimeSection>; updates GoToBottom, navigation, and all picker call sites accordingly.

Closes #2960. Web picker rework deferred to a follow-up per ticket scope.