### PR TITLE
fix(tui): stop test runs from clobbering ~/.conductor/config.toml

### DIFF
--- a/conductor-tui/src/app/action_dispatch.rs
+++ b/conductor-tui/src/app/action_dispatch.rs
@@ -1592,6 +1592,7 @@ mod tests {
     use crate::state::Modal;
 
     fn make_test_app() -> App {
+        crate::test_support::isolate_conductor_home();
         let conn = conductor_core::test_helpers::create_test_conn();
         App::new(
             conn,

--- a/conductor-tui/src/app/crud_operations.rs
+++ b/conductor-tui/src/app/crud_operations.rs
@@ -631,6 +631,7 @@ mod tests {
     use crate::state::{FormAction, InputAction, Modal, View};
 
     fn make_test_app() -> App {
+        crate::test_support::isolate_conductor_home();
         let conn = conductor_core::test_helpers::create_test_conn();
         App::new(
             conn,

--- a/conductor-tui/src/app/input_handling.rs
+++ b/conductor-tui/src/app/input_handling.rs
@@ -1151,6 +1151,7 @@ mod tests {
     /// - repo `r1` (slug `test-repo`)
     /// - worktree `w1` (slug `feat-test`, branch `feat/test`, status `active`)
     fn make_app() -> App {
+        crate::test_support::isolate_conductor_home();
         let conn = conductor_core::test_helpers::setup_db();
         App::new(
             conn,
@@ -1465,6 +1466,7 @@ mod tests {
         other: Vec<(&str, Vec<&str>)>,
     ) -> Config {
         use conductor_core::config::RuntimeConfig;
+        crate::test_support::isolate_conductor_home();
         let mut config = Config::default();
         if !claude_custom.is_empty() {
             config.runtimes.insert(
@@ -1489,6 +1491,7 @@ mod tests {
 
     #[test]
     fn build_runtime_sections_empty_config_returns_claude_with_known_models() {
+        crate::test_support::isolate_conductor_home();
         let config = Config::default();
         let sections = build_runtime_sections(&config);
         assert_eq!(sections.len(), 1);

--- a/conductor-tui/src/app/navigation.rs
+++ b/conductor-tui/src/app/navigation.rs
@@ -1073,6 +1073,7 @@ mod tests {
     use crate::state::{ColumnFocus, View, WorkflowDefFocus, WorkflowPickerTarget, WorkflowsFocus};
 
     fn make_test_app() -> App {
+        crate::test_support::isolate_conductor_home();
         let conn = conductor_core::test_helpers::create_test_conn();
         App::new(
             conn,

--- a/conductor-tui/src/app/settings_management.rs
+++ b/conductor-tui/src/app/settings_management.rs
@@ -232,17 +232,7 @@ impl App {
     }
 
     /// Spawn a background thread to save the current config (non-blocking).
-    ///
-    /// Skipped under `cfg(test)`: `save_config` writes to the user's real
-    /// `~/.conductor/config.toml` (the global path resolved by
-    /// `conductor_dir()`), and unit tests construct an in-memory `Config`
-    /// with fixture data — running them would clobber the developer's
-    /// actual config. Production builds (the `conductor-tui` binary) do
-    /// not set `cfg(test)` and persist normally.
     pub(super) fn save_config_background(&mut self) {
-        if cfg!(test) {
-            return;
-        }
         let config = self.config.clone();
         std::thread::spawn(move || {
             if let Err(e) = conductor_core::config::save_config(&config) {

--- a/conductor-tui/src/app/settings_management.rs
+++ b/conductor-tui/src/app/settings_management.rs
@@ -232,7 +232,17 @@ impl App {
     }
 
     /// Spawn a background thread to save the current config (non-blocking).
+    ///
+    /// Skipped under `cfg(test)`: `save_config` writes to the user's real
+    /// `~/.conductor/config.toml` (the global path resolved by
+    /// `conductor_dir()`), and unit tests construct an in-memory `Config`
+    /// with fixture data — running them would clobber the developer's
+    /// actual config. Production builds (the `conductor-tui` binary) do
+    /// not set `cfg(test)` and persist normally.
     pub(super) fn save_config_background(&mut self) {
+        if cfg!(test) {
+            return;
+        }
         let config = self.config.clone();
         std::thread::spawn(move || {
             if let Err(e) = conductor_core::config::save_config(&config) {

--- a/conductor-tui/src/app/tests/action_handler_tests.rs
+++ b/conductor-tui/src/app/tests/action_handler_tests.rs
@@ -6,6 +6,7 @@ use crate::theme::Theme;
 use conductor_core::config::Config;
 
 fn make_app() -> App {
+    crate::test_support::isolate_conductor_home();
     let conn = conductor_core::db::open_database(std::path::Path::new(":memory:")).unwrap();
     App::new(
         conn,

--- a/conductor-tui/src/app/tests/mod.rs
+++ b/conductor-tui/src/app/tests/mod.rs
@@ -96,6 +96,7 @@ fn test_wrap_decrement_empty_list() {
 }
 
 fn make_test_app() -> App {
+    crate::test_support::isolate_conductor_home();
     let conn = conductor_core::test_helpers::create_test_conn();
     App::new(
         conn,

--- a/conductor-tui/src/app/workflow_management.rs
+++ b/conductor-tui/src/app/workflow_management.rs
@@ -2155,6 +2155,7 @@ mod tests {
     use conductor_core::{config::Config, repo::Repo, worktree::Worktree};
 
     fn make_app() -> App {
+        crate::test_support::isolate_conductor_home();
         let conn = conductor_core::test_helpers::create_test_conn();
         App::new(
             conn,

--- a/conductor-tui/src/main.rs
+++ b/conductor-tui/src/main.rs
@@ -9,6 +9,9 @@ mod state;
 mod theme;
 mod ui;
 
+#[cfg(test)]
+mod test_support;
+
 use anyhow::Result;
 
 use conductor_core::Conductor;

--- a/conductor-tui/src/test_support.rs
+++ b/conductor-tui/src/test_support.rs
@@ -1,0 +1,29 @@
+//! Test-only helpers that prevent the unit-test suite from touching the
+//! developer's real `~/.conductor` directory.
+//!
+//! `conductor_core::config::conductor_dir()` resolves the global data dir
+//! once via `OnceLock`, honoring `CONDUCTOR_HOME` if it's set when the
+//! lookup happens. Several `App` handler tests (settings → runtimes,
+//! workflow exec config, etc.) construct in-memory fixtures that, when
+//! exercised, eventually call `save_config` or read paths derived from
+//! `conductor_dir()`. Without isolation those writes land in the
+//! developer's real `~/.conductor/config.toml`.
+//!
+//! [`isolate_conductor_home`] sets `CONDUCTOR_HOME` to a per-process temp
+//! directory exactly once. Every `make_app`-style test helper calls it
+//! before constructing `Config::default()` (which is the first call that
+//! triggers the `OnceLock` resolution), so the global is never observed.
+
+use std::sync::Once;
+
+static INIT: Once = Once::new();
+
+/// Point `CONDUCTOR_HOME` at a temp dir for the rest of the test process.
+/// Idempotent — safe to call from every test helper.
+pub(crate) fn isolate_conductor_home() {
+    INIT.call_once(|| {
+        let dir = std::env::temp_dir().join(format!("conductor-tui-tests-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        std::env::set_var("CONDUCTOR_HOME", dir);
+    });
+}


### PR DESCRIPTION
## Summary

Tests in conductor-tui were overwriting the developer's real `~/.conductor/config.toml` on every `cargo test` run.

`save_config_background` (in `conductor-tui/src/app/settings_management.rs`) spawns a thread that calls `conductor_core::config::save_config`, which resolves to the global config path via `conductor_dir()`. Several settings handler tests construct an in-memory `Config` containing a fixture runtime named `qwen-local` with models `["a","b","c"]` and trigger the save path — clobbering whatever the developer actually had on disk.

This regression is independent of any specific PR; the testable handlers exist in current `release/0.15.1`. The fix guards `save_config_background` with `if cfg!(test) { return; }` so test builds skip the write while production builds (the `conductor-tui` binary, compiled without `cfg(test)`) persist normally.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p conductor-tui --all-targets -- -D warnings`
- [x] `cargo test -p conductor-tui` — 847 passed
- [ ] Manual: run `cargo test -p conductor-tui` and confirm `~/.conductor/config.toml` is untouched (no `[runtimes.qwen-local]` appears)

## Cleanup note

If your `~/.conductor/config.toml` already has a `[runtimes.qwen-local]` block from prior test runs, remove it manually after merging this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)