### PR TITLE
fix(tui): strip newlines from agent event summaries

### DIFF
--- a/conductor-tui/src/ui/workflows.rs
+++ b/conductor-tui/src/ui/workflows.rs
@@ -2016,10 +2016,12 @@ fn render_step_agent_activity(
                 .map(|ms| format!(" ({:.1}s)", ms as f64 / 1000.0))
                 .unwrap_or_default();
             let ts = ev.started_at.get(11..19).unwrap_or(&ev.started_at);
-            let summary = truncate(
-                &shorten_paths(&ev.summary, worktree_path, state.home_dir.as_deref()),
-                80,
-            );
+            // Take only the first line — embedded \n in a Span is rendered as a
+            // zero-width grapheme that the terminal interprets as a line feed,
+            // moving the cursor mid-frame and leaving stale right-edge artifacts
+            // that ratatui's diff renderer never overwrites.
+            let shortened = shorten_paths(&ev.summary, worktree_path, state.home_dir.as_deref());
+            let summary = truncate(shortened.lines().next().unwrap_or(""), 80);
             let spans = vec![
                 Span::styled(
                     format!("{ts} "),


### PR DESCRIPTION
## Summary

Fixes the right-edge render artifacts (`a...`, `d a...`, `rgo...`) that smear the agent activity pane in the workflow run detail view, especially after scrolling through events.

**Root cause:** Some agent event summaries (e.g. retry prompts that begin with `[Previous attempt failed]\nError: workflow error: turn_cap_reached: 100 turns\n…`) contain a `\n` within the first 77 characters. The agent panel rendered them as a single `Span::styled(summary, …)` inside a `Line`. Ratatui treats the embedded newline as a zero-width grapheme appended to the previous cell — so when the buffer is flushed, the raw `\n` is sent straight to the terminal as a line feed. The cursor moves mid-frame, subsequent cells in that frame land at wrong positions, and the diff renderer never re-touches those cells on later frames so the fragments persist until a manual clear or resize.

The other `truncate` callers in `workflows.rs` (1234, 1296, 1832, 1838) already do `.lines().next().unwrap_or("")` for exactly this reason; the agent pane's call site missed it.

## Fix

Take `lines().next()` before truncating so only the first line of the summary ever reaches the `Span`.

## Test plan

- [x] `cargo build -p conductor-tui`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p conductor-tui -- -D warnings`
- [x] `cargo test -p conductor-tui` (22 passed)
- [ ] Manual: open the workflow run detail view in the TUI, scroll through agent events for a run that includes a retry prompt; right-edge artifacts should no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)