### PR TITLE
fix(review-pr): unmask gh stderr and retry resolve-pr-base on transient failure

### DIFF
--- a/.conductor/scripts/resolve-pr-base.sh
+++ b/.conductor/scripts/resolve-pr-base.sh
@@ -20,11 +20,20 @@ fi
 
 # `gh pr list --head <branch>` keys on the explicit branch name and is not
 # affected by cwd or the currently checked-out HEAD of an unrelated repo.
+# Capture stderr so a transient gh failure (auth, network, 5xx) surfaces in
+# the run log instead of being indistinguishable from a real "no PR" result.
+GH_STDERR=$(mktemp)
+trap 'rm -f "${GH_STDERR}"' EXIT
 BASE_BRANCH=$(gh pr list --head "${BRANCH}" --state open \
-                --json baseRefName -q '.[0].baseRefName' 2>/dev/null || true)
+                --json baseRefName -q '.[0].baseRefName' 2>"${GH_STDERR}" || true)
+GH_ERR=$(cat "${GH_STDERR}")
 
 if [ -z "${BASE_BRANCH}" ]; then
   echo "ERROR: could not resolve PR base branch for branch '${BRANCH}'." >&2
+  if [ -n "${GH_ERR}" ]; then
+    echo "       gh stderr:" >&2
+    printf '%s\n' "${GH_ERR}" | sed 's/^/         /' >&2
+  fi
   echo "       Aborting rather than falling back to 'main' silently — a wrong" >&2
   echo "       base produces a fabricated diff that contaminates every reviewer." >&2
   exit 1

--- a/.conductor/workflows/review-pr.wf
+++ b/.conductor/workflows/review-pr.wf
@@ -16,7 +16,8 @@ workflow review-pr {
   // Without this, reviewer agents and detect-* scripts each run their own
   // `gh pr view` and the silent fallback to `main` corrupts the diff. #2736.
   script resolve-pr-base {
-    run = ".conductor/scripts/resolve-pr-base.sh"
+    run     = ".conductor/scripts/resolve-pr-base.sh"
+    retries = 1
   }
   script detect-db-migrations {
     run = ".conductor/scripts/detect-db-migrations.sh"


### PR DESCRIPTION
## Summary
- `resolve-pr-base.sh` swallowed `gh pr list` stderr with `2>/dev/null`, so a transient gh failure (auth refresh, network, 5xx, rate limit) was indistinguishable from a real "no open PR" result. Run `01KR6C4KAABTBGTYDWW2DB4PWV` failed for exactly this reason — the PR existed and re-running the same command succeeded.
- Capture gh stderr to a tempfile and echo it in the abort message so the actual cause shows up in the run log.
- Add `retries = 1` to the `resolve-pr-base` step in `review-pr.wf` so a single transient blip self-heals instead of failing the whole review-pr run.

## Test plan
- [x] `conductor_validate_workflow review-pr` passes on this branch.
- [x] Re-ran the script locally on a branch with no PR: still aborts with the same human-facing error (and no spurious gh-stderr block, since gh succeeds with an empty list when there's no PR).
- [ ] Next review-pr run that hits a real gh failure will surface the underlying error in the run log instead of a generic abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)